### PR TITLE
MM-11 - [BE] Create Logout functionality

### DIFF
--- a/api/src/auth/auth.resolver.ts
+++ b/api/src/auth/auth.resolver.ts
@@ -1,11 +1,12 @@
 import { Resolver, Query, Mutation, Args, Int } from '@nestjs/graphql'
 
-import { SignUpReturnType } from './types'
+import { LogoutReturnType, SignUpReturnType } from './types'
 import { AuthService } from './auth.service'
 import { Auth } from './entities/auth.entity'
 import { SignUpInput } from './dto/signup-input'
 import { SignInInput } from './dto/signin-input'
 import { SignResponse } from './dto/sign-response'
+import { LogoutResponse } from './dto/logout-response'
 import { UpdateAuthInput } from './dto/update-auth.input'
 
 @Resolver(() => Auth)
@@ -22,6 +23,11 @@ export class AuthResolver {
     return this.authService.signin(signInInput)
   }
 
+  @Mutation(() => LogoutResponse)
+  logout(@Args('id', { type: () => Int }) id: number): LogoutReturnType {
+    return this.authService.logout(id)
+  }
+
   @Query(() => Auth, { name: 'auth' })
   findOne(@Args('id', { type: () => Int }) id: number): string {
     return this.authService.findOne(id)
@@ -30,10 +36,5 @@ export class AuthResolver {
   @Mutation(() => Auth)
   updateAuth(@Args('updateAuthInput') updateAuthInput: UpdateAuthInput): string {
     return this.authService.update(updateAuthInput.id)
-  }
-
-  @Mutation(() => Auth)
-  removeAuth(@Args('id', { type: () => Int }) id: number): string {
-    return this.authService.remove(id)
   }
 }

--- a/api/src/auth/auth.service.ts
+++ b/api/src/auth/auth.service.ts
@@ -1,12 +1,12 @@
 import * as argon from 'argon2'
 import { JwtService } from '@nestjs/jwt'
-import { ForbiddenException, Injectable } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
+import { ForbiddenException, Injectable } from '@nestjs/common'
 
 import { SignUpInput } from './dto/signup-input'
 import { SignInInput } from './dto/signin-input'
-import { SignUpReturnType, Token } from './types'
 import { PrismaService } from '~/prisma/prisma.service'
+import { LogoutReturnType, SignUpReturnType, Token } from './types'
 
 @Injectable()
 export class AuthService {
@@ -63,10 +63,6 @@ export class AuthService {
     return `This action updates a #${id} auth`
   }
 
-  remove(id: number): string {
-    return `This action removes a #${id} auth`
-  }
-
   async createToken(userId: number, email: string): Promise<Token> {
     const accessToken = this.jwtService.sign(
       {
@@ -106,5 +102,17 @@ export class AuthService {
         refreshToken: hashedRefreshToken
       }
     })
+  }
+
+  async logout(userId: number): LogoutReturnType {
+    await this.prisma.user.updateMany({
+      where: { id: userId, refreshToken: { not: null } },
+      data: {
+        refreshToken: null
+      }
+    })
+    return {
+      loggedOut: true
+    }
   }
 }

--- a/api/src/auth/dto/logout-response.ts
+++ b/api/src/auth/dto/logout-response.ts
@@ -1,0 +1,9 @@
+import { IsBoolean } from 'class-validator'
+import { Field, ObjectType } from '@nestjs/graphql'
+
+@ObjectType()
+export class LogoutResponse {
+  @IsBoolean()
+  @Field()
+  loggedOut: boolean
+}

--- a/api/src/auth/types.ts
+++ b/api/src/auth/types.ts
@@ -11,3 +11,5 @@ export type UserToken = {
 } & Token
 
 export type SignUpReturnType = Promise<Prisma.Prisma__UserClient<UserToken, never>>
+
+export type LogoutReturnType = Promise<{ loggedOut: boolean }>

--- a/api/src/schema.gql
+++ b/api/src/schema.gql
@@ -7,8 +7,12 @@ type Auth {
   exampleField: Int!
 }
 
+type LogoutResponse {
+  loggedOut: Boolean!
+}
+
 type Mutation {
-  removeAuth(id: Int!): Auth!
+  logout(id: Int!): LogoutResponse!
   signin(signInInput: SignInInput!): SignResponse!
   signup(signupInput: SignUpInput!): SignResponse!
   updateAuth(updateAuthInput: UpdateAuthInput!): Auth!


### PR DESCRIPTION
## Issue Link

- https://www.notion.so/MM-11-BE-Create-Logout-functionality-5e036935c7b949eca2d3f000f2c2713f?pvs=4

## Definition of Done

- [x] Create Logout Function to Remove the Hashed Refresh Token in the database

## Notes

- N/A

## Pre-condition

### Docker Setup
- docker-compose up --build

### Local Setup
- cd client && npm install && npm run dev
- cd api && npm install && npm run start:dev
- goto the http://localhost:3030/graphql

```
mutation Logout($logoutId: Int!) {
  logout(id: $logoutId) {
    loggedOut
  }
}
```
input
```
{
  "logoutId": <your-user-id>
}
```


## Expected Output

- It should now have a logout functionality to delete the hashed refresh token

## Screenshots/Recordings

[logout.webm](https://github.com/Osomware/meme-me/assets/108642414/34009180-cd46-4e35-a7f0-b46b161851af)

