### PR TITLE
MM-13 - [BE] Create User Seeders

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -10,6 +10,7 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@apollo/server": "^4.7.5",
+        "@faker-js/faker": "^8.0.2",
         "@nestjs/apollo": "^12.0.7",
         "@nestjs/common": "^9.0.0",
         "@nestjs/config": "^3.0.0",
@@ -1111,6 +1112,21 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.0.2.tgz",
+      "integrity": "sha512-Uo3pGspElQW91PCvKSIAXoEgAUlRnH29sX2/p89kg7sP1m2PzCufHINd0FhTXQf6DYGiUlVncdSPa2F9wxed2A==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+        "npm": ">=6.14.13"
       }
     },
     "node_modules/@graphql-tools/merge": {

--- a/api/package.json
+++ b/api/package.json
@@ -17,10 +17,12 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "seed": "ts-node prisma/seeders"
   },
   "dependencies": {
     "@apollo/server": "^4.7.5",
+    "@faker-js/faker": "^8.0.2",
     "@nestjs/apollo": "^12.0.7",
     "@nestjs/common": "^9.0.0",
     "@nestjs/config": "^3.0.0",

--- a/api/prisma/seeders/index.ts
+++ b/api/prisma/seeders/index.ts
@@ -1,0 +1,18 @@
+import { PrismaClient } from '@prisma/client'
+
+import { newUsers } from './users'
+
+const prisma = new PrismaClient()
+
+const seed = async (): Promise<void> => {
+  await prisma.user.createMany({
+    data: newUsers
+  })
+}
+
+;(async () => {
+  await seed()
+  console.info('Success: Created New Seeder')
+})().catch((error) => {
+  console.error('Error in IIFE:', error)
+})

--- a/api/prisma/seeders/users.ts
+++ b/api/prisma/seeders/users.ts
@@ -1,0 +1,19 @@
+import { faker } from '@faker-js/faker'
+
+export type User = {
+  name: string
+  email: string
+  password: string
+  username: string
+}
+
+export const createRandomUser = (): User => ({
+  name: faker.internet.displayName(),
+  username: faker.internet.userName(),
+  email: faker.internet.email(),
+  password: faker.internet.password()
+})
+
+export const newUsers: User[] = faker.helpers.multiple(createRandomUser, {
+  count: 10
+})


### PR DESCRIPTION
## Issue Link

- https://www.notion.so/MM-13-BE-Create-User-Seeders-c3bcac863d3843ef9ddcdf04fa94561b?pvs=4

## Definition of Done

- [x] Install faker for dummy data
- [x] Genereate random Users 

## Notes

- N/A

## Pre-condition

### Docker Setup

- docker-compose up --build

### Local Setup

- cd client && npm install && npm run dev
- cd api && npm install && npm run start:dev

- change directory on the api and run the `npm run seed`

## Expected Output

- It should now have a functionality to create a seeder for users using fakejs

## Screenshots/Recordings

![image](https://github.com/Osomware/meme-me/assets/108642414/81be8d9e-9073-447e-83ec-38747069bd0d)
