### PR TITLE
MM-17 - [FE] - Implement Show Password Toggle

### DIFF
--- a/client/src/components/molecules/FormInput/index.tsx
+++ b/client/src/components/molecules/FormInput/index.tsx
@@ -1,8 +1,8 @@
 import clsx from 'clsx'
-import { Icon, User } from 'react-feather'
 import { capitalize, isEmpty } from 'lodash'
-import React, { ComponentProps } from 'react'
 import { useFormContext } from 'react-hook-form'
+import { Eye, EyeOff, Icon, User } from 'react-feather'
+import React, { ComponentProps, useState } from 'react'
 
 import Input from '~/components/atoms/Input'
 import { FormErrorMessage } from '~/components/atoms/FormErrorMessage'
@@ -11,10 +11,11 @@ type FormInputProps = {
   icon?: Icon
   label: string
   name: string
-  type?: string
+  type?: 'text' | 'submit' | 'password' | 'email'
 } & ComponentProps<'input'>
 
 const FormInput: React.FC<FormInputProps> = (props): JSX.Element => {
+  const [showPass, setShowPass] = useState<boolean>(false)
   const Icon = props.icon as Icon
   const { label, name, type, ...rest } = props
 
@@ -22,6 +23,10 @@ const FormInput: React.FC<FormInputProps> = (props): JSX.Element => {
     register,
     formState: { errors, isSubmitting }
   } = useFormContext()
+
+  const handleShowPasswordToggle = (): void => {
+    setShowPass(!showPass)
+  }
 
   return (
     <section className="flex flex-col space-y-1">
@@ -35,15 +40,38 @@ const FormInput: React.FC<FormInputProps> = (props): JSX.Element => {
           />
         </div>
         <Input
-          type={type}
+          type={showPass ? 'text' : type}
           {...rest}
           color="primary"
-          className="pl-12 text-sm py-2.5 font-medium"
+          className={clsx('pl-12 text-sm py-2.5 font-medium', type === 'password' && 'pr-8')}
           {...register(name)}
           disabled={isSubmitting}
           placeholder={capitalize(label)}
           iserror={!isEmpty(errors[name])}
         />
+        {type === 'password' && (
+          <button
+            type="button"
+            onClick={handleShowPasswordToggle}
+            className="outline-none group absolute inset-y-0 right-3 block overflow-hidden"
+          >
+            {showPass ? (
+              <EyeOff
+                className={clsx(
+                  'h-4 w-4 text-secondary-200 group-hover:text-secondary-300',
+                  'group-focus:text-secondary-300'
+                )}
+              />
+            ) : (
+              <Eye
+                className={clsx(
+                  'h-4 w-4 text-secondary-200 group-hover:text-secondary-300',
+                  'group-focus:text-secondary-300'
+                )}
+              />
+            )}
+          </button>
+        )}
       </div>
       {!isEmpty(errors[name]) && (
         <FormErrorMessage>{errors[name]?.message as unknown as string}</FormErrorMessage>


### PR DESCRIPTION
## Issue Link

- https://www.notion.so/MM-17-FE-Implement-Show-Password-Toggle-f941b10766714dd0be63b24f639dfa4b?pvs=4

## Definition of Done

- [x] Add Eye icon to show toggle of password

## Notes

- Improvement task

## Pre-condition

### Docker Setup

- docker-compose up --build

### Local Setup

- cd client && npm install && npm run dev
- cd api && npm install && npm run start:dev
- go to the sign-in/up page

## Expected Output

- It should now have a toggle for showing password in the password field

## Screenshots/Recordings
[password toggle.webm](https://github.com/Osomware/meme-me/assets/108642414/785ee18e-e86e-42a3-a426-0d97504bc54f)

