### PR TITLE
MM-18 - [BE] - Prisma Auto Generate GraphQL Inputs with Validation from class-validator

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -49,6 +49,7 @@
         "jest": "29.5.0",
         "prettier": "^2.3.2",
         "prisma": "^5.0.0",
+        "prisma-nestjs-graphql": "^19.0.0",
         "source-map-support": "^0.5.20",
         "supertest": "^6.1.3",
         "ts-jest": "29.1.0",
@@ -2187,6 +2188,17 @@
         }
       }
     },
+    "node_modules/@prisma/debug": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.1.0.tgz",
+      "integrity": "sha512-8jmiICy2uW+fHuoRDQGEB94XBkUmJu1wCaHWW/1ycbTNyaJqiTUL8EE7InzPcZRuebYKDU3QSUOlkUMH453A2Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/debug": "4.1.8",
+        "debug": "4.3.4",
+        "strip-ansi": "6.0.1"
+      }
+    },
     "node_modules/@prisma/engines": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.0.0.tgz",
@@ -2198,6 +2210,27 @@
       "version": "4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584",
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584.tgz",
       "integrity": "sha512-HHiUF6NixsldsP3JROq07TYBLEjXFKr6PdH8H4gK/XAoTmIplOJBCgrIUMrsRAnEuGyRoRLXKXWUb943+PFoKQ=="
+    },
+    "node_modules/@prisma/generator-helper": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@prisma/generator-helper/-/generator-helper-5.1.0.tgz",
+      "integrity": "sha512-N/6nE76YFByywR5tTScevPJGfbftdRbANPlTsL5KvpJWnnLPBvNZCtGpto2Ax4Ot15zLA0/olql5609X2zzXcg==",
+      "dev": true,
+      "dependencies": {
+        "@prisma/debug": "5.1.0",
+        "@types/cross-spawn": "6.0.2",
+        "cross-spawn": "7.0.3",
+        "kleur": "4.1.5"
+      }
+    },
+    "node_modules/@prisma/generator-helper/node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -2275,6 +2308,51 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@ts-morph/common": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.17.0.tgz",
+      "integrity": "sha512-RMSSvSfs9kb0VzkvQ2NWobwnj7TxCA9vI/IjR9bDHqgAyVbu2T0DN4wiKVqomyDWqO7dPr/tErSfq7urQ1Q37g==",
+      "dev": true,
+      "dependencies": {
+        "fast-glob": "^3.2.11",
+        "minimatch": "^5.1.0",
+        "mkdirp": "^1.0.4",
+        "path-browserify": "^1.0.1"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -2364,6 +2442,24 @@
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.2.tgz",
       "integrity": "sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==",
       "dev": true
+    },
+    "node_modules/@types/cross-spawn": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/cross-spawn/-/cross-spawn-6.0.2.tgz",
+      "integrity": "sha512-KuwNhp3eza+Rhu8IFI5HUXRP0LIhqH5cAjubUvGXXthh4YYBuP2ntwEX+Cz8GJoZUHlKo247wPWOfA9LYEq4cw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
+      "integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/ms": "*"
+      }
     },
     "node_modules/@types/eslint": {
       "version": "8.44.0",
@@ -2484,6 +2580,12 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
+    },
+    "node_modules/@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "18.16.12",
@@ -3264,6 +3366,18 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
+    "node_modules/await-event-emitter": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/await-event-emitter/-/await-event-emitter-2.0.2.tgz",
+      "integrity": "sha512-3+cjm1wr2MQz0bFM1f5F0pR9XUitF5/kaKUfeGXJWFKC57FgDY61BoQp/xzjjkxXCz8tw1S2fCpeHtxpTID9tA==",
+      "dev": true,
+      "dependencies": {
+        "is-promise": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/babel-jest": {
       "version": "29.6.1",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.6.1.tgz",
@@ -3820,6 +3934,12 @@
         "node": ">= 0.12.0"
       }
     },
+    "node_modules/code-block-writer": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-11.0.3.tgz",
+      "integrity": "sha512-NiujjUFB4SwScJq2bwbYUtXbZhBSlY6vYzm++3Q6oC+U+injTqfPYFK8wS9COOmb2lueqp0ZRB4nK1VYeHgNyw==",
+      "dev": true
+    },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
@@ -4320,6 +4440,15 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/escape-goat": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-2.1.1.tgz",
+      "integrity": "sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/escape-html": {
@@ -4881,6 +5010,32 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/filename-reserved-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+      "integrity": "sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/filenamify": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.3.0.tgz",
+      "integrity": "sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==",
+      "dev": true,
+      "dependencies": {
+        "filename-reserved-regex": "^2.0.0",
+        "strip-outer": "^1.0.1",
+        "trim-repeated": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -4936,6 +5091,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "bin": {
+        "flat": "cli.js"
       }
     },
     "node_modules/flat-cache": {
@@ -5174,6 +5338,12 @@
       "engines": {
         "node": ">=8.0.0"
       }
+    },
+    "node_modules/get-relative-path": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-relative-path/-/get-relative-path-1.0.2.tgz",
+      "integrity": "sha512-dGkopYfmB4sXMTcZslq5SojEYakpdCSj/SVSHLhv7D6RBHzvDtd/3Q8lTEOAhVKxPPeAHu/YYkENbbz3PaH+8w==",
+      "dev": true
     },
     "node_modules/get-stream": {
       "version": "6.0.1",
@@ -5631,6 +5801,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -7076,6 +7252,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/outmatch": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/outmatch/-/outmatch-0.7.0.tgz",
+      "integrity": "sha512-w1ybiTBffGiwxOO7JJBVVOsIiWwzcfSl/D80amWAU2UDe1o9/SySOUzAwDuN3+jGKQRs0UCDTS8rndFiroJgVQ==",
+      "dev": true
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -7197,6 +7379,12 @@
       "engines": {
         "node": ">= 0.4.0"
       }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -7460,6 +7648,29 @@
         "node": ">=16.13"
       }
     },
+    "node_modules/prisma-nestjs-graphql": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/prisma-nestjs-graphql/-/prisma-nestjs-graphql-19.0.0.tgz",
+      "integrity": "sha512-tPBl3lCW35oDxb7+8V8GN2+6zUS14dCdE/ZoX45SwOA5M16tW3kgFKvClGjO25VY6J2rcZJAzaoTIIJgS/Vt8Q==",
+      "dev": true,
+      "dependencies": {
+        "@prisma/generator-helper": "^5.0.0",
+        "await-event-emitter": "^2.0.2",
+        "filenamify": "4.X",
+        "flat": "^5.0.2",
+        "get-relative-path": "^1.0.2",
+        "graceful-fs": "^4.2.11",
+        "json5": "^2.2.3",
+        "lodash": "^4.17.21",
+        "outmatch": "^0.7.0",
+        "pluralize": "^8.0.0",
+        "pupa": "2.X",
+        "ts-morph": ">=11 <=16"
+      },
+      "bin": {
+        "prisma-nestjs-graphql": "bin.js"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -7507,6 +7718,18 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pupa": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/pupa/-/pupa-2.1.1.tgz",
+      "integrity": "sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==",
+      "dev": true,
+      "dependencies": {
+        "escape-goat": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/pure-rand": {
@@ -8268,6 +8491,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-outer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+      "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-outer/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/subscriptions-transport-ws": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.11.0.tgz",
@@ -8612,6 +8856,27 @@
         "tree-kill": "cli.js"
       }
     },
+    "node_modules/trim-repeated": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+      "integrity": "sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/trim-repeated/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/ts-jest": {
       "version": "29.1.0",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.0.tgz",
@@ -8672,6 +8937,16 @@
       "peerDependencies": {
         "typescript": "*",
         "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/ts-morph": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-16.0.0.tgz",
+      "integrity": "sha512-jGNF0GVpFj0orFw55LTsQxVYEUOCWBAbR5Ls7fTYE5pQsbW18ssTb/6UXx/GYAEjS+DQTp8VoTw0vqYMiaaQuw==",
+      "dev": true,
+      "dependencies": {
+        "@ts-morph/common": "~0.17.0",
+        "code-block-writer": "^11.0.3"
       }
     },
     "node_modules/ts-node": {

--- a/api/package.json
+++ b/api/package.json
@@ -62,6 +62,7 @@
     "jest": "29.5.0",
     "prettier": "^2.3.2",
     "prisma": "^5.0.0",
+    "prisma-nestjs-graphql": "^19.0.0",
     "source-map-support": "^0.5.20",
     "supertest": "^6.1.3",
     "ts-jest": "29.1.0",

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -10,11 +10,21 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+generator nestgraphql {
+  provider               = "node node_modules/prisma-nestjs-graphql"
+  output                 = "../src/@generated"
+  fields_Validator_from  = "class-validator"
+  fields_Validator_input = true
+}
+
 model User {
   id           Int      @id @default(autoincrement())
   email        String   @unique
+  /// @Validator.MinLength(5)
   username     String   @unique
+  /// @Validator.MinLength(3)
   name         String
+  /// @Validator.MinLength(6)
   password     String
   refreshToken String?
   role         Role     @default(USER)

--- a/api/src/@generated/prisma/affected-rows.output.ts
+++ b/api/src/@generated/prisma/affected-rows.output.ts
@@ -1,0 +1,9 @@
+import { Field } from '@nestjs/graphql'
+import { ObjectType } from '@nestjs/graphql'
+import { Int } from '@nestjs/graphql'
+
+@ObjectType()
+export class AffectedRows {
+  @Field(() => Int, { nullable: false })
+  count!: number
+}

--- a/api/src/@generated/prisma/date-time-field-update-operations.input.ts
+++ b/api/src/@generated/prisma/date-time-field-update-operations.input.ts
@@ -1,0 +1,8 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+
+@InputType()
+export class DateTimeFieldUpdateOperationsInput {
+  @Field(() => Date, { nullable: true })
+  set?: Date | string
+}

--- a/api/src/@generated/prisma/date-time-filter.input.ts
+++ b/api/src/@generated/prisma/date-time-filter.input.ts
@@ -1,0 +1,30 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { NestedDateTimeFilter } from './nested-date-time-filter.input'
+
+@InputType()
+export class DateTimeFilter {
+  @Field(() => Date, { nullable: true })
+  equals?: Date | string;
+
+  @Field(() => [Date], { nullable: true })
+  in?: Array<Date> | Array<string>
+
+  @Field(() => [Date], { nullable: true })
+  notIn?: Array<Date> | Array<string>
+
+  @Field(() => Date, { nullable: true })
+  lt?: Date | string
+
+  @Field(() => Date, { nullable: true })
+  lte?: Date | string
+
+  @Field(() => Date, { nullable: true })
+  gt?: Date | string
+
+  @Field(() => Date, { nullable: true })
+  gte?: Date | string
+
+  @Field(() => NestedDateTimeFilter, { nullable: true })
+  not?: NestedDateTimeFilter
+}

--- a/api/src/@generated/prisma/date-time-with-aggregates-filter.input.ts
+++ b/api/src/@generated/prisma/date-time-with-aggregates-filter.input.ts
@@ -1,0 +1,41 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { NestedDateTimeWithAggregatesFilter } from './nested-date-time-with-aggregates-filter.input'
+import { NestedIntFilter } from './nested-int-filter.input'
+import { NestedDateTimeFilter } from './nested-date-time-filter.input'
+
+@InputType()
+export class DateTimeWithAggregatesFilter {
+  @Field(() => Date, { nullable: true })
+  equals?: Date | string;
+
+  @Field(() => [Date], { nullable: true })
+  in?: Array<Date> | Array<string>
+
+  @Field(() => [Date], { nullable: true })
+  notIn?: Array<Date> | Array<string>
+
+  @Field(() => Date, { nullable: true })
+  lt?: Date | string
+
+  @Field(() => Date, { nullable: true })
+  lte?: Date | string
+
+  @Field(() => Date, { nullable: true })
+  gt?: Date | string
+
+  @Field(() => Date, { nullable: true })
+  gte?: Date | string
+
+  @Field(() => NestedDateTimeWithAggregatesFilter, { nullable: true })
+  not?: NestedDateTimeWithAggregatesFilter
+
+  @Field(() => NestedIntFilter, { nullable: true })
+  _count?: NestedIntFilter
+
+  @Field(() => NestedDateTimeFilter, { nullable: true })
+  _min?: NestedDateTimeFilter
+
+  @Field(() => NestedDateTimeFilter, { nullable: true })
+  _max?: NestedDateTimeFilter
+}

--- a/api/src/@generated/prisma/enum-role-field-update-operations.input.ts
+++ b/api/src/@generated/prisma/enum-role-field-update-operations.input.ts
@@ -1,0 +1,9 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { Role } from './role.enum'
+
+@InputType()
+export class EnumRoleFieldUpdateOperationsInput {
+  @Field(() => Role, { nullable: true })
+  set?: keyof typeof Role
+}

--- a/api/src/@generated/prisma/enum-role-filter.input.ts
+++ b/api/src/@generated/prisma/enum-role-filter.input.ts
@@ -1,0 +1,19 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { Role } from './role.enum'
+import { NestedEnumRoleFilter } from './nested-enum-role-filter.input'
+
+@InputType()
+export class EnumRoleFilter {
+  @Field(() => Role, { nullable: true })
+  equals?: keyof typeof Role;
+
+  @Field(() => [Role], { nullable: true })
+  in?: Array<keyof typeof Role>
+
+  @Field(() => [Role], { nullable: true })
+  notIn?: Array<keyof typeof Role>
+
+  @Field(() => NestedEnumRoleFilter, { nullable: true })
+  not?: NestedEnumRoleFilter
+}

--- a/api/src/@generated/prisma/enum-role-with-aggregates-filter.input.ts
+++ b/api/src/@generated/prisma/enum-role-with-aggregates-filter.input.ts
@@ -1,0 +1,30 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { Role } from './role.enum'
+import { NestedEnumRoleWithAggregatesFilter } from './nested-enum-role-with-aggregates-filter.input'
+import { NestedIntFilter } from './nested-int-filter.input'
+import { NestedEnumRoleFilter } from './nested-enum-role-filter.input'
+
+@InputType()
+export class EnumRoleWithAggregatesFilter {
+  @Field(() => Role, { nullable: true })
+  equals?: keyof typeof Role;
+
+  @Field(() => [Role], { nullable: true })
+  in?: Array<keyof typeof Role>
+
+  @Field(() => [Role], { nullable: true })
+  notIn?: Array<keyof typeof Role>
+
+  @Field(() => NestedEnumRoleWithAggregatesFilter, { nullable: true })
+  not?: NestedEnumRoleWithAggregatesFilter
+
+  @Field(() => NestedIntFilter, { nullable: true })
+  _count?: NestedIntFilter
+
+  @Field(() => NestedEnumRoleFilter, { nullable: true })
+  _min?: NestedEnumRoleFilter
+
+  @Field(() => NestedEnumRoleFilter, { nullable: true })
+  _max?: NestedEnumRoleFilter
+}

--- a/api/src/@generated/prisma/int-field-update-operations.input.ts
+++ b/api/src/@generated/prisma/int-field-update-operations.input.ts
@@ -1,0 +1,21 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { Int } from '@nestjs/graphql'
+
+@InputType()
+export class IntFieldUpdateOperationsInput {
+  @Field(() => Int, { nullable: true })
+  set?: number
+
+  @Field(() => Int, { nullable: true })
+  increment?: number
+
+  @Field(() => Int, { nullable: true })
+  decrement?: number
+
+  @Field(() => Int, { nullable: true })
+  multiply?: number
+
+  @Field(() => Int, { nullable: true })
+  divide?: number
+}

--- a/api/src/@generated/prisma/int-filter.input.ts
+++ b/api/src/@generated/prisma/int-filter.input.ts
@@ -1,0 +1,31 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { Int } from '@nestjs/graphql'
+import { NestedIntFilter } from './nested-int-filter.input'
+
+@InputType()
+export class IntFilter {
+  @Field(() => Int, { nullable: true })
+  equals?: number;
+
+  @Field(() => [Int], { nullable: true })
+  in?: Array<number>
+
+  @Field(() => [Int], { nullable: true })
+  notIn?: Array<number>
+
+  @Field(() => Int, { nullable: true })
+  lt?: number
+
+  @Field(() => Int, { nullable: true })
+  lte?: number
+
+  @Field(() => Int, { nullable: true })
+  gt?: number
+
+  @Field(() => Int, { nullable: true })
+  gte?: number
+
+  @Field(() => NestedIntFilter, { nullable: true })
+  not?: NestedIntFilter
+}

--- a/api/src/@generated/prisma/int-with-aggregates-filter.input.ts
+++ b/api/src/@generated/prisma/int-with-aggregates-filter.input.ts
@@ -1,0 +1,48 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { Int } from '@nestjs/graphql'
+import { NestedIntWithAggregatesFilter } from './nested-int-with-aggregates-filter.input'
+import { NestedIntFilter } from './nested-int-filter.input'
+import { NestedFloatFilter } from './nested-float-filter.input'
+
+@InputType()
+export class IntWithAggregatesFilter {
+  @Field(() => Int, { nullable: true })
+  equals?: number;
+
+  @Field(() => [Int], { nullable: true })
+  in?: Array<number>
+
+  @Field(() => [Int], { nullable: true })
+  notIn?: Array<number>
+
+  @Field(() => Int, { nullable: true })
+  lt?: number
+
+  @Field(() => Int, { nullable: true })
+  lte?: number
+
+  @Field(() => Int, { nullable: true })
+  gt?: number
+
+  @Field(() => Int, { nullable: true })
+  gte?: number
+
+  @Field(() => NestedIntWithAggregatesFilter, { nullable: true })
+  not?: NestedIntWithAggregatesFilter
+
+  @Field(() => NestedIntFilter, { nullable: true })
+  _count?: NestedIntFilter
+
+  @Field(() => NestedFloatFilter, { nullable: true })
+  _avg?: NestedFloatFilter
+
+  @Field(() => NestedIntFilter, { nullable: true })
+  _sum?: NestedIntFilter
+
+  @Field(() => NestedIntFilter, { nullable: true })
+  _min?: NestedIntFilter
+
+  @Field(() => NestedIntFilter, { nullable: true })
+  _max?: NestedIntFilter
+}

--- a/api/src/@generated/prisma/nested-date-time-filter.input.ts
+++ b/api/src/@generated/prisma/nested-date-time-filter.input.ts
@@ -1,0 +1,29 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+
+@InputType()
+export class NestedDateTimeFilter {
+  @Field(() => Date, { nullable: true })
+  equals?: Date | string;
+
+  @Field(() => [Date], { nullable: true })
+  in?: Array<Date> | Array<string>
+
+  @Field(() => [Date], { nullable: true })
+  notIn?: Array<Date> | Array<string>
+
+  @Field(() => Date, { nullable: true })
+  lt?: Date | string
+
+  @Field(() => Date, { nullable: true })
+  lte?: Date | string
+
+  @Field(() => Date, { nullable: true })
+  gt?: Date | string
+
+  @Field(() => Date, { nullable: true })
+  gte?: Date | string
+
+  @Field(() => NestedDateTimeFilter, { nullable: true })
+  not?: NestedDateTimeFilter
+}

--- a/api/src/@generated/prisma/nested-date-time-with-aggregates-filter.input.ts
+++ b/api/src/@generated/prisma/nested-date-time-with-aggregates-filter.input.ts
@@ -1,0 +1,40 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { NestedIntFilter } from './nested-int-filter.input'
+import { NestedDateTimeFilter } from './nested-date-time-filter.input'
+
+@InputType()
+export class NestedDateTimeWithAggregatesFilter {
+  @Field(() => Date, { nullable: true })
+  equals?: Date | string;
+
+  @Field(() => [Date], { nullable: true })
+  in?: Array<Date> | Array<string>
+
+  @Field(() => [Date], { nullable: true })
+  notIn?: Array<Date> | Array<string>
+
+  @Field(() => Date, { nullable: true })
+  lt?: Date | string
+
+  @Field(() => Date, { nullable: true })
+  lte?: Date | string
+
+  @Field(() => Date, { nullable: true })
+  gt?: Date | string
+
+  @Field(() => Date, { nullable: true })
+  gte?: Date | string
+
+  @Field(() => NestedDateTimeWithAggregatesFilter, { nullable: true })
+  not?: NestedDateTimeWithAggregatesFilter
+
+  @Field(() => NestedIntFilter, { nullable: true })
+  _count?: NestedIntFilter
+
+  @Field(() => NestedDateTimeFilter, { nullable: true })
+  _min?: NestedDateTimeFilter
+
+  @Field(() => NestedDateTimeFilter, { nullable: true })
+  _max?: NestedDateTimeFilter
+}

--- a/api/src/@generated/prisma/nested-enum-role-filter.input.ts
+++ b/api/src/@generated/prisma/nested-enum-role-filter.input.ts
@@ -1,0 +1,18 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { Role } from './role.enum'
+
+@InputType()
+export class NestedEnumRoleFilter {
+  @Field(() => Role, { nullable: true })
+  equals?: keyof typeof Role;
+
+  @Field(() => [Role], { nullable: true })
+  in?: Array<keyof typeof Role>
+
+  @Field(() => [Role], { nullable: true })
+  notIn?: Array<keyof typeof Role>
+
+  @Field(() => NestedEnumRoleFilter, { nullable: true })
+  not?: NestedEnumRoleFilter
+}

--- a/api/src/@generated/prisma/nested-enum-role-with-aggregates-filter.input.ts
+++ b/api/src/@generated/prisma/nested-enum-role-with-aggregates-filter.input.ts
@@ -1,0 +1,29 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { Role } from './role.enum'
+import { NestedIntFilter } from './nested-int-filter.input'
+import { NestedEnumRoleFilter } from './nested-enum-role-filter.input'
+
+@InputType()
+export class NestedEnumRoleWithAggregatesFilter {
+  @Field(() => Role, { nullable: true })
+  equals?: keyof typeof Role;
+
+  @Field(() => [Role], { nullable: true })
+  in?: Array<keyof typeof Role>
+
+  @Field(() => [Role], { nullable: true })
+  notIn?: Array<keyof typeof Role>
+
+  @Field(() => NestedEnumRoleWithAggregatesFilter, { nullable: true })
+  not?: NestedEnumRoleWithAggregatesFilter
+
+  @Field(() => NestedIntFilter, { nullable: true })
+  _count?: NestedIntFilter
+
+  @Field(() => NestedEnumRoleFilter, { nullable: true })
+  _min?: NestedEnumRoleFilter
+
+  @Field(() => NestedEnumRoleFilter, { nullable: true })
+  _max?: NestedEnumRoleFilter
+}

--- a/api/src/@generated/prisma/nested-float-filter.input.ts
+++ b/api/src/@generated/prisma/nested-float-filter.input.ts
@@ -1,0 +1,30 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { Float } from '@nestjs/graphql'
+
+@InputType()
+export class NestedFloatFilter {
+  @Field(() => Float, { nullable: true })
+  equals?: number;
+
+  @Field(() => [Float], { nullable: true })
+  in?: Array<number>
+
+  @Field(() => [Float], { nullable: true })
+  notIn?: Array<number>
+
+  @Field(() => Float, { nullable: true })
+  lt?: number
+
+  @Field(() => Float, { nullable: true })
+  lte?: number
+
+  @Field(() => Float, { nullable: true })
+  gt?: number
+
+  @Field(() => Float, { nullable: true })
+  gte?: number
+
+  @Field(() => NestedFloatFilter, { nullable: true })
+  not?: NestedFloatFilter
+}

--- a/api/src/@generated/prisma/nested-int-filter.input.ts
+++ b/api/src/@generated/prisma/nested-int-filter.input.ts
@@ -1,0 +1,30 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { Int } from '@nestjs/graphql'
+
+@InputType()
+export class NestedIntFilter {
+  @Field(() => Int, { nullable: true })
+  equals?: number;
+
+  @Field(() => [Int], { nullable: true })
+  in?: Array<number>
+
+  @Field(() => [Int], { nullable: true })
+  notIn?: Array<number>
+
+  @Field(() => Int, { nullable: true })
+  lt?: number
+
+  @Field(() => Int, { nullable: true })
+  lte?: number
+
+  @Field(() => Int, { nullable: true })
+  gt?: number
+
+  @Field(() => Int, { nullable: true })
+  gte?: number
+
+  @Field(() => NestedIntFilter, { nullable: true })
+  not?: NestedIntFilter
+}

--- a/api/src/@generated/prisma/nested-int-nullable-filter.input.ts
+++ b/api/src/@generated/prisma/nested-int-nullable-filter.input.ts
@@ -1,0 +1,30 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { Int } from '@nestjs/graphql'
+
+@InputType()
+export class NestedIntNullableFilter {
+  @Field(() => Int, { nullable: true })
+  equals?: number;
+
+  @Field(() => [Int], { nullable: true })
+  in?: Array<number>
+
+  @Field(() => [Int], { nullable: true })
+  notIn?: Array<number>
+
+  @Field(() => Int, { nullable: true })
+  lt?: number
+
+  @Field(() => Int, { nullable: true })
+  lte?: number
+
+  @Field(() => Int, { nullable: true })
+  gt?: number
+
+  @Field(() => Int, { nullable: true })
+  gte?: number
+
+  @Field(() => NestedIntNullableFilter, { nullable: true })
+  not?: NestedIntNullableFilter
+}

--- a/api/src/@generated/prisma/nested-int-with-aggregates-filter.input.ts
+++ b/api/src/@generated/prisma/nested-int-with-aggregates-filter.input.ts
@@ -1,0 +1,47 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { Int } from '@nestjs/graphql'
+import { NestedIntFilter } from './nested-int-filter.input'
+import { NestedFloatFilter } from './nested-float-filter.input'
+
+@InputType()
+export class NestedIntWithAggregatesFilter {
+  @Field(() => Int, { nullable: true })
+  equals?: number;
+
+  @Field(() => [Int], { nullable: true })
+  in?: Array<number>
+
+  @Field(() => [Int], { nullable: true })
+  notIn?: Array<number>
+
+  @Field(() => Int, { nullable: true })
+  lt?: number
+
+  @Field(() => Int, { nullable: true })
+  lte?: number
+
+  @Field(() => Int, { nullable: true })
+  gt?: number
+
+  @Field(() => Int, { nullable: true })
+  gte?: number
+
+  @Field(() => NestedIntWithAggregatesFilter, { nullable: true })
+  not?: NestedIntWithAggregatesFilter
+
+  @Field(() => NestedIntFilter, { nullable: true })
+  _count?: NestedIntFilter
+
+  @Field(() => NestedFloatFilter, { nullable: true })
+  _avg?: NestedFloatFilter
+
+  @Field(() => NestedIntFilter, { nullable: true })
+  _sum?: NestedIntFilter
+
+  @Field(() => NestedIntFilter, { nullable: true })
+  _min?: NestedIntFilter
+
+  @Field(() => NestedIntFilter, { nullable: true })
+  _max?: NestedIntFilter
+}

--- a/api/src/@generated/prisma/nested-string-filter.input.ts
+++ b/api/src/@generated/prisma/nested-string-filter.input.ts
@@ -1,0 +1,38 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+
+@InputType()
+export class NestedStringFilter {
+  @Field(() => String, { nullable: true })
+  equals?: string;
+
+  @Field(() => [String], { nullable: true })
+  in?: Array<string>
+
+  @Field(() => [String], { nullable: true })
+  notIn?: Array<string>
+
+  @Field(() => String, { nullable: true })
+  lt?: string
+
+  @Field(() => String, { nullable: true })
+  lte?: string
+
+  @Field(() => String, { nullable: true })
+  gt?: string
+
+  @Field(() => String, { nullable: true })
+  gte?: string
+
+  @Field(() => String, { nullable: true })
+  contains?: string
+
+  @Field(() => String, { nullable: true })
+  startsWith?: string
+
+  @Field(() => String, { nullable: true })
+  endsWith?: string
+
+  @Field(() => NestedStringFilter, { nullable: true })
+  not?: NestedStringFilter
+}

--- a/api/src/@generated/prisma/nested-string-nullable-filter.input.ts
+++ b/api/src/@generated/prisma/nested-string-nullable-filter.input.ts
@@ -1,0 +1,38 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+
+@InputType()
+export class NestedStringNullableFilter {
+  @Field(() => String, { nullable: true })
+  equals?: string;
+
+  @Field(() => [String], { nullable: true })
+  in?: Array<string>
+
+  @Field(() => [String], { nullable: true })
+  notIn?: Array<string>
+
+  @Field(() => String, { nullable: true })
+  lt?: string
+
+  @Field(() => String, { nullable: true })
+  lte?: string
+
+  @Field(() => String, { nullable: true })
+  gt?: string
+
+  @Field(() => String, { nullable: true })
+  gte?: string
+
+  @Field(() => String, { nullable: true })
+  contains?: string
+
+  @Field(() => String, { nullable: true })
+  startsWith?: string
+
+  @Field(() => String, { nullable: true })
+  endsWith?: string
+
+  @Field(() => NestedStringNullableFilter, { nullable: true })
+  not?: NestedStringNullableFilter
+}

--- a/api/src/@generated/prisma/nested-string-nullable-with-aggregates-filter.input.ts
+++ b/api/src/@generated/prisma/nested-string-nullable-with-aggregates-filter.input.ts
@@ -1,0 +1,49 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { NestedIntNullableFilter } from './nested-int-nullable-filter.input'
+import { NestedStringNullableFilter } from './nested-string-nullable-filter.input'
+
+@InputType()
+export class NestedStringNullableWithAggregatesFilter {
+  @Field(() => String, { nullable: true })
+  equals?: string;
+
+  @Field(() => [String], { nullable: true })
+  in?: Array<string>
+
+  @Field(() => [String], { nullable: true })
+  notIn?: Array<string>
+
+  @Field(() => String, { nullable: true })
+  lt?: string
+
+  @Field(() => String, { nullable: true })
+  lte?: string
+
+  @Field(() => String, { nullable: true })
+  gt?: string
+
+  @Field(() => String, { nullable: true })
+  gte?: string
+
+  @Field(() => String, { nullable: true })
+  contains?: string
+
+  @Field(() => String, { nullable: true })
+  startsWith?: string
+
+  @Field(() => String, { nullable: true })
+  endsWith?: string
+
+  @Field(() => NestedStringNullableWithAggregatesFilter, { nullable: true })
+  not?: NestedStringNullableWithAggregatesFilter
+
+  @Field(() => NestedIntNullableFilter, { nullable: true })
+  _count?: NestedIntNullableFilter
+
+  @Field(() => NestedStringNullableFilter, { nullable: true })
+  _min?: NestedStringNullableFilter
+
+  @Field(() => NestedStringNullableFilter, { nullable: true })
+  _max?: NestedStringNullableFilter
+}

--- a/api/src/@generated/prisma/nested-string-with-aggregates-filter.input.ts
+++ b/api/src/@generated/prisma/nested-string-with-aggregates-filter.input.ts
@@ -1,0 +1,49 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { NestedIntFilter } from './nested-int-filter.input'
+import { NestedStringFilter } from './nested-string-filter.input'
+
+@InputType()
+export class NestedStringWithAggregatesFilter {
+  @Field(() => String, { nullable: true })
+  equals?: string;
+
+  @Field(() => [String], { nullable: true })
+  in?: Array<string>
+
+  @Field(() => [String], { nullable: true })
+  notIn?: Array<string>
+
+  @Field(() => String, { nullable: true })
+  lt?: string
+
+  @Field(() => String, { nullable: true })
+  lte?: string
+
+  @Field(() => String, { nullable: true })
+  gt?: string
+
+  @Field(() => String, { nullable: true })
+  gte?: string
+
+  @Field(() => String, { nullable: true })
+  contains?: string
+
+  @Field(() => String, { nullable: true })
+  startsWith?: string
+
+  @Field(() => String, { nullable: true })
+  endsWith?: string
+
+  @Field(() => NestedStringWithAggregatesFilter, { nullable: true })
+  not?: NestedStringWithAggregatesFilter
+
+  @Field(() => NestedIntFilter, { nullable: true })
+  _count?: NestedIntFilter
+
+  @Field(() => NestedStringFilter, { nullable: true })
+  _min?: NestedStringFilter
+
+  @Field(() => NestedStringFilter, { nullable: true })
+  _max?: NestedStringFilter
+}

--- a/api/src/@generated/prisma/nullable-string-field-update-operations.input.ts
+++ b/api/src/@generated/prisma/nullable-string-field-update-operations.input.ts
@@ -1,0 +1,8 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+
+@InputType()
+export class NullableStringFieldUpdateOperationsInput {
+  @Field(() => String, { nullable: true })
+  set?: string
+}

--- a/api/src/@generated/prisma/nulls-order.enum.ts
+++ b/api/src/@generated/prisma/nulls-order.enum.ts
@@ -1,0 +1,8 @@
+import { registerEnumType } from '@nestjs/graphql'
+
+export enum NullsOrder {
+  first = 'first',
+  last = 'last'
+}
+
+registerEnumType(NullsOrder, { name: 'NullsOrder', description: undefined })

--- a/api/src/@generated/prisma/query-mode.enum.ts
+++ b/api/src/@generated/prisma/query-mode.enum.ts
@@ -1,0 +1,8 @@
+import { registerEnumType } from '@nestjs/graphql'
+
+export enum QueryMode {
+  'default' = 'default',
+  insensitive = 'insensitive'
+}
+
+registerEnumType(QueryMode, { name: 'QueryMode', description: undefined })

--- a/api/src/@generated/prisma/role.enum.ts
+++ b/api/src/@generated/prisma/role.enum.ts
@@ -1,0 +1,8 @@
+import { registerEnumType } from '@nestjs/graphql'
+
+export enum Role {
+  USER = 'USER',
+  ADMIN = 'ADMIN'
+}
+
+registerEnumType(Role, { name: 'Role', description: undefined })

--- a/api/src/@generated/prisma/sort-order.enum.ts
+++ b/api/src/@generated/prisma/sort-order.enum.ts
@@ -1,0 +1,8 @@
+import { registerEnumType } from '@nestjs/graphql'
+
+export enum SortOrder {
+  asc = 'asc',
+  desc = 'desc'
+}
+
+registerEnumType(SortOrder, { name: 'SortOrder', description: undefined })

--- a/api/src/@generated/prisma/sort-order.input.ts
+++ b/api/src/@generated/prisma/sort-order.input.ts
@@ -1,0 +1,13 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { SortOrder } from './sort-order.enum'
+import { NullsOrder } from './nulls-order.enum'
+
+@InputType()
+export class SortOrderInput {
+  @Field(() => SortOrder, { nullable: false })
+  sort!: keyof typeof SortOrder
+
+  @Field(() => NullsOrder, { nullable: true })
+  nulls?: keyof typeof NullsOrder
+}

--- a/api/src/@generated/prisma/string-field-update-operations.input.ts
+++ b/api/src/@generated/prisma/string-field-update-operations.input.ts
@@ -1,0 +1,8 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+
+@InputType()
+export class StringFieldUpdateOperationsInput {
+  @Field(() => String, { nullable: true })
+  set?: string
+}

--- a/api/src/@generated/prisma/string-filter.input.ts
+++ b/api/src/@generated/prisma/string-filter.input.ts
@@ -1,0 +1,43 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { QueryMode } from './query-mode.enum'
+import { NestedStringFilter } from './nested-string-filter.input'
+
+@InputType()
+export class StringFilter {
+  @Field(() => String, { nullable: true })
+  equals?: string;
+
+  @Field(() => [String], { nullable: true })
+  in?: Array<string>
+
+  @Field(() => [String], { nullable: true })
+  notIn?: Array<string>
+
+  @Field(() => String, { nullable: true })
+  lt?: string
+
+  @Field(() => String, { nullable: true })
+  lte?: string
+
+  @Field(() => String, { nullable: true })
+  gt?: string
+
+  @Field(() => String, { nullable: true })
+  gte?: string
+
+  @Field(() => String, { nullable: true })
+  contains?: string
+
+  @Field(() => String, { nullable: true })
+  startsWith?: string
+
+  @Field(() => String, { nullable: true })
+  endsWith?: string
+
+  @Field(() => QueryMode, { nullable: true })
+  mode?: keyof typeof QueryMode
+
+  @Field(() => NestedStringFilter, { nullable: true })
+  not?: NestedStringFilter
+}

--- a/api/src/@generated/prisma/string-nullable-filter.input.ts
+++ b/api/src/@generated/prisma/string-nullable-filter.input.ts
@@ -1,0 +1,43 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { QueryMode } from './query-mode.enum'
+import { NestedStringNullableFilter } from './nested-string-nullable-filter.input'
+
+@InputType()
+export class StringNullableFilter {
+  @Field(() => String, { nullable: true })
+  equals?: string;
+
+  @Field(() => [String], { nullable: true })
+  in?: Array<string>
+
+  @Field(() => [String], { nullable: true })
+  notIn?: Array<string>
+
+  @Field(() => String, { nullable: true })
+  lt?: string
+
+  @Field(() => String, { nullable: true })
+  lte?: string
+
+  @Field(() => String, { nullable: true })
+  gt?: string
+
+  @Field(() => String, { nullable: true })
+  gte?: string
+
+  @Field(() => String, { nullable: true })
+  contains?: string
+
+  @Field(() => String, { nullable: true })
+  startsWith?: string
+
+  @Field(() => String, { nullable: true })
+  endsWith?: string
+
+  @Field(() => QueryMode, { nullable: true })
+  mode?: keyof typeof QueryMode
+
+  @Field(() => NestedStringNullableFilter, { nullable: true })
+  not?: NestedStringNullableFilter
+}

--- a/api/src/@generated/prisma/string-nullable-with-aggregates-filter.input.ts
+++ b/api/src/@generated/prisma/string-nullable-with-aggregates-filter.input.ts
@@ -1,0 +1,54 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { QueryMode } from './query-mode.enum'
+import { NestedStringNullableWithAggregatesFilter } from './nested-string-nullable-with-aggregates-filter.input'
+import { NestedIntNullableFilter } from './nested-int-nullable-filter.input'
+import { NestedStringNullableFilter } from './nested-string-nullable-filter.input'
+
+@InputType()
+export class StringNullableWithAggregatesFilter {
+  @Field(() => String, { nullable: true })
+  equals?: string;
+
+  @Field(() => [String], { nullable: true })
+  in?: Array<string>
+
+  @Field(() => [String], { nullable: true })
+  notIn?: Array<string>
+
+  @Field(() => String, { nullable: true })
+  lt?: string
+
+  @Field(() => String, { nullable: true })
+  lte?: string
+
+  @Field(() => String, { nullable: true })
+  gt?: string
+
+  @Field(() => String, { nullable: true })
+  gte?: string
+
+  @Field(() => String, { nullable: true })
+  contains?: string
+
+  @Field(() => String, { nullable: true })
+  startsWith?: string
+
+  @Field(() => String, { nullable: true })
+  endsWith?: string
+
+  @Field(() => QueryMode, { nullable: true })
+  mode?: keyof typeof QueryMode
+
+  @Field(() => NestedStringNullableWithAggregatesFilter, { nullable: true })
+  not?: NestedStringNullableWithAggregatesFilter
+
+  @Field(() => NestedIntNullableFilter, { nullable: true })
+  _count?: NestedIntNullableFilter
+
+  @Field(() => NestedStringNullableFilter, { nullable: true })
+  _min?: NestedStringNullableFilter
+
+  @Field(() => NestedStringNullableFilter, { nullable: true })
+  _max?: NestedStringNullableFilter
+}

--- a/api/src/@generated/prisma/string-with-aggregates-filter.input.ts
+++ b/api/src/@generated/prisma/string-with-aggregates-filter.input.ts
@@ -1,0 +1,54 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { QueryMode } from './query-mode.enum'
+import { NestedStringWithAggregatesFilter } from './nested-string-with-aggregates-filter.input'
+import { NestedIntFilter } from './nested-int-filter.input'
+import { NestedStringFilter } from './nested-string-filter.input'
+
+@InputType()
+export class StringWithAggregatesFilter {
+  @Field(() => String, { nullable: true })
+  equals?: string;
+
+  @Field(() => [String], { nullable: true })
+  in?: Array<string>
+
+  @Field(() => [String], { nullable: true })
+  notIn?: Array<string>
+
+  @Field(() => String, { nullable: true })
+  lt?: string
+
+  @Field(() => String, { nullable: true })
+  lte?: string
+
+  @Field(() => String, { nullable: true })
+  gt?: string
+
+  @Field(() => String, { nullable: true })
+  gte?: string
+
+  @Field(() => String, { nullable: true })
+  contains?: string
+
+  @Field(() => String, { nullable: true })
+  startsWith?: string
+
+  @Field(() => String, { nullable: true })
+  endsWith?: string
+
+  @Field(() => QueryMode, { nullable: true })
+  mode?: keyof typeof QueryMode
+
+  @Field(() => NestedStringWithAggregatesFilter, { nullable: true })
+  not?: NestedStringWithAggregatesFilter
+
+  @Field(() => NestedIntFilter, { nullable: true })
+  _count?: NestedIntFilter
+
+  @Field(() => NestedStringFilter, { nullable: true })
+  _min?: NestedStringFilter
+
+  @Field(() => NestedStringFilter, { nullable: true })
+  _max?: NestedStringFilter
+}

--- a/api/src/@generated/prisma/transaction-isolation-level.enum.ts
+++ b/api/src/@generated/prisma/transaction-isolation-level.enum.ts
@@ -1,0 +1,13 @@
+import { registerEnumType } from '@nestjs/graphql'
+
+export enum TransactionIsolationLevel {
+  ReadUncommitted = 'ReadUncommitted',
+  ReadCommitted = 'ReadCommitted',
+  RepeatableRead = 'RepeatableRead',
+  Serializable = 'Serializable'
+}
+
+registerEnumType(TransactionIsolationLevel, {
+  name: 'TransactionIsolationLevel',
+  description: undefined
+})

--- a/api/src/@generated/user/aggregate-user.output.ts
+++ b/api/src/@generated/user/aggregate-user.output.ts
@@ -1,0 +1,25 @@
+import { Field } from '@nestjs/graphql'
+import { ObjectType } from '@nestjs/graphql'
+import { UserCountAggregate } from './user-count-aggregate.output'
+import { UserAvgAggregate } from './user-avg-aggregate.output'
+import { UserSumAggregate } from './user-sum-aggregate.output'
+import { UserMinAggregate } from './user-min-aggregate.output'
+import { UserMaxAggregate } from './user-max-aggregate.output'
+
+@ObjectType()
+export class AggregateUser {
+  @Field(() => UserCountAggregate, { nullable: true })
+  _count?: UserCountAggregate
+
+  @Field(() => UserAvgAggregate, { nullable: true })
+  _avg?: UserAvgAggregate
+
+  @Field(() => UserSumAggregate, { nullable: true })
+  _sum?: UserSumAggregate
+
+  @Field(() => UserMinAggregate, { nullable: true })
+  _min?: UserMinAggregate
+
+  @Field(() => UserMaxAggregate, { nullable: true })
+  _max?: UserMaxAggregate
+}

--- a/api/src/@generated/user/create-many-user.args.ts
+++ b/api/src/@generated/user/create-many-user.args.ts
@@ -1,0 +1,14 @@
+import { Field } from '@nestjs/graphql'
+import { ArgsType } from '@nestjs/graphql'
+import { UserCreateManyInput } from './user-create-many.input'
+import { Type } from 'class-transformer'
+
+@ArgsType()
+export class CreateManyUserArgs {
+  @Field(() => [UserCreateManyInput], { nullable: false })
+  @Type(() => UserCreateManyInput)
+  data!: Array<UserCreateManyInput>
+
+  @Field(() => Boolean, { nullable: true })
+  skipDuplicates?: boolean
+}

--- a/api/src/@generated/user/create-one-user.args.ts
+++ b/api/src/@generated/user/create-one-user.args.ts
@@ -1,0 +1,11 @@
+import { Field } from '@nestjs/graphql'
+import { ArgsType } from '@nestjs/graphql'
+import { UserCreateInput } from './user-create.input'
+import { Type } from 'class-transformer'
+
+@ArgsType()
+export class CreateOneUserArgs {
+  @Field(() => UserCreateInput, { nullable: false })
+  @Type(() => UserCreateInput)
+  data!: UserCreateInput
+}

--- a/api/src/@generated/user/delete-many-user.args.ts
+++ b/api/src/@generated/user/delete-many-user.args.ts
@@ -1,0 +1,11 @@
+import { Field } from '@nestjs/graphql'
+import { ArgsType } from '@nestjs/graphql'
+import { UserWhereInput } from './user-where.input'
+import { Type } from 'class-transformer'
+
+@ArgsType()
+export class DeleteManyUserArgs {
+  @Field(() => UserWhereInput, { nullable: true })
+  @Type(() => UserWhereInput)
+  where?: UserWhereInput
+}

--- a/api/src/@generated/user/delete-one-user.args.ts
+++ b/api/src/@generated/user/delete-one-user.args.ts
@@ -1,0 +1,12 @@
+import { Field } from '@nestjs/graphql'
+import { ArgsType } from '@nestjs/graphql'
+import { Prisma } from '@prisma/client'
+import { UserWhereUniqueInput } from './user-where-unique.input'
+import { Type } from 'class-transformer'
+
+@ArgsType()
+export class DeleteOneUserArgs {
+  @Field(() => UserWhereUniqueInput, { nullable: false })
+  @Type(() => UserWhereUniqueInput)
+  where!: Prisma.AtLeast<UserWhereUniqueInput, 'id' | 'email' | 'username'>
+}

--- a/api/src/@generated/user/find-first-user-or-throw.args.ts
+++ b/api/src/@generated/user/find-first-user-or-throw.args.ts
@@ -1,0 +1,31 @@
+import { Field } from '@nestjs/graphql'
+import { ArgsType } from '@nestjs/graphql'
+import { UserWhereInput } from './user-where.input'
+import { Type } from 'class-transformer'
+import { UserOrderByWithRelationInput } from './user-order-by-with-relation.input'
+import { Prisma } from '@prisma/client'
+import { UserWhereUniqueInput } from './user-where-unique.input'
+import { Int } from '@nestjs/graphql'
+import { UserScalarFieldEnum } from './user-scalar-field.enum'
+
+@ArgsType()
+export class FindFirstUserOrThrowArgs {
+  @Field(() => UserWhereInput, { nullable: true })
+  @Type(() => UserWhereInput)
+  where?: UserWhereInput
+
+  @Field(() => [UserOrderByWithRelationInput], { nullable: true })
+  orderBy?: Array<UserOrderByWithRelationInput>
+
+  @Field(() => UserWhereUniqueInput, { nullable: true })
+  cursor?: Prisma.AtLeast<UserWhereUniqueInput, 'id' | 'email' | 'username'>
+
+  @Field(() => Int, { nullable: true })
+  take?: number
+
+  @Field(() => Int, { nullable: true })
+  skip?: number
+
+  @Field(() => [UserScalarFieldEnum], { nullable: true })
+  distinct?: Array<keyof typeof UserScalarFieldEnum>
+}

--- a/api/src/@generated/user/find-first-user.args.ts
+++ b/api/src/@generated/user/find-first-user.args.ts
@@ -1,0 +1,31 @@
+import { Field } from '@nestjs/graphql'
+import { ArgsType } from '@nestjs/graphql'
+import { UserWhereInput } from './user-where.input'
+import { Type } from 'class-transformer'
+import { UserOrderByWithRelationInput } from './user-order-by-with-relation.input'
+import { Prisma } from '@prisma/client'
+import { UserWhereUniqueInput } from './user-where-unique.input'
+import { Int } from '@nestjs/graphql'
+import { UserScalarFieldEnum } from './user-scalar-field.enum'
+
+@ArgsType()
+export class FindFirstUserArgs {
+  @Field(() => UserWhereInput, { nullable: true })
+  @Type(() => UserWhereInput)
+  where?: UserWhereInput
+
+  @Field(() => [UserOrderByWithRelationInput], { nullable: true })
+  orderBy?: Array<UserOrderByWithRelationInput>
+
+  @Field(() => UserWhereUniqueInput, { nullable: true })
+  cursor?: Prisma.AtLeast<UserWhereUniqueInput, 'id' | 'email' | 'username'>
+
+  @Field(() => Int, { nullable: true })
+  take?: number
+
+  @Field(() => Int, { nullable: true })
+  skip?: number
+
+  @Field(() => [UserScalarFieldEnum], { nullable: true })
+  distinct?: Array<keyof typeof UserScalarFieldEnum>
+}

--- a/api/src/@generated/user/find-many-user.args.ts
+++ b/api/src/@generated/user/find-many-user.args.ts
@@ -1,0 +1,31 @@
+import { Field } from '@nestjs/graphql'
+import { ArgsType } from '@nestjs/graphql'
+import { UserWhereInput } from './user-where.input'
+import { Type } from 'class-transformer'
+import { UserOrderByWithRelationInput } from './user-order-by-with-relation.input'
+import { Prisma } from '@prisma/client'
+import { UserWhereUniqueInput } from './user-where-unique.input'
+import { Int } from '@nestjs/graphql'
+import { UserScalarFieldEnum } from './user-scalar-field.enum'
+
+@ArgsType()
+export class FindManyUserArgs {
+  @Field(() => UserWhereInput, { nullable: true })
+  @Type(() => UserWhereInput)
+  where?: UserWhereInput
+
+  @Field(() => [UserOrderByWithRelationInput], { nullable: true })
+  orderBy?: Array<UserOrderByWithRelationInput>
+
+  @Field(() => UserWhereUniqueInput, { nullable: true })
+  cursor?: Prisma.AtLeast<UserWhereUniqueInput, 'id' | 'email' | 'username'>
+
+  @Field(() => Int, { nullable: true })
+  take?: number
+
+  @Field(() => Int, { nullable: true })
+  skip?: number
+
+  @Field(() => [UserScalarFieldEnum], { nullable: true })
+  distinct?: Array<keyof typeof UserScalarFieldEnum>
+}

--- a/api/src/@generated/user/find-unique-user-or-throw.args.ts
+++ b/api/src/@generated/user/find-unique-user-or-throw.args.ts
@@ -1,0 +1,12 @@
+import { Field } from '@nestjs/graphql'
+import { ArgsType } from '@nestjs/graphql'
+import { Prisma } from '@prisma/client'
+import { UserWhereUniqueInput } from './user-where-unique.input'
+import { Type } from 'class-transformer'
+
+@ArgsType()
+export class FindUniqueUserOrThrowArgs {
+  @Field(() => UserWhereUniqueInput, { nullable: false })
+  @Type(() => UserWhereUniqueInput)
+  where!: Prisma.AtLeast<UserWhereUniqueInput, 'id' | 'email' | 'username'>
+}

--- a/api/src/@generated/user/find-unique-user.args.ts
+++ b/api/src/@generated/user/find-unique-user.args.ts
@@ -1,0 +1,12 @@
+import { Field } from '@nestjs/graphql'
+import { ArgsType } from '@nestjs/graphql'
+import { Prisma } from '@prisma/client'
+import { UserWhereUniqueInput } from './user-where-unique.input'
+import { Type } from 'class-transformer'
+
+@ArgsType()
+export class FindUniqueUserArgs {
+  @Field(() => UserWhereUniqueInput, { nullable: false })
+  @Type(() => UserWhereUniqueInput)
+  where!: Prisma.AtLeast<UserWhereUniqueInput, 'id' | 'email' | 'username'>
+}

--- a/api/src/@generated/user/update-many-user.args.ts
+++ b/api/src/@generated/user/update-many-user.args.ts
@@ -1,0 +1,16 @@
+import { Field } from '@nestjs/graphql'
+import { ArgsType } from '@nestjs/graphql'
+import { UserUpdateManyMutationInput } from './user-update-many-mutation.input'
+import { Type } from 'class-transformer'
+import { UserWhereInput } from './user-where.input'
+
+@ArgsType()
+export class UpdateManyUserArgs {
+  @Field(() => UserUpdateManyMutationInput, { nullable: false })
+  @Type(() => UserUpdateManyMutationInput)
+  data!: UserUpdateManyMutationInput
+
+  @Field(() => UserWhereInput, { nullable: true })
+  @Type(() => UserWhereInput)
+  where?: UserWhereInput
+}

--- a/api/src/@generated/user/update-one-user.args.ts
+++ b/api/src/@generated/user/update-one-user.args.ts
@@ -1,0 +1,17 @@
+import { Field } from '@nestjs/graphql'
+import { ArgsType } from '@nestjs/graphql'
+import { UserUpdateInput } from './user-update.input'
+import { Type } from 'class-transformer'
+import { Prisma } from '@prisma/client'
+import { UserWhereUniqueInput } from './user-where-unique.input'
+
+@ArgsType()
+export class UpdateOneUserArgs {
+  @Field(() => UserUpdateInput, { nullable: false })
+  @Type(() => UserUpdateInput)
+  data!: UserUpdateInput
+
+  @Field(() => UserWhereUniqueInput, { nullable: false })
+  @Type(() => UserWhereUniqueInput)
+  where!: Prisma.AtLeast<UserWhereUniqueInput, 'id' | 'email' | 'username'>
+}

--- a/api/src/@generated/user/upsert-one-user.args.ts
+++ b/api/src/@generated/user/upsert-one-user.args.ts
@@ -1,0 +1,22 @@
+import { Field } from '@nestjs/graphql'
+import { ArgsType } from '@nestjs/graphql'
+import { Prisma } from '@prisma/client'
+import { UserWhereUniqueInput } from './user-where-unique.input'
+import { Type } from 'class-transformer'
+import { UserCreateInput } from './user-create.input'
+import { UserUpdateInput } from './user-update.input'
+
+@ArgsType()
+export class UpsertOneUserArgs {
+  @Field(() => UserWhereUniqueInput, { nullable: false })
+  @Type(() => UserWhereUniqueInput)
+  where!: Prisma.AtLeast<UserWhereUniqueInput, 'id' | 'email' | 'username'>
+
+  @Field(() => UserCreateInput, { nullable: false })
+  @Type(() => UserCreateInput)
+  create!: UserCreateInput
+
+  @Field(() => UserUpdateInput, { nullable: false })
+  @Type(() => UserUpdateInput)
+  update!: UserUpdateInput
+}

--- a/api/src/@generated/user/user-aggregate.args.ts
+++ b/api/src/@generated/user/user-aggregate.args.ts
@@ -1,0 +1,47 @@
+import { Field } from '@nestjs/graphql'
+import { ArgsType } from '@nestjs/graphql'
+import { UserWhereInput } from './user-where.input'
+import { Type } from 'class-transformer'
+import { UserOrderByWithRelationInput } from './user-order-by-with-relation.input'
+import { Prisma } from '@prisma/client'
+import { UserWhereUniqueInput } from './user-where-unique.input'
+import { Int } from '@nestjs/graphql'
+import { UserCountAggregateInput } from './user-count-aggregate.input'
+import { UserAvgAggregateInput } from './user-avg-aggregate.input'
+import { UserSumAggregateInput } from './user-sum-aggregate.input'
+import { UserMinAggregateInput } from './user-min-aggregate.input'
+import { UserMaxAggregateInput } from './user-max-aggregate.input'
+
+@ArgsType()
+export class UserAggregateArgs {
+  @Field(() => UserWhereInput, { nullable: true })
+  @Type(() => UserWhereInput)
+  where?: UserWhereInput
+
+  @Field(() => [UserOrderByWithRelationInput], { nullable: true })
+  orderBy?: Array<UserOrderByWithRelationInput>
+
+  @Field(() => UserWhereUniqueInput, { nullable: true })
+  cursor?: Prisma.AtLeast<UserWhereUniqueInput, 'id' | 'email' | 'username'>
+
+  @Field(() => Int, { nullable: true })
+  take?: number
+
+  @Field(() => Int, { nullable: true })
+  skip?: number
+
+  @Field(() => UserCountAggregateInput, { nullable: true })
+  _count?: UserCountAggregateInput
+
+  @Field(() => UserAvgAggregateInput, { nullable: true })
+  _avg?: UserAvgAggregateInput
+
+  @Field(() => UserSumAggregateInput, { nullable: true })
+  _sum?: UserSumAggregateInput
+
+  @Field(() => UserMinAggregateInput, { nullable: true })
+  _min?: UserMinAggregateInput
+
+  @Field(() => UserMaxAggregateInput, { nullable: true })
+  _max?: UserMaxAggregateInput
+}

--- a/api/src/@generated/user/user-avg-aggregate.input.ts
+++ b/api/src/@generated/user/user-avg-aggregate.input.ts
@@ -1,0 +1,8 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+
+@InputType()
+export class UserAvgAggregateInput {
+  @Field(() => Boolean, { nullable: true })
+  id?: true
+}

--- a/api/src/@generated/user/user-avg-aggregate.output.ts
+++ b/api/src/@generated/user/user-avg-aggregate.output.ts
@@ -1,0 +1,9 @@
+import { Field } from '@nestjs/graphql'
+import { ObjectType } from '@nestjs/graphql'
+import { Float } from '@nestjs/graphql'
+
+@ObjectType()
+export class UserAvgAggregate {
+  @Field(() => Float, { nullable: true })
+  id?: number
+}

--- a/api/src/@generated/user/user-avg-order-by-aggregate.input.ts
+++ b/api/src/@generated/user/user-avg-order-by-aggregate.input.ts
@@ -1,0 +1,9 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { SortOrder } from '../prisma/sort-order.enum'
+
+@InputType()
+export class UserAvgOrderByAggregateInput {
+  @Field(() => SortOrder, { nullable: true })
+  id?: keyof typeof SortOrder
+}

--- a/api/src/@generated/user/user-count-aggregate.input.ts
+++ b/api/src/@generated/user/user-count-aggregate.input.ts
@@ -1,0 +1,35 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+
+@InputType()
+export class UserCountAggregateInput {
+  @Field(() => Boolean, { nullable: true })
+  id?: true
+
+  @Field(() => Boolean, { nullable: true })
+  email?: true
+
+  @Field(() => Boolean, { nullable: true })
+  username?: true
+
+  @Field(() => Boolean, { nullable: true })
+  name?: true
+
+  @Field(() => Boolean, { nullable: true })
+  password?: true
+
+  @Field(() => Boolean, { nullable: true })
+  refreshToken?: true
+
+  @Field(() => Boolean, { nullable: true })
+  role?: true
+
+  @Field(() => Boolean, { nullable: true })
+  createdAt?: true
+
+  @Field(() => Boolean, { nullable: true })
+  updatedAt?: true
+
+  @Field(() => Boolean, { nullable: true })
+  _all?: true
+}

--- a/api/src/@generated/user/user-count-aggregate.output.ts
+++ b/api/src/@generated/user/user-count-aggregate.output.ts
@@ -1,0 +1,36 @@
+import { Field } from '@nestjs/graphql'
+import { ObjectType } from '@nestjs/graphql'
+import { Int } from '@nestjs/graphql'
+
+@ObjectType()
+export class UserCountAggregate {
+  @Field(() => Int, { nullable: false })
+  id!: number
+
+  @Field(() => Int, { nullable: false })
+  email!: number
+
+  @Field(() => Int, { nullable: false })
+  username!: number
+
+  @Field(() => Int, { nullable: false })
+  name!: number
+
+  @Field(() => Int, { nullable: false })
+  password!: number
+
+  @Field(() => Int, { nullable: false })
+  refreshToken!: number
+
+  @Field(() => Int, { nullable: false })
+  role!: number
+
+  @Field(() => Int, { nullable: false })
+  createdAt!: number
+
+  @Field(() => Int, { nullable: false })
+  updatedAt!: number
+
+  @Field(() => Int, { nullable: false })
+  _all!: number
+}

--- a/api/src/@generated/user/user-count-order-by-aggregate.input.ts
+++ b/api/src/@generated/user/user-count-order-by-aggregate.input.ts
@@ -1,0 +1,33 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { SortOrder } from '../prisma/sort-order.enum'
+
+@InputType()
+export class UserCountOrderByAggregateInput {
+  @Field(() => SortOrder, { nullable: true })
+  id?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  email?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  username?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  name?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  password?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  refreshToken?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  role?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  createdAt?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  updatedAt?: keyof typeof SortOrder
+}

--- a/api/src/@generated/user/user-create-many.input.ts
+++ b/api/src/@generated/user/user-create-many.input.ts
@@ -1,0 +1,38 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { Int } from '@nestjs/graphql'
+import * as Validator from 'class-validator'
+import { Role } from '../prisma/role.enum'
+
+@InputType()
+export class UserCreateManyInput {
+  @Field(() => Int, { nullable: true })
+  id?: number
+
+  @Field(() => String, { nullable: false })
+  email!: string
+
+  @Field(() => String, { nullable: false })
+  @Validator.MinLength(5)
+  username!: string
+
+  @Field(() => String, { nullable: false })
+  @Validator.MinLength(3)
+  name!: string
+
+  @Field(() => String, { nullable: false })
+  @Validator.MinLength(6)
+  password!: string
+
+  @Field(() => String, { nullable: true })
+  refreshToken?: string
+
+  @Field(() => Role, { nullable: true })
+  role?: keyof typeof Role
+
+  @Field(() => Date, { nullable: true })
+  createdAt?: Date | string
+
+  @Field(() => Date, { nullable: true })
+  updatedAt?: Date | string
+}

--- a/api/src/@generated/user/user-create.input.ts
+++ b/api/src/@generated/user/user-create.input.ts
@@ -1,0 +1,34 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import * as Validator from 'class-validator'
+import { Role } from '../prisma/role.enum'
+
+@InputType()
+export class UserCreateInput {
+  @Field(() => String, { nullable: false })
+  email!: string
+
+  @Field(() => String, { nullable: false })
+  @Validator.MinLength(5)
+  username!: string
+
+  @Field(() => String, { nullable: false })
+  @Validator.MinLength(3)
+  name!: string
+
+  @Field(() => String, { nullable: false })
+  @Validator.MinLength(6)
+  password!: string
+
+  @Field(() => String, { nullable: true })
+  refreshToken?: string
+
+  @Field(() => Role, { nullable: true })
+  role?: keyof typeof Role
+
+  @Field(() => Date, { nullable: true })
+  createdAt?: Date | string
+
+  @Field(() => Date, { nullable: true })
+  updatedAt?: Date | string
+}

--- a/api/src/@generated/user/user-group-by.args.ts
+++ b/api/src/@generated/user/user-group-by.args.ts
@@ -1,0 +1,50 @@
+import { Field } from '@nestjs/graphql'
+import { ArgsType } from '@nestjs/graphql'
+import { UserWhereInput } from './user-where.input'
+import { Type } from 'class-transformer'
+import { UserOrderByWithAggregationInput } from './user-order-by-with-aggregation.input'
+import { UserScalarFieldEnum } from './user-scalar-field.enum'
+import { UserScalarWhereWithAggregatesInput } from './user-scalar-where-with-aggregates.input'
+import { Int } from '@nestjs/graphql'
+import { UserCountAggregateInput } from './user-count-aggregate.input'
+import { UserAvgAggregateInput } from './user-avg-aggregate.input'
+import { UserSumAggregateInput } from './user-sum-aggregate.input'
+import { UserMinAggregateInput } from './user-min-aggregate.input'
+import { UserMaxAggregateInput } from './user-max-aggregate.input'
+
+@ArgsType()
+export class UserGroupByArgs {
+  @Field(() => UserWhereInput, { nullable: true })
+  @Type(() => UserWhereInput)
+  where?: UserWhereInput
+
+  @Field(() => [UserOrderByWithAggregationInput], { nullable: true })
+  orderBy?: Array<UserOrderByWithAggregationInput>
+
+  @Field(() => [UserScalarFieldEnum], { nullable: false })
+  by!: Array<keyof typeof UserScalarFieldEnum>
+
+  @Field(() => UserScalarWhereWithAggregatesInput, { nullable: true })
+  having?: UserScalarWhereWithAggregatesInput
+
+  @Field(() => Int, { nullable: true })
+  take?: number
+
+  @Field(() => Int, { nullable: true })
+  skip?: number
+
+  @Field(() => UserCountAggregateInput, { nullable: true })
+  _count?: UserCountAggregateInput
+
+  @Field(() => UserAvgAggregateInput, { nullable: true })
+  _avg?: UserAvgAggregateInput
+
+  @Field(() => UserSumAggregateInput, { nullable: true })
+  _sum?: UserSumAggregateInput
+
+  @Field(() => UserMinAggregateInput, { nullable: true })
+  _min?: UserMinAggregateInput
+
+  @Field(() => UserMaxAggregateInput, { nullable: true })
+  _max?: UserMaxAggregateInput
+}

--- a/api/src/@generated/user/user-group-by.output.ts
+++ b/api/src/@generated/user/user-group-by.output.ts
@@ -1,0 +1,54 @@
+import { Field } from '@nestjs/graphql'
+import { ObjectType } from '@nestjs/graphql'
+import { Int } from '@nestjs/graphql'
+import { Role } from '../prisma/role.enum'
+import { UserCountAggregate } from './user-count-aggregate.output'
+import { UserAvgAggregate } from './user-avg-aggregate.output'
+import { UserSumAggregate } from './user-sum-aggregate.output'
+import { UserMinAggregate } from './user-min-aggregate.output'
+import { UserMaxAggregate } from './user-max-aggregate.output'
+
+@ObjectType()
+export class UserGroupBy {
+  @Field(() => Int, { nullable: false })
+  id!: number
+
+  @Field(() => String, { nullable: false })
+  email!: string
+
+  @Field(() => String, { nullable: false })
+  username!: string
+
+  @Field(() => String, { nullable: false })
+  name!: string
+
+  @Field(() => String, { nullable: false })
+  password!: string
+
+  @Field(() => String, { nullable: true })
+  refreshToken?: string
+
+  @Field(() => Role, { nullable: false })
+  role!: keyof typeof Role
+
+  @Field(() => Date, { nullable: false })
+  createdAt!: Date | string
+
+  @Field(() => Date, { nullable: false })
+  updatedAt!: Date | string
+
+  @Field(() => UserCountAggregate, { nullable: true })
+  _count?: UserCountAggregate
+
+  @Field(() => UserAvgAggregate, { nullable: true })
+  _avg?: UserAvgAggregate
+
+  @Field(() => UserSumAggregate, { nullable: true })
+  _sum?: UserSumAggregate
+
+  @Field(() => UserMinAggregate, { nullable: true })
+  _min?: UserMinAggregate
+
+  @Field(() => UserMaxAggregate, { nullable: true })
+  _max?: UserMaxAggregate
+}

--- a/api/src/@generated/user/user-max-aggregate.input.ts
+++ b/api/src/@generated/user/user-max-aggregate.input.ts
@@ -1,0 +1,32 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+
+@InputType()
+export class UserMaxAggregateInput {
+  @Field(() => Boolean, { nullable: true })
+  id?: true
+
+  @Field(() => Boolean, { nullable: true })
+  email?: true
+
+  @Field(() => Boolean, { nullable: true })
+  username?: true
+
+  @Field(() => Boolean, { nullable: true })
+  name?: true
+
+  @Field(() => Boolean, { nullable: true })
+  password?: true
+
+  @Field(() => Boolean, { nullable: true })
+  refreshToken?: true
+
+  @Field(() => Boolean, { nullable: true })
+  role?: true
+
+  @Field(() => Boolean, { nullable: true })
+  createdAt?: true
+
+  @Field(() => Boolean, { nullable: true })
+  updatedAt?: true
+}

--- a/api/src/@generated/user/user-max-aggregate.output.ts
+++ b/api/src/@generated/user/user-max-aggregate.output.ts
@@ -1,0 +1,34 @@
+import { Field } from '@nestjs/graphql'
+import { ObjectType } from '@nestjs/graphql'
+import { Int } from '@nestjs/graphql'
+import { Role } from '../prisma/role.enum'
+
+@ObjectType()
+export class UserMaxAggregate {
+  @Field(() => Int, { nullable: true })
+  id?: number
+
+  @Field(() => String, { nullable: true })
+  email?: string
+
+  @Field(() => String, { nullable: true })
+  username?: string
+
+  @Field(() => String, { nullable: true })
+  name?: string
+
+  @Field(() => String, { nullable: true })
+  password?: string
+
+  @Field(() => String, { nullable: true })
+  refreshToken?: string
+
+  @Field(() => Role, { nullable: true })
+  role?: keyof typeof Role
+
+  @Field(() => Date, { nullable: true })
+  createdAt?: Date | string
+
+  @Field(() => Date, { nullable: true })
+  updatedAt?: Date | string
+}

--- a/api/src/@generated/user/user-max-order-by-aggregate.input.ts
+++ b/api/src/@generated/user/user-max-order-by-aggregate.input.ts
@@ -1,0 +1,33 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { SortOrder } from '../prisma/sort-order.enum'
+
+@InputType()
+export class UserMaxOrderByAggregateInput {
+  @Field(() => SortOrder, { nullable: true })
+  id?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  email?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  username?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  name?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  password?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  refreshToken?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  role?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  createdAt?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  updatedAt?: keyof typeof SortOrder
+}

--- a/api/src/@generated/user/user-min-aggregate.input.ts
+++ b/api/src/@generated/user/user-min-aggregate.input.ts
@@ -1,0 +1,32 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+
+@InputType()
+export class UserMinAggregateInput {
+  @Field(() => Boolean, { nullable: true })
+  id?: true
+
+  @Field(() => Boolean, { nullable: true })
+  email?: true
+
+  @Field(() => Boolean, { nullable: true })
+  username?: true
+
+  @Field(() => Boolean, { nullable: true })
+  name?: true
+
+  @Field(() => Boolean, { nullable: true })
+  password?: true
+
+  @Field(() => Boolean, { nullable: true })
+  refreshToken?: true
+
+  @Field(() => Boolean, { nullable: true })
+  role?: true
+
+  @Field(() => Boolean, { nullable: true })
+  createdAt?: true
+
+  @Field(() => Boolean, { nullable: true })
+  updatedAt?: true
+}

--- a/api/src/@generated/user/user-min-aggregate.output.ts
+++ b/api/src/@generated/user/user-min-aggregate.output.ts
@@ -1,0 +1,34 @@
+import { Field } from '@nestjs/graphql'
+import { ObjectType } from '@nestjs/graphql'
+import { Int } from '@nestjs/graphql'
+import { Role } from '../prisma/role.enum'
+
+@ObjectType()
+export class UserMinAggregate {
+  @Field(() => Int, { nullable: true })
+  id?: number
+
+  @Field(() => String, { nullable: true })
+  email?: string
+
+  @Field(() => String, { nullable: true })
+  username?: string
+
+  @Field(() => String, { nullable: true })
+  name?: string
+
+  @Field(() => String, { nullable: true })
+  password?: string
+
+  @Field(() => String, { nullable: true })
+  refreshToken?: string
+
+  @Field(() => Role, { nullable: true })
+  role?: keyof typeof Role
+
+  @Field(() => Date, { nullable: true })
+  createdAt?: Date | string
+
+  @Field(() => Date, { nullable: true })
+  updatedAt?: Date | string
+}

--- a/api/src/@generated/user/user-min-order-by-aggregate.input.ts
+++ b/api/src/@generated/user/user-min-order-by-aggregate.input.ts
@@ -1,0 +1,33 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { SortOrder } from '../prisma/sort-order.enum'
+
+@InputType()
+export class UserMinOrderByAggregateInput {
+  @Field(() => SortOrder, { nullable: true })
+  id?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  email?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  username?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  name?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  password?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  refreshToken?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  role?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  createdAt?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  updatedAt?: keyof typeof SortOrder
+}

--- a/api/src/@generated/user/user-order-by-with-aggregation.input.ts
+++ b/api/src/@generated/user/user-order-by-with-aggregation.input.ts
@@ -1,0 +1,54 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { SortOrder } from '../prisma/sort-order.enum'
+import { SortOrderInput } from '../prisma/sort-order.input'
+import { UserCountOrderByAggregateInput } from './user-count-order-by-aggregate.input'
+import { UserAvgOrderByAggregateInput } from './user-avg-order-by-aggregate.input'
+import { UserMaxOrderByAggregateInput } from './user-max-order-by-aggregate.input'
+import { UserMinOrderByAggregateInput } from './user-min-order-by-aggregate.input'
+import { UserSumOrderByAggregateInput } from './user-sum-order-by-aggregate.input'
+
+@InputType()
+export class UserOrderByWithAggregationInput {
+  @Field(() => SortOrder, { nullable: true })
+  id?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  email?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  username?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  name?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  password?: keyof typeof SortOrder
+
+  @Field(() => SortOrderInput, { nullable: true })
+  refreshToken?: SortOrderInput
+
+  @Field(() => SortOrder, { nullable: true })
+  role?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  createdAt?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  updatedAt?: keyof typeof SortOrder
+
+  @Field(() => UserCountOrderByAggregateInput, { nullable: true })
+  _count?: UserCountOrderByAggregateInput
+
+  @Field(() => UserAvgOrderByAggregateInput, { nullable: true })
+  _avg?: UserAvgOrderByAggregateInput
+
+  @Field(() => UserMaxOrderByAggregateInput, { nullable: true })
+  _max?: UserMaxOrderByAggregateInput
+
+  @Field(() => UserMinOrderByAggregateInput, { nullable: true })
+  _min?: UserMinOrderByAggregateInput
+
+  @Field(() => UserSumOrderByAggregateInput, { nullable: true })
+  _sum?: UserSumOrderByAggregateInput
+}

--- a/api/src/@generated/user/user-order-by-with-relation.input.ts
+++ b/api/src/@generated/user/user-order-by-with-relation.input.ts
@@ -1,0 +1,34 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { SortOrder } from '../prisma/sort-order.enum'
+import { SortOrderInput } from '../prisma/sort-order.input'
+
+@InputType()
+export class UserOrderByWithRelationInput {
+  @Field(() => SortOrder, { nullable: true })
+  id?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  email?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  username?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  name?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  password?: keyof typeof SortOrder
+
+  @Field(() => SortOrderInput, { nullable: true })
+  refreshToken?: SortOrderInput
+
+  @Field(() => SortOrder, { nullable: true })
+  role?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  createdAt?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  updatedAt?: keyof typeof SortOrder
+}

--- a/api/src/@generated/user/user-scalar-field.enum.ts
+++ b/api/src/@generated/user/user-scalar-field.enum.ts
@@ -1,0 +1,15 @@
+import { registerEnumType } from '@nestjs/graphql'
+
+export enum UserScalarFieldEnum {
+  id = 'id',
+  email = 'email',
+  username = 'username',
+  name = 'name',
+  password = 'password',
+  refreshToken = 'refreshToken',
+  role = 'role',
+  createdAt = 'createdAt',
+  updatedAt = 'updatedAt'
+}
+
+registerEnumType(UserScalarFieldEnum, { name: 'UserScalarFieldEnum', description: undefined })

--- a/api/src/@generated/user/user-scalar-where-with-aggregates.input.ts
+++ b/api/src/@generated/user/user-scalar-where-with-aggregates.input.ts
@@ -1,0 +1,46 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { IntWithAggregatesFilter } from '../prisma/int-with-aggregates-filter.input'
+import { StringWithAggregatesFilter } from '../prisma/string-with-aggregates-filter.input'
+import { StringNullableWithAggregatesFilter } from '../prisma/string-nullable-with-aggregates-filter.input'
+import { EnumRoleWithAggregatesFilter } from '../prisma/enum-role-with-aggregates-filter.input'
+import { DateTimeWithAggregatesFilter } from '../prisma/date-time-with-aggregates-filter.input'
+
+@InputType()
+export class UserScalarWhereWithAggregatesInput {
+  @Field(() => [UserScalarWhereWithAggregatesInput], { nullable: true })
+  AND?: Array<UserScalarWhereWithAggregatesInput>
+
+  @Field(() => [UserScalarWhereWithAggregatesInput], { nullable: true })
+  OR?: Array<UserScalarWhereWithAggregatesInput>
+
+  @Field(() => [UserScalarWhereWithAggregatesInput], { nullable: true })
+  NOT?: Array<UserScalarWhereWithAggregatesInput>
+
+  @Field(() => IntWithAggregatesFilter, { nullable: true })
+  id?: IntWithAggregatesFilter
+
+  @Field(() => StringWithAggregatesFilter, { nullable: true })
+  email?: StringWithAggregatesFilter
+
+  @Field(() => StringWithAggregatesFilter, { nullable: true })
+  username?: StringWithAggregatesFilter
+
+  @Field(() => StringWithAggregatesFilter, { nullable: true })
+  name?: StringWithAggregatesFilter
+
+  @Field(() => StringWithAggregatesFilter, { nullable: true })
+  password?: StringWithAggregatesFilter
+
+  @Field(() => StringNullableWithAggregatesFilter, { nullable: true })
+  refreshToken?: StringNullableWithAggregatesFilter
+
+  @Field(() => EnumRoleWithAggregatesFilter, { nullable: true })
+  role?: EnumRoleWithAggregatesFilter
+
+  @Field(() => DateTimeWithAggregatesFilter, { nullable: true })
+  createdAt?: DateTimeWithAggregatesFilter
+
+  @Field(() => DateTimeWithAggregatesFilter, { nullable: true })
+  updatedAt?: DateTimeWithAggregatesFilter
+}

--- a/api/src/@generated/user/user-sum-aggregate.input.ts
+++ b/api/src/@generated/user/user-sum-aggregate.input.ts
@@ -1,0 +1,8 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+
+@InputType()
+export class UserSumAggregateInput {
+  @Field(() => Boolean, { nullable: true })
+  id?: true
+}

--- a/api/src/@generated/user/user-sum-aggregate.output.ts
+++ b/api/src/@generated/user/user-sum-aggregate.output.ts
@@ -1,0 +1,9 @@
+import { Field } from '@nestjs/graphql'
+import { ObjectType } from '@nestjs/graphql'
+import { Int } from '@nestjs/graphql'
+
+@ObjectType()
+export class UserSumAggregate {
+  @Field(() => Int, { nullable: true })
+  id?: number
+}

--- a/api/src/@generated/user/user-sum-order-by-aggregate.input.ts
+++ b/api/src/@generated/user/user-sum-order-by-aggregate.input.ts
@@ -1,0 +1,9 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { SortOrder } from '../prisma/sort-order.enum'
+
+@InputType()
+export class UserSumOrderByAggregateInput {
+  @Field(() => SortOrder, { nullable: true })
+  id?: keyof typeof SortOrder
+}

--- a/api/src/@generated/user/user-unchecked-create.input.ts
+++ b/api/src/@generated/user/user-unchecked-create.input.ts
@@ -1,0 +1,38 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { Int } from '@nestjs/graphql'
+import * as Validator from 'class-validator'
+import { Role } from '../prisma/role.enum'
+
+@InputType()
+export class UserUncheckedCreateInput {
+  @Field(() => Int, { nullable: true })
+  id?: number
+
+  @Field(() => String, { nullable: false })
+  email!: string
+
+  @Field(() => String, { nullable: false })
+  @Validator.MinLength(5)
+  username!: string
+
+  @Field(() => String, { nullable: false })
+  @Validator.MinLength(3)
+  name!: string
+
+  @Field(() => String, { nullable: false })
+  @Validator.MinLength(6)
+  password!: string
+
+  @Field(() => String, { nullable: true })
+  refreshToken?: string
+
+  @Field(() => Role, { nullable: true })
+  role?: keyof typeof Role
+
+  @Field(() => Date, { nullable: true })
+  createdAt?: Date | string
+
+  @Field(() => Date, { nullable: true })
+  updatedAt?: Date | string
+}

--- a/api/src/@generated/user/user-unchecked-update-many.input.ts
+++ b/api/src/@generated/user/user-unchecked-update-many.input.ts
@@ -1,0 +1,37 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { IntFieldUpdateOperationsInput } from '../prisma/int-field-update-operations.input'
+import { StringFieldUpdateOperationsInput } from '../prisma/string-field-update-operations.input'
+import { NullableStringFieldUpdateOperationsInput } from '../prisma/nullable-string-field-update-operations.input'
+import { EnumRoleFieldUpdateOperationsInput } from '../prisma/enum-role-field-update-operations.input'
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input'
+
+@InputType()
+export class UserUncheckedUpdateManyInput {
+  @Field(() => IntFieldUpdateOperationsInput, { nullable: true })
+  id?: IntFieldUpdateOperationsInput
+
+  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
+  email?: StringFieldUpdateOperationsInput
+
+  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
+  username?: StringFieldUpdateOperationsInput
+
+  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
+  name?: StringFieldUpdateOperationsInput
+
+  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
+  password?: StringFieldUpdateOperationsInput
+
+  @Field(() => NullableStringFieldUpdateOperationsInput, { nullable: true })
+  refreshToken?: NullableStringFieldUpdateOperationsInput
+
+  @Field(() => EnumRoleFieldUpdateOperationsInput, { nullable: true })
+  role?: EnumRoleFieldUpdateOperationsInput
+
+  @Field(() => DateTimeFieldUpdateOperationsInput, { nullable: true })
+  createdAt?: DateTimeFieldUpdateOperationsInput
+
+  @Field(() => DateTimeFieldUpdateOperationsInput, { nullable: true })
+  updatedAt?: DateTimeFieldUpdateOperationsInput
+}

--- a/api/src/@generated/user/user-unchecked-update.input.ts
+++ b/api/src/@generated/user/user-unchecked-update.input.ts
@@ -1,0 +1,37 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { IntFieldUpdateOperationsInput } from '../prisma/int-field-update-operations.input'
+import { StringFieldUpdateOperationsInput } from '../prisma/string-field-update-operations.input'
+import { NullableStringFieldUpdateOperationsInput } from '../prisma/nullable-string-field-update-operations.input'
+import { EnumRoleFieldUpdateOperationsInput } from '../prisma/enum-role-field-update-operations.input'
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input'
+
+@InputType()
+export class UserUncheckedUpdateInput {
+  @Field(() => IntFieldUpdateOperationsInput, { nullable: true })
+  id?: IntFieldUpdateOperationsInput
+
+  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
+  email?: StringFieldUpdateOperationsInput
+
+  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
+  username?: StringFieldUpdateOperationsInput
+
+  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
+  name?: StringFieldUpdateOperationsInput
+
+  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
+  password?: StringFieldUpdateOperationsInput
+
+  @Field(() => NullableStringFieldUpdateOperationsInput, { nullable: true })
+  refreshToken?: NullableStringFieldUpdateOperationsInput
+
+  @Field(() => EnumRoleFieldUpdateOperationsInput, { nullable: true })
+  role?: EnumRoleFieldUpdateOperationsInput
+
+  @Field(() => DateTimeFieldUpdateOperationsInput, { nullable: true })
+  createdAt?: DateTimeFieldUpdateOperationsInput
+
+  @Field(() => DateTimeFieldUpdateOperationsInput, { nullable: true })
+  updatedAt?: DateTimeFieldUpdateOperationsInput
+}

--- a/api/src/@generated/user/user-update-many-mutation.input.ts
+++ b/api/src/@generated/user/user-update-many-mutation.input.ts
@@ -1,0 +1,33 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { StringFieldUpdateOperationsInput } from '../prisma/string-field-update-operations.input'
+import { NullableStringFieldUpdateOperationsInput } from '../prisma/nullable-string-field-update-operations.input'
+import { EnumRoleFieldUpdateOperationsInput } from '../prisma/enum-role-field-update-operations.input'
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input'
+
+@InputType()
+export class UserUpdateManyMutationInput {
+  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
+  email?: StringFieldUpdateOperationsInput
+
+  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
+  username?: StringFieldUpdateOperationsInput
+
+  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
+  name?: StringFieldUpdateOperationsInput
+
+  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
+  password?: StringFieldUpdateOperationsInput
+
+  @Field(() => NullableStringFieldUpdateOperationsInput, { nullable: true })
+  refreshToken?: NullableStringFieldUpdateOperationsInput
+
+  @Field(() => EnumRoleFieldUpdateOperationsInput, { nullable: true })
+  role?: EnumRoleFieldUpdateOperationsInput
+
+  @Field(() => DateTimeFieldUpdateOperationsInput, { nullable: true })
+  createdAt?: DateTimeFieldUpdateOperationsInput
+
+  @Field(() => DateTimeFieldUpdateOperationsInput, { nullable: true })
+  updatedAt?: DateTimeFieldUpdateOperationsInput
+}

--- a/api/src/@generated/user/user-update.input.ts
+++ b/api/src/@generated/user/user-update.input.ts
@@ -1,0 +1,33 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { StringFieldUpdateOperationsInput } from '../prisma/string-field-update-operations.input'
+import { NullableStringFieldUpdateOperationsInput } from '../prisma/nullable-string-field-update-operations.input'
+import { EnumRoleFieldUpdateOperationsInput } from '../prisma/enum-role-field-update-operations.input'
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input'
+
+@InputType()
+export class UserUpdateInput {
+  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
+  email?: StringFieldUpdateOperationsInput
+
+  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
+  username?: StringFieldUpdateOperationsInput
+
+  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
+  name?: StringFieldUpdateOperationsInput
+
+  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
+  password?: StringFieldUpdateOperationsInput
+
+  @Field(() => NullableStringFieldUpdateOperationsInput, { nullable: true })
+  refreshToken?: NullableStringFieldUpdateOperationsInput
+
+  @Field(() => EnumRoleFieldUpdateOperationsInput, { nullable: true })
+  role?: EnumRoleFieldUpdateOperationsInput
+
+  @Field(() => DateTimeFieldUpdateOperationsInput, { nullable: true })
+  createdAt?: DateTimeFieldUpdateOperationsInput
+
+  @Field(() => DateTimeFieldUpdateOperationsInput, { nullable: true })
+  updatedAt?: DateTimeFieldUpdateOperationsInput
+}

--- a/api/src/@generated/user/user-where-unique.input.ts
+++ b/api/src/@generated/user/user-where-unique.input.ts
@@ -1,0 +1,49 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { Int } from '@nestjs/graphql'
+import * as Validator from 'class-validator'
+import { UserWhereInput } from './user-where.input'
+import { StringFilter } from '../prisma/string-filter.input'
+import { StringNullableFilter } from '../prisma/string-nullable-filter.input'
+import { EnumRoleFilter } from '../prisma/enum-role-filter.input'
+import { DateTimeFilter } from '../prisma/date-time-filter.input'
+
+@InputType()
+export class UserWhereUniqueInput {
+  @Field(() => Int, { nullable: true })
+  id?: number
+
+  @Field(() => String, { nullable: true })
+  email?: string
+
+  @Field(() => String, { nullable: true })
+  @Validator.MinLength(5)
+  username?: string
+
+  @Field(() => [UserWhereInput], { nullable: true })
+  AND?: Array<UserWhereInput>
+
+  @Field(() => [UserWhereInput], { nullable: true })
+  OR?: Array<UserWhereInput>
+
+  @Field(() => [UserWhereInput], { nullable: true })
+  NOT?: Array<UserWhereInput>
+
+  @Field(() => StringFilter, { nullable: true })
+  name?: StringFilter
+
+  @Field(() => StringFilter, { nullable: true })
+  password?: StringFilter
+
+  @Field(() => StringNullableFilter, { nullable: true })
+  refreshToken?: StringNullableFilter
+
+  @Field(() => EnumRoleFilter, { nullable: true })
+  role?: EnumRoleFilter
+
+  @Field(() => DateTimeFilter, { nullable: true })
+  createdAt?: DateTimeFilter
+
+  @Field(() => DateTimeFilter, { nullable: true })
+  updatedAt?: DateTimeFilter
+}

--- a/api/src/@generated/user/user-where.input.ts
+++ b/api/src/@generated/user/user-where.input.ts
@@ -1,0 +1,46 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { IntFilter } from '../prisma/int-filter.input'
+import { StringFilter } from '../prisma/string-filter.input'
+import { StringNullableFilter } from '../prisma/string-nullable-filter.input'
+import { EnumRoleFilter } from '../prisma/enum-role-filter.input'
+import { DateTimeFilter } from '../prisma/date-time-filter.input'
+
+@InputType()
+export class UserWhereInput {
+  @Field(() => [UserWhereInput], { nullable: true })
+  AND?: Array<UserWhereInput>
+
+  @Field(() => [UserWhereInput], { nullable: true })
+  OR?: Array<UserWhereInput>
+
+  @Field(() => [UserWhereInput], { nullable: true })
+  NOT?: Array<UserWhereInput>
+
+  @Field(() => IntFilter, { nullable: true })
+  id?: IntFilter
+
+  @Field(() => StringFilter, { nullable: true })
+  email?: StringFilter
+
+  @Field(() => StringFilter, { nullable: true })
+  username?: StringFilter
+
+  @Field(() => StringFilter, { nullable: true })
+  name?: StringFilter
+
+  @Field(() => StringFilter, { nullable: true })
+  password?: StringFilter
+
+  @Field(() => StringNullableFilter, { nullable: true })
+  refreshToken?: StringNullableFilter
+
+  @Field(() => EnumRoleFilter, { nullable: true })
+  role?: EnumRoleFilter
+
+  @Field(() => DateTimeFilter, { nullable: true })
+  createdAt?: DateTimeFilter
+
+  @Field(() => DateTimeFilter, { nullable: true })
+  updatedAt?: DateTimeFilter
+}

--- a/api/src/@generated/user/user.model.ts
+++ b/api/src/@generated/user/user.model.ts
@@ -1,0 +1,34 @@
+import { Field } from '@nestjs/graphql'
+import { ObjectType } from '@nestjs/graphql'
+import { ID } from '@nestjs/graphql'
+import { Role } from '../prisma/role.enum'
+
+@ObjectType()
+export class User {
+  @Field(() => ID, { nullable: false })
+  id!: number
+
+  @Field(() => String, { nullable: false })
+  email!: string
+
+  @Field(() => String, { nullable: false })
+  username!: string
+
+  @Field(() => String, { nullable: false })
+  name!: string
+
+  @Field(() => String, { nullable: false })
+  password!: string
+
+  @Field(() => String, { nullable: true })
+  refreshToken!: string | null
+
+  @Field(() => Role, { nullable: false, defaultValue: 'USER' })
+  role!: keyof typeof Role
+
+  @Field(() => Date, { nullable: false })
+  createdAt!: Date
+
+  @Field(() => Date, { nullable: false })
+  updatedAt!: Date
+}

--- a/api/src/auth/auth.resolver.ts
+++ b/api/src/auth/auth.resolver.ts
@@ -4,7 +4,6 @@ import { Resolver, Query, Mutation, Args, Int } from '@nestjs/graphql'
 import { User } from '~/user/user.entity'
 import { AuthService } from './auth.service'
 import { Auth } from './entities/auth.entity'
-import { SignUpInput } from './dto/signup-input'
 import { SignInInput } from './dto/signin-input'
 import { SignResponse } from './dto/sign-response'
 import { LogoutResponse } from './dto/logout-response'
@@ -14,6 +13,7 @@ import { NewTokensResonse } from './dto/new-tokens-reponse'
 import { RefreshTokenGuard } from './guards/refreshToken.guard'
 import { CurrentUser } from './decorators/currentUser.decorator'
 import { CurrentUserId } from './decorators/currentUserId.decotrator'
+import { UserCreateInput } from '~/@generated/user/user-create.input'
 
 @Resolver(() => Auth)
 export class AuthResolver {
@@ -21,7 +21,7 @@ export class AuthResolver {
 
   @Public()
   @Mutation(() => SignResponse)
-  signup(@Args('signupInput') signupInput: SignUpInput): SignReturnType {
+  signup(@Args('signupInput') signupInput: UserCreateInput): SignReturnType {
     return this.authService.signup(signupInput)
   }
 

--- a/api/src/auth/auth.service.ts
+++ b/api/src/auth/auth.service.ts
@@ -4,10 +4,10 @@ import { ConfigService } from '@nestjs/config'
 import { ConflictException, ForbiddenException, Injectable } from '@nestjs/common'
 
 import { User } from '~/user/user.entity'
-import { SignUpInput } from './dto/signup-input'
 import { SignInInput } from './dto/signin-input'
 import { PrismaService } from '~/prisma/prisma.service'
 import { LogoutReturnType, SignReturnType, Token } from './types'
+import { UserCreateInput } from '~/@generated/user/user-create.input'
 
 type FieldValues = 'email' | 'username'
 
@@ -32,7 +32,7 @@ export class AuthService {
     return !fieldExists
   }
 
-  async signup(signupInput: SignUpInput): SignReturnType {
+  async signup(signupInput: UserCreateInput): SignReturnType {
     const isEmailUnique = await this.isFieldUnique('email', signupInput.email)
     const isUsernameUnique = await this.isFieldUnique('username', signupInput.username)
 

--- a/api/src/auth/dto/signin-input.ts
+++ b/api/src/auth/dto/signin-input.ts
@@ -1,6 +1,6 @@
 import { InputType, PickType } from '@nestjs/graphql'
 
-import { SignUpInput } from './signup-input'
+import { UserCreateInput } from '~/@generated/user/user-create.input'
 
 @InputType()
-export class SignInInput extends PickType(SignUpInput, ['email', 'password'] as const) {}
+export class SignInInput extends PickType(UserCreateInput, ['email', 'password'] as const) {}

--- a/api/src/schema.gql
+++ b/api/src/schema.gql
@@ -2,6 +2,11 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
 # ------------------------------------------------------
 
+"""
+A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format.
+"""
+scalar DateTime
+
 type LogoutResponse {
   loggedOut: Boolean!
 }
@@ -10,7 +15,7 @@ type Mutation {
   getNewTokens: NewTokensResonse!
   logout(id: Int!): LogoutResponse!
   signin(signInInput: SignInInput!): SignResponse!
-  signup(signupInput: SignUpInput!): SignResponse!
+  signup(signupInput: UserCreateInput!): SignResponse!
 }
 
 type NewTokensResonse {
@@ -20,6 +25,11 @@ type NewTokensResonse {
 
 type Query {
   findOne(id: Int!): User!
+}
+
+enum Role {
+  ADMIN
+  USER
 }
 
 input SignInInput {
@@ -33,17 +43,21 @@ type SignResponse {
   user: User!
 }
 
-input SignUpInput {
-  email: String!
-  name: String!
-  password: String!
-  username: String!
-}
-
 type User {
   email: String!
   id: Int!
   name: String!
   role: String!
+  username: String!
+}
+
+input UserCreateInput {
+  createdAt: DateTime
+  email: String!
+  name: String!
+  password: String!
+  refreshToken: String
+  role: Role
+  updatedAt: DateTime
   username: String!
 }

--- a/client/src/graphql/mutations/auth.ts
+++ b/client/src/graphql/mutations/auth.ts
@@ -1,7 +1,7 @@
 import { gql } from 'graphql-request'
 
 export const SIGN_UP_MUTATION = gql`
-  mutation Signup($input: SignUpInput!) {
+  mutation Signup($input: UserCreateInput!) {
     signup(signupInput: $input) {
       accessToken
       refreshToken


### PR DESCRIPTION
## Issue Link

- https://www.notion.so/MM-18-BE-Prisma-Auto-Generate-GraphQL-Inputs-with-Validation-from-class-validator-bd8c59bf62ef4a43a4539a224d12b862?pvs=4

## Definition of Done

- [x] Install `prisma-nestjs-graphql` package for auto generating DTO and Input validation
- [x] Reused auto generated DTO and Input Fields 


## Notes

- Improvement task
- Package used https://www.npmjs.com/package/prisma-nestjs-graphql

## Pre-condition

### Docker Setup

- docker-compose up --build

### Local Setup

- cd client && npm install && npm run dev
- cd api && npm install && npm run start:dev
- go to the BE and run npx prisma generate

## Expected Output

- It should now have a auto generate graphql input and DTOs

## Screenshots/Recordings

![image](https://github.com/Osomware/meme-me/assets/108642414/9e72a554-eeb6-4afd-9d15-cc17ff26cfb3)
![image](https://github.com/Osomware/meme-me/assets/108642414/3a822cd2-8ffd-4939-8548-7d0a975fa4b3)
