### PR TITLE
MM-23 - [FE] Fix Graphql Unauthorized Error Response with Auto Logout

### DIFF
--- a/client/src/components/organisms/UploadPostModal/index.tsx
+++ b/client/src/components/organisms/UploadPostModal/index.tsx
@@ -73,9 +73,6 @@ const UploadPostModal: FC<UploadPostModalProps> = ({ isOpen, closeModal }): JSX.
         onSettled() {
           handleReset()
           closeModal()
-        },
-        onError: (error: any) => {
-          toast.error(error?.message)
         }
       }
     )

--- a/client/src/hooks/usePost.ts
+++ b/client/src/hooks/usePost.ts
@@ -48,9 +48,7 @@ const usePost = (): ReturnType => {
         void router.push(`/@${username}/posts/${postId}`)
         toast.success('Successfully Posted!')
       },
-      onError: (error: Error) => {
-        toast.success(error.message)
-      }
+      onError: () => {}
     })
 
   return {


### PR DESCRIPTION
## Issue Link

- https://www.notion.so/MM-23-FE-Fix-Graphql-Unauthorized-Error-Response-with-Auto-Logout-c3b7b3dafcb845f794c428be34b47e0a?pvs=4

## Definition of Done

- [x] Check If the graphql response is Unauthorized and perform auto logout with message in order to generate new accessToken

## Notes

- This is temporary solution for frontend side in order to prevent the tampering of accessToken

## Pre-condition

### Docker Setup

- docker-compose up --build

### Local Setup

- cd client && npm install && npm run dev
- cd api && npm install && npm run start:dev
- login and try to create post and tamper the cookies in your heaters it will automatically logout if the token is unverfied

## Expected Output

- It should now have a temporary solution for the frontend side which if anyone tampers the frontend side in accessToken it will eventually logout to and login in order to generate new accessToken that match in the backend

## Screenshots/Recordings

[prevention.webm](https://github.com/Osomware/meme-me/assets/108642414/e881fd31-a098-41d1-b794-0a1ba41e2cdf)
