### PR TITLE
MM-24 - [FE] Add Emoji in the Post Caption

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,6 +8,8 @@
       "name": "client",
       "version": "0.1.0",
       "dependencies": {
+        "@emoji-mart/data": "^1.1.2",
+        "@emoji-mart/react": "^1.1.1",
         "@headlessui/react": "^1.7.15",
         "@hookform/resolvers": "^3.1.1",
         "@icon-park/react": "^1.4.2",
@@ -16,6 +18,7 @@
         "autoprefixer": "10.4.14",
         "clsx": "^1.2.1",
         "cookies-next": "^2.1.2",
+        "emoji-mart": "^5.5.2",
         "eslint-config-next": "13.4.9",
         "graphql": "^16.7.1",
         "graphql-request": "^6.1.0",
@@ -109,6 +112,20 @@
       "resolved": "https://registry.npmjs.org/@bedrock-layout/use-stateful-ref/-/use-stateful-ref-1.4.1.tgz",
       "integrity": "sha512-4eKO2KdQEXcR5LI4QcxqlJykJUDQJWDeWYAukIn6sRQYoabcfI5kDl61PUi6FR6o8VFgQ8IEP7HleKqWlSe8SQ==",
       "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18"
+      }
+    },
+    "node_modules/@emoji-mart/data": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@emoji-mart/data/-/data-1.1.2.tgz",
+      "integrity": "sha512-1HP8BxD2azjqWJvxIaWAMyTySeZY0Osr83ukYjltPVkNXeJvTz7yDrPLBtnrD5uqJ3tg4CcLuuBW09wahqL/fg=="
+    },
+    "node_modules/@emoji-mart/react": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@emoji-mart/react/-/react-1.1.1.tgz",
+      "integrity": "sha512-NMlFNeWgv1//uPsvLxvGQoIerPuVdXwK/EUek8OOkJ6wVOWPUizRBJU0hDqWZCOROVpfBgCemaC3m6jDOXi03g==",
+      "peerDependencies": {
+        "emoji-mart": "^5.2",
         "react": "^16.8 || ^17 || ^18"
       }
     },
@@ -1608,6 +1625,11 @@
       "version": "1.4.455",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.455.tgz",
       "integrity": "sha512-8tgdX0Odl24LtmLwxotpJCVjIndN559AvaOtd67u+2mo+IDsgsTF580NB+uuDCqsHw8yFg53l5+imFV9Fw3cbA=="
+    },
+    "node_modules/emoji-mart": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/emoji-mart/-/emoji-mart-5.5.2.tgz",
+      "integrity": "sha512-Sqc/nso4cjxhOwWJsp9xkVm8OF5c+mJLZJFoFfzRuKO+yWiN7K8c96xmtughYb0d/fZ8UC6cLIQ/p4BR6Pv3/A=="
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",

--- a/client/package.json
+++ b/client/package.json
@@ -13,6 +13,8 @@
     "check-all": "npm run check-format && npm run check-lint && npm run check-types && npm run build"
   },
   "dependencies": {
+    "@emoji-mart/data": "^1.1.2",
+    "@emoji-mart/react": "^1.1.1",
     "@headlessui/react": "^1.7.15",
     "@hookform/resolvers": "^3.1.1",
     "@icon-park/react": "^1.4.2",
@@ -21,6 +23,7 @@
     "autoprefixer": "10.4.14",
     "clsx": "^1.2.1",
     "cookies-next": "^2.1.2",
+    "emoji-mart": "^5.5.2",
     "eslint-config-next": "13.4.9",
     "graphql": "^16.7.1",
     "graphql-request": "^6.1.0",

--- a/client/src/components/molecules/EmojiPopoverPicker/index.tsx
+++ b/client/src/components/molecules/EmojiPopoverPicker/index.tsx
@@ -1,0 +1,55 @@
+import dynamic from 'next/dynamic'
+import classNames from 'classnames'
+import { Popover } from '@headlessui/react'
+import { WinkingFace } from '@icon-park/react'
+import React, { ComponentProps, FC } from 'react'
+import data from '@emoji-mart/data/sets/14/facebook.json'
+
+import { Emoji } from '~/utils/types/emoji'
+import PopoverTransition from '~/components/templates/PopoverTransition'
+
+const EmojiPicker = dynamic(async () => await import('@emoji-mart/react'), {
+  ssr: false
+})
+
+type Props = {
+  handleEmojiSelect: (emoji: Emoji) => void
+  panelPosition?: string
+} & ComponentProps<'div'>
+
+const EmojiPopoverPicker: FC<Props> = (props): JSX.Element => {
+  const { handleEmojiSelect, panelPosition, ...rest } = props
+
+  return (
+    <Popover as="div" className="">
+      {({ open }) => (
+        <>
+          <Popover.Button
+            type="button"
+            className={classNames(
+              'text-slate-400 outline-none hover:text-slate-500',
+              'transition duration-150 ease-in-out',
+              open ? '!text-slate-500' : ''
+            )}
+          >
+            <WinkingFace theme="outline" size="22" strokeWidth={2} />
+          </Popover.Button>
+          <Popover.Overlay className="fixed inset-0" />
+          <PopoverTransition>
+            <Popover.Panel>
+              <div className={classNames('absolute z-40', panelPosition)} {...rest}>
+                <EmojiPicker data={data} onEmojiSelect={handleEmojiSelect} theme="light" />
+              </div>
+            </Popover.Panel>
+          </PopoverTransition>
+        </>
+      )}
+    </Popover>
+  )
+}
+
+EmojiPopoverPicker.defaultProps = {
+  panelPosition: 'right-0'
+}
+
+export default EmojiPopoverPicker

--- a/client/src/components/organisms/UploadPostModal/index.tsx
+++ b/client/src/components/organisms/UploadPostModal/index.tsx
@@ -2,21 +2,24 @@ import clsx from 'clsx'
 import { isEmpty } from 'lodash'
 import dynamic from 'next/dynamic'
 import toast from 'react-hot-toast'
+import { Disclosure } from '@headlessui/react'
 import { yupResolver } from '@hookform/resolvers/yup'
 import React, { FC, ReactNode, useState } from 'react'
-import { Disclosure, Switch } from '@headlessui/react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 import { AvatarFullConfig, genConfig } from 'react-nice-avatar'
-import { ChevronDown, ChevronLeft, MapPin, Smile } from 'react-feather'
+import { ChevronDown, ChevronLeft, MapPin } from 'react-feather'
 
 import Carousel from './../Carousel'
 import usePost from '~/hooks/usePost'
 import { useStore } from '~/utils/zustand'
 import Spinner from '~/utils/icons/Spinner'
+import { Emoji } from '~/utils/types/emoji'
 import { useZustand } from '~/hooks/useZustand'
 import { UploadDropzone } from '~/utils/uploadthing'
 import DialogTemplate from '~/components/templates/DialogTemplate'
 import { UserPostFormValues, UserPostSchema } from '~/utils/yup-schema'
+import EmojiPopoverPicker from '~/components/molecules/EmojiPopoverPicker'
+import SwitchGroupTemplate from '~/components/templates/SwitchGroupTemplate'
 
 const ReactNiceAvatar = dynamic(async () => await import('react-nice-avatar'), { ssr: false })
 
@@ -47,6 +50,13 @@ const UploadPostModal: FC<UploadPostModalProps> = ({ isOpen, closeModal }): JSX.
     mode: 'onTouched',
     resolver: yupResolver(UserPostSchema)
   })
+
+  const handleEmojiSelect = (emoji: Emoji): void => {
+    const captions = watch('captions')
+    if (captions !== undefined) {
+      setValue('captions', captions + emoji.native)
+    }
+  }
 
   const isFileExist = watch('mediaUrls')
 
@@ -85,7 +95,7 @@ const UploadPostModal: FC<UploadPostModalProps> = ({ isOpen, closeModal }): JSX.
         closeModal
       }}
       className={clsx(
-        'w-ful font-normal text-secondary !rounded-[20px]',
+        'w-ful font-normal text-secondary !rounded-[20px] !overflow-visible',
         !isEmpty(isFileExist) ? 'max-w-[710px]' : 'max-w-xl'
       )}
     >
@@ -118,7 +128,7 @@ const UploadPostModal: FC<UploadPostModalProps> = ({ isOpen, closeModal }): JSX.
         </header>
         <main
           className={clsx(
-            'overflow-hidden font-light h-[550px]',
+            'font-light min-h-[550px]',
             isEmpty(isFileExist) && 'flex place-content-center'
           )}
         >
@@ -139,8 +149,8 @@ const UploadPostModal: FC<UploadPostModalProps> = ({ isOpen, closeModal }): JSX.
             </section>
           )}
           {!isEmpty(isFileExist) && (
-            <section className="relative h-full flex">
-              <div className="h-full w-full flex justify-center items-center max-w-sm overflow-hidden bg-black">
+            <section className="relative h-full flex flex-col-reverse md:flex-row">
+              <div className="min-h-[550px] rounded-bl-2xl h-full w-full flex justify-center items-center max-w-sm overflow-hidden bg-black">
                 <Carousel>
                   {
                     fileUrls?.map((asset, idx) => {
@@ -164,7 +174,7 @@ const UploadPostModal: FC<UploadPostModalProps> = ({ isOpen, closeModal }): JSX.
                   }
                 </Carousel>
               </div>
-              <div className="overflow-y-auto custom-scrollbar h-[550px] w-80 p-4">
+              <div className="w-full md:w-80 p-4">
                 <div className="flex items-center space-x-2">
                   <ReactNiceAvatar
                     className={clsx(
@@ -175,7 +185,7 @@ const UploadPostModal: FC<UploadPostModalProps> = ({ isOpen, closeModal }): JSX.
                   />
                   <h2 className="font-medium">{user?.username}</h2>
                 </div>
-                <section className="mt-2">
+                <section className="relative mt-2">
                   <textarea
                     placeholder="Write a caption"
                     {...register('captions')}
@@ -188,10 +198,12 @@ const UploadPostModal: FC<UploadPostModalProps> = ({ isOpen, closeModal }): JSX.
                     disabled={isSubmitting}
                   ></textarea>
                   <div className="flex items-center justify-between text-secondary-200">
-                    <button type="button" className="outline-none hover:text-secondary-300">
-                      <Smile className="w-6 h-6 stroke-1" />
-                    </button>
-                    <span className="text-xs">0/200</span>
+                    <EmojiPopoverPicker
+                      {...{
+                        handleEmojiSelect
+                      }}
+                    />
+                    <span className="text-xs">{`${watch('captions')?.length ?? 0}/200`}</span>
                   </div>
                 </section>
                 <section className="mt-3 flex items-center justify-between text-secondary-200 space-x-2">
@@ -220,69 +232,26 @@ const UploadPostModal: FC<UploadPostModalProps> = ({ isOpen, closeModal }): JSX.
                         />
                       </Disclosure.Button>
                       <Disclosure.Panel className="text-sm text-gray-500 space-y-4">
-                        <section>
-                          <Switch.Group>
-                            <div className="flex items-center justify-between">
-                              <Switch.Label className="mr-2 text-secondary-300">
-                                Hide like and view counts on this post
-                              </Switch.Label>
-                              <Switch
-                                checked={isHideCountPostAndLike}
-                                onChange={setIsHideCountPostAndLike}
-                                className={clsx(
-                                  isHideCountPostAndLike ? 'bg-primary' : 'bg-secondary-200',
-                                  'relative inline-flex h-6 w-12 items-center rounded-full transition-colors',
-                                  'focus:outline-none focus:ring-2 ',
-                                  'focus:ring-offset-2 focus:ring-primary-200'
-                                )}
-                              >
-                                <span
-                                  className={clsx(
-                                    isHideCountPostAndLike ? 'translate-x-6' : 'translate-x-1',
-                                    'inline-block h-4 w-4 transform rounded-full',
-                                    'bg-white transition-transform'
-                                  )}
-                                />
-                              </Switch>
-                            </div>
-                          </Switch.Group>
-                          <p className="mt-2 text-secondary-200 text-xs font-light">
-                            Only you will see the total number of likes and views on this post. You
-                            change this alter by going to the ... menu at the top of the post. To
-                            hide like counts on other’s post, go to your account settings.
-                          </p>
-                        </section>
-                        <section>
-                          <Switch.Group>
-                            <div className="flex items-center justify-between">
-                              <Switch.Label className="mr-2 text-secondary-300">
-                                Turn off commenting
-                              </Switch.Label>
-                              <Switch
-                                checked={isTurnOffComment}
-                                onChange={setTurnOffComment}
-                                className={clsx(
-                                  isTurnOffComment ? 'bg-primary' : 'bg-secondary-200',
-                                  'relative inline-flex h-6 w-12 items-center rounded-full transition-colors',
-                                  'focus:outline-none focus:ring-2 ',
-                                  'focus:ring-offset-2 focus:ring-primary-200'
-                                )}
-                              >
-                                <span
-                                  className={clsx(
-                                    isTurnOffComment ? 'translate-x-6' : 'translate-x-1',
-                                    'inline-block h-4 w-4 transform rounded-full',
-                                    'bg-white transition-transform'
-                                  )}
-                                />
-                              </Switch>
-                            </div>
-                          </Switch.Group>
-                          <p className="mt-2 text-secondary-200 text-xs font-light">
-                            You can change this later by going to the ... menu at the top of your
-                            post.
-                          </p>
-                        </section>
+                        <SwitchGroupTemplate
+                          {...{
+                            label: 'Turn off commenting',
+                            content:
+                              'Only you will see the total number of likes and views on this post. You change this alter by going to the ... menu at the top of the post. To hide like counts on other’s post, go to your account settings.',
+                            checked: isHideCountPostAndLike,
+                            onChange: setIsHideCountPostAndLike,
+                            isActive: isHideCountPostAndLike
+                          }}
+                        />
+                        <SwitchGroupTemplate
+                          {...{
+                            label: 'Hide like and view counts on this post',
+                            content:
+                              'You can change this later by going to the ... menu at the top of your post.',
+                            checked: isTurnOffComment,
+                            onChange: setTurnOffComment,
+                            isActive: isTurnOffComment
+                          }}
+                        />
                       </Disclosure.Panel>
                     </>
                   )}

--- a/client/src/components/templates/SwitchGroupTemplate/index.tsx
+++ b/client/src/components/templates/SwitchGroupTemplate/index.tsx
@@ -1,0 +1,46 @@
+import clsx from 'clsx'
+import { Switch } from '@headlessui/react'
+import React, { Dispatch, FC, SetStateAction } from 'react'
+
+export type SwitchGroupTemplateProps = {
+  label: string
+  checked: boolean
+  onChange: Dispatch<SetStateAction<boolean>>
+  isActive: boolean
+  content: string
+}
+
+const SwitchGroupTemplate: FC<SwitchGroupTemplateProps> = (props): JSX.Element => {
+  const { label, checked, onChange, isActive, content } = props
+
+  return (
+    <section>
+      <Switch.Group>
+        <div className="flex items-center justify-between">
+          <Switch.Label className="mr-2 text-secondary-300">{label}</Switch.Label>
+          <Switch
+            checked={checked}
+            onChange={onChange}
+            className={clsx(
+              isActive ? 'bg-primary' : 'bg-secondary-200',
+              'relative inline-flex h-6 w-12 items-center rounded-full transition-colors',
+              'focus:outline-none focus:ring-2 ',
+              'focus:ring-offset-2 focus:ring-primary-200'
+            )}
+          >
+            <span
+              className={clsx(
+                isActive ? 'translate-x-6' : 'translate-x-1',
+                'inline-block h-4 w-4 transform rounded-full',
+                'bg-white transition-transform'
+              )}
+            />
+          </Switch>
+        </div>
+      </Switch.Group>
+      <p className="mt-2 text-secondary-200 text-xs font-light">{content}</p>
+    </section>
+  )
+}
+
+export default SwitchGroupTemplate

--- a/client/src/utils/types/emoji.ts
+++ b/client/src/utils/types/emoji.ts
@@ -1,0 +1,18 @@
+export type Emoji = {
+  id: string
+  keywords: Keyword
+  name: string
+  native: string
+  shortcodes: string
+  unified: string
+}
+
+export type Keyword =
+  | 'heart'
+  | 'eyes'
+  | 'love'
+  | 'like'
+  | 'affection'
+  | 'valentines'
+  | 'infatuation'
+  | 'crush'

--- a/client/src/utils/yup-schema/index.ts
+++ b/client/src/utils/yup-schema/index.ts
@@ -23,7 +23,7 @@ export type SignInFormValues = yup.InferType<typeof SignInSchema>
 
 export const UserPostSchema = yup.object().shape({
   mediaUrls: yup.array().of(yup.string().url().required('Media URL is required')),
-  captions: yup.string(),
+  captions: yup.string().max(200),
   location: yup.string()
 })
 


### PR DESCRIPTION
## Issue Link

- https://www.notion.so/MM-24-FE-Add-Emoji-in-the-Post-Caption-86c497e79f4a426c9a8f09e745b22f68?pvs=4

## Definition of Done

- [x] Fix the max length of caption in the yup schema
- [x] Auto count the numbering of 0/200
- [x] Add emoji in the caption field

## Notes

- npm package: https://github.com/missive/emoji-mart
- This is improvement task

## Pre-condition

### Docker Setup

- docker-compose up --build

### Local Setup

- cd client && npm install && npm run dev
- cd api && npm install && npm run start:dev
- create post with and add the emoji in your caption

## Expected Output

- It should now have an emoji in the caption post for interactivity

## Screenshots/Recordings
[add emoji.webm](https://github.com/Osomware/meme-me/assets/108642414/a85760a1-3133-478d-8d56-214362159033)
