### PR TITLE
MM-28 - [BE] Fetch Single Post Functionality

### DIFF
--- a/api/src/auth/auth.resolver.ts
+++ b/api/src/auth/auth.resolver.ts
@@ -14,7 +14,7 @@ import { RefreshTokenGuard } from './guards/refreshToken.guard'
 import { CurrentUser } from './decorators/currentUser.decorator'
 import { CurrentUserId } from './decorators/currentUserId.decotrator'
 import { UserCreateInput } from '~/@generated/user/user-create.input'
-import { FindFirstUserArgs } from '~/@generated/user/find-first-user.args'
+import { FindFirstUserOrThrowArgs } from '~/@generated/user/find-first-user-or-throw.args'
 
 @Resolver(() => Auth)
 export class AuthResolver {
@@ -38,7 +38,7 @@ export class AuthResolver {
   }
 
   @Query(() => User, { name: 'findOneUser' })
-  findOne(@Args() args: FindFirstUserArgs): Promise<User> {
+  findOne(@Args() args: FindFirstUserOrThrowArgs): Promise<User> {
     return this.authService.findOne(args)
   }
 

--- a/api/src/auth/auth.service.ts
+++ b/api/src/auth/auth.service.ts
@@ -8,7 +8,7 @@ import { SignInInput } from './dto/signin-input'
 import { PrismaService } from '~/prisma/prisma.service'
 import { LogoutReturnType, SignReturnType, Token } from './types'
 import { UserCreateInput } from '~/@generated/user/user-create.input'
-import { FindFirstUserArgs } from '~/@generated/user/find-first-user.args'
+import { FindFirstUserOrThrowArgs } from '~/@generated/user/find-first-user-or-throw.args'
 
 type FieldValues = 'email' | 'username'
 
@@ -136,14 +136,8 @@ export class AuthService {
     }
   }
 
-  async findOne(args: FindFirstUserArgs): Promise<User> {
-    const user = await this.prisma.user.findFirst(args)
-
-    if (!user) {
-      throw new ForbiddenException('User does not exist')
-    }
-
-    return user
+  async findOne(args: FindFirstUserOrThrowArgs): Promise<User> {
+    return await this.prisma.user.findFirstOrThrow(args)
   }
 
   async getNewTokens(userId: number, rt: string): SignReturnType {

--- a/api/src/post/post.resolver.ts
+++ b/api/src/post/post.resolver.ts
@@ -1,9 +1,10 @@
-import { Resolver, Query, Mutation, Args, Int } from '@nestjs/graphql'
+import { Resolver, Query, Mutation, Args } from '@nestjs/graphql'
 
 import { PostService } from './post.service'
 import { Post } from './entities/post.entity'
 import { FindManyPostArgs } from '~/@generated/post/find-many-post.args'
 import { CurrentUserId } from '~/auth/decorators/currentUserId.decotrator'
+import { FindFirstPostOrThrowArgs } from '~/@generated/post/find-first-post-or-throw.args'
 import { PostCreateWithoutUserInput } from '~/@generated/post/post-create-without-user.input'
 
 @Resolver(() => Post)
@@ -18,14 +19,13 @@ export class PostResolver {
     return await this.postService.create(createPostInput, userId)
   }
 
-  // * Name: Represents the name in graphql playground
   @Query(() => [Post], { name: 'findAllPost' })
   findAll(@Args() args: FindManyPostArgs): Promise<Post[]> {
     return this.postService.findAll(args)
   }
 
   @Query(() => Post, { name: 'findOnePost' })
-  findOne(@Args('id', { type: () => Int }) id: number): string {
-    return this.postService.findOne(id)
+  findOne(@Args() args: FindFirstPostOrThrowArgs): Promise<Post> {
+    return this.postService.findOne(args)
   }
 }

--- a/api/src/post/post.service.ts
+++ b/api/src/post/post.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@nestjs/common'
 import { Post } from '~/@generated/post/post.model'
 import { PrismaService } from '~/prisma/prisma.service'
 import { FindManyPostArgs } from '~/@generated/post/find-many-post.args'
+import { FindFirstPostOrThrowArgs } from '~/@generated/post/find-first-post-or-throw.args'
 import { PostCreateWithoutUserInput } from '~/@generated/post/post-create-without-user.input'
 
 @Injectable()
@@ -50,7 +51,20 @@ export class PostService {
     })
   }
 
-  findOne(id: number): string {
-    return `This action returns a #${id} post`
+  async findOne(args: FindFirstPostOrThrowArgs): Promise<Post> {
+    return await this.prisma.post.findFirstOrThrow({
+      ...args,
+      select: {
+        id: true,
+        title: true,
+        userId: true,
+        mediaUrls: true,
+        createdAt: true,
+        updatedAt: true,
+        isHideLikeAndCount: true,
+        isTurnOffComment: true,
+        user: true
+      }
+    })
   }
 }

--- a/api/src/schema.gql
+++ b/api/src/schema.gql
@@ -242,7 +242,7 @@ input PostWhereUniqueInput {
 
 type Query {
   findAllPost(cursor: PostWhereUniqueInput, distinct: [PostScalarFieldEnum!], orderBy: [PostOrderByWithRelationInput!], skip: Int, take: Int, where: PostWhereInput): [Post!]!
-  findOnePost(id: Int!): Post!
+  findOnePost(cursor: PostWhereUniqueInput, distinct: [PostScalarFieldEnum!], orderBy: [PostOrderByWithRelationInput!], skip: Int, take: Int, where: PostWhereInput): Post!
   findOneUser(cursor: UserWhereUniqueInput, distinct: [UserScalarFieldEnum!], orderBy: [UserOrderByWithRelationInput!], skip: Int, take: Int, where: UserWhereInput): User!
 }
 


### PR DESCRIPTION
## Issue Link

- https://www.notion.so/MM-28-BE-Fetch-Single-Post-Functionality-247256372b62420bbab76e9aabfa7939?pvs=4

## Definition of Done

- [x] Modified Prisma `findFirst` with `findFirstOrThrow` implementation
- [x] Implement Fetch Single Post Functionality with Throw not found Post 

## Notes

- BE Task

## Pre-condition

### Docker Setup

- docker-compose up --build

### Local Setup

- cd client && npm install && npm run dev
- cd api && npm install && npm run dev
- goto the http://localhost:3030/graphql

```
query FindOnePost($where: PostWhereInput) {
  findOnePost(where: $where) {
    createdAt
    id
    isHideLikeAndCount
    isTurnOffComment
    mediaUrls
    title
    updatedAt
    user {
      email
      id
      name
      role
      username
    }
  }
}
```

input

```
{
  "where": {
    "id": {
      "equals": <id of the post>
    }
  }
}

```

## Expected Output

- It should now have a graphql api for fetching single post

## Screenshots/Recordings
[get single post.webm](https://github.com/Osomware/meme-me/assets/108642414/5f6d20a4-5c42-41ba-87c7-60c5286705a7)

