### PR TITLE
MM-30 - [BE] Implement Post Hashtags

### DIFF
--- a/api/prisma/migrations/20230814024020_add_post_hashtags/migration.sql
+++ b/api/prisma/migrations/20230814024020_add_post_hashtags/migration.sql
@@ -1,0 +1,30 @@
+-- CreateTable
+CREATE TABLE "Hashtag" (
+    "id" SERIAL NOT NULL,
+    "tag" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Hashtag_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "_PostHashtags" (
+    "A" INTEGER NOT NULL,
+    "B" INTEGER NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Hashtag_tag_key" ON "Hashtag"("tag");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_PostHashtags_AB_unique" ON "_PostHashtags"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_PostHashtags_B_index" ON "_PostHashtags"("B");
+
+-- AddForeignKey
+ALTER TABLE "_PostHashtags" ADD CONSTRAINT "_PostHashtags_A_fkey" FOREIGN KEY ("A") REFERENCES "Hashtag"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_PostHashtags" ADD CONSTRAINT "_PostHashtags_B_fkey" FOREIGN KEY ("B") REFERENCES "Post"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -39,13 +39,22 @@ enum Role {
 }
 
 model Post {
-  id                 Int      @id @default(autoincrement())
+  id                 Int       @id @default(autoincrement())
   title              String?
   mediaUrls          String[]
-  user               User     @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  user               User      @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   userId             Int
-  isHideLikeAndCount Boolean  @default(false)
-  isTurnOffComment   Boolean  @default(false)
-  createdAt          DateTime @default(now())
-  updatedAt          DateTime @default(now())
+  isHideLikeAndCount Boolean   @default(false)
+  isTurnOffComment   Boolean   @default(false)
+  hashtags           Hashtag[] @relation("PostHashtags")
+  createdAt          DateTime  @default(now())
+  updatedAt          DateTime  @default(now())
+}
+
+model Hashtag {
+  id        Int      @id @default(autoincrement())
+  tag       String   @unique
+  posts     Post[]   @relation("PostHashtags")
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now())
 }

--- a/api/prisma/seeders/hashtags.ts
+++ b/api/prisma/seeders/hashtags.ts
@@ -1,0 +1,14 @@
+import { faker } from '@faker-js/faker'
+
+export type Hashtag = {
+  tag: string
+}
+
+const numHashtags = 10
+const generateRandomHashtags = (): Hashtag[] => {
+  return Array.from({ length: numHashtags }, () => ({
+    tag: faker.lorem.word() // Use Faker to generate random tag names
+  }))
+}
+
+export const newHashtags: Hashtag[] = generateRandomHashtags()

--- a/api/prisma/seeders/index.ts
+++ b/api/prisma/seeders/index.ts
@@ -2,6 +2,7 @@ import { PrismaClient } from '@prisma/client'
 
 import { newUsers, User } from './users'
 import { newPosts, Post } from './posts'
+import { newHashtags } from './hashtags'
 
 const prisma = new PrismaClient()
 
@@ -25,6 +26,10 @@ const seed = async (): Promise<void> => {
       })
     })
   )
+
+  await prisma.hashtag.createMany({
+    data: newHashtags
+  })
 }
 
 ;(async () => {

--- a/api/src/@generated/hashtag/aggregate-hashtag.output.ts
+++ b/api/src/@generated/hashtag/aggregate-hashtag.output.ts
@@ -1,0 +1,25 @@
+import { Field } from '@nestjs/graphql'
+import { ObjectType } from '@nestjs/graphql'
+import { HashtagCountAggregate } from './hashtag-count-aggregate.output'
+import { HashtagAvgAggregate } from './hashtag-avg-aggregate.output'
+import { HashtagSumAggregate } from './hashtag-sum-aggregate.output'
+import { HashtagMinAggregate } from './hashtag-min-aggregate.output'
+import { HashtagMaxAggregate } from './hashtag-max-aggregate.output'
+
+@ObjectType()
+export class AggregateHashtag {
+  @Field(() => HashtagCountAggregate, { nullable: true })
+  _count?: HashtagCountAggregate
+
+  @Field(() => HashtagAvgAggregate, { nullable: true })
+  _avg?: HashtagAvgAggregate
+
+  @Field(() => HashtagSumAggregate, { nullable: true })
+  _sum?: HashtagSumAggregate
+
+  @Field(() => HashtagMinAggregate, { nullable: true })
+  _min?: HashtagMinAggregate
+
+  @Field(() => HashtagMaxAggregate, { nullable: true })
+  _max?: HashtagMaxAggregate
+}

--- a/api/src/@generated/hashtag/create-many-hashtag.args.ts
+++ b/api/src/@generated/hashtag/create-many-hashtag.args.ts
@@ -1,0 +1,14 @@
+import { Field } from '@nestjs/graphql'
+import { ArgsType } from '@nestjs/graphql'
+import { HashtagCreateManyInput } from './hashtag-create-many.input'
+import { Type } from 'class-transformer'
+
+@ArgsType()
+export class CreateManyHashtagArgs {
+  @Field(() => [HashtagCreateManyInput], { nullable: false })
+  @Type(() => HashtagCreateManyInput)
+  data!: Array<HashtagCreateManyInput>
+
+  @Field(() => Boolean, { nullable: true })
+  skipDuplicates?: boolean
+}

--- a/api/src/@generated/hashtag/create-one-hashtag.args.ts
+++ b/api/src/@generated/hashtag/create-one-hashtag.args.ts
@@ -1,0 +1,11 @@
+import { Field } from '@nestjs/graphql'
+import { ArgsType } from '@nestjs/graphql'
+import { HashtagCreateInput } from './hashtag-create.input'
+import { Type } from 'class-transformer'
+
+@ArgsType()
+export class CreateOneHashtagArgs {
+  @Field(() => HashtagCreateInput, { nullable: false })
+  @Type(() => HashtagCreateInput)
+  data!: HashtagCreateInput
+}

--- a/api/src/@generated/hashtag/delete-many-hashtag.args.ts
+++ b/api/src/@generated/hashtag/delete-many-hashtag.args.ts
@@ -1,0 +1,11 @@
+import { Field } from '@nestjs/graphql'
+import { ArgsType } from '@nestjs/graphql'
+import { HashtagWhereInput } from './hashtag-where.input'
+import { Type } from 'class-transformer'
+
+@ArgsType()
+export class DeleteManyHashtagArgs {
+  @Field(() => HashtagWhereInput, { nullable: true })
+  @Type(() => HashtagWhereInput)
+  where?: HashtagWhereInput
+}

--- a/api/src/@generated/hashtag/delete-one-hashtag.args.ts
+++ b/api/src/@generated/hashtag/delete-one-hashtag.args.ts
@@ -1,0 +1,12 @@
+import { Field } from '@nestjs/graphql'
+import { ArgsType } from '@nestjs/graphql'
+import { Prisma } from '@prisma/client'
+import { HashtagWhereUniqueInput } from './hashtag-where-unique.input'
+import { Type } from 'class-transformer'
+
+@ArgsType()
+export class DeleteOneHashtagArgs {
+  @Field(() => HashtagWhereUniqueInput, { nullable: false })
+  @Type(() => HashtagWhereUniqueInput)
+  where!: Prisma.AtLeast<HashtagWhereUniqueInput, 'id' | 'tag'>
+}

--- a/api/src/@generated/hashtag/find-first-hashtag-or-throw.args.ts
+++ b/api/src/@generated/hashtag/find-first-hashtag-or-throw.args.ts
@@ -1,0 +1,31 @@
+import { Field } from '@nestjs/graphql'
+import { ArgsType } from '@nestjs/graphql'
+import { HashtagWhereInput } from './hashtag-where.input'
+import { Type } from 'class-transformer'
+import { HashtagOrderByWithRelationInput } from './hashtag-order-by-with-relation.input'
+import { Prisma } from '@prisma/client'
+import { HashtagWhereUniqueInput } from './hashtag-where-unique.input'
+import { Int } from '@nestjs/graphql'
+import { HashtagScalarFieldEnum } from './hashtag-scalar-field.enum'
+
+@ArgsType()
+export class FindFirstHashtagOrThrowArgs {
+  @Field(() => HashtagWhereInput, { nullable: true })
+  @Type(() => HashtagWhereInput)
+  where?: HashtagWhereInput
+
+  @Field(() => [HashtagOrderByWithRelationInput], { nullable: true })
+  orderBy?: Array<HashtagOrderByWithRelationInput>
+
+  @Field(() => HashtagWhereUniqueInput, { nullable: true })
+  cursor?: Prisma.AtLeast<HashtagWhereUniqueInput, 'id' | 'tag'>
+
+  @Field(() => Int, { nullable: true })
+  take?: number
+
+  @Field(() => Int, { nullable: true })
+  skip?: number
+
+  @Field(() => [HashtagScalarFieldEnum], { nullable: true })
+  distinct?: Array<keyof typeof HashtagScalarFieldEnum>
+}

--- a/api/src/@generated/hashtag/find-first-hashtag.args.ts
+++ b/api/src/@generated/hashtag/find-first-hashtag.args.ts
@@ -1,0 +1,31 @@
+import { Field } from '@nestjs/graphql'
+import { ArgsType } from '@nestjs/graphql'
+import { HashtagWhereInput } from './hashtag-where.input'
+import { Type } from 'class-transformer'
+import { HashtagOrderByWithRelationInput } from './hashtag-order-by-with-relation.input'
+import { Prisma } from '@prisma/client'
+import { HashtagWhereUniqueInput } from './hashtag-where-unique.input'
+import { Int } from '@nestjs/graphql'
+import { HashtagScalarFieldEnum } from './hashtag-scalar-field.enum'
+
+@ArgsType()
+export class FindFirstHashtagArgs {
+  @Field(() => HashtagWhereInput, { nullable: true })
+  @Type(() => HashtagWhereInput)
+  where?: HashtagWhereInput
+
+  @Field(() => [HashtagOrderByWithRelationInput], { nullable: true })
+  orderBy?: Array<HashtagOrderByWithRelationInput>
+
+  @Field(() => HashtagWhereUniqueInput, { nullable: true })
+  cursor?: Prisma.AtLeast<HashtagWhereUniqueInput, 'id' | 'tag'>
+
+  @Field(() => Int, { nullable: true })
+  take?: number
+
+  @Field(() => Int, { nullable: true })
+  skip?: number
+
+  @Field(() => [HashtagScalarFieldEnum], { nullable: true })
+  distinct?: Array<keyof typeof HashtagScalarFieldEnum>
+}

--- a/api/src/@generated/hashtag/find-many-hashtag.args.ts
+++ b/api/src/@generated/hashtag/find-many-hashtag.args.ts
@@ -1,0 +1,31 @@
+import { Field } from '@nestjs/graphql'
+import { ArgsType } from '@nestjs/graphql'
+import { HashtagWhereInput } from './hashtag-where.input'
+import { Type } from 'class-transformer'
+import { HashtagOrderByWithRelationInput } from './hashtag-order-by-with-relation.input'
+import { Prisma } from '@prisma/client'
+import { HashtagWhereUniqueInput } from './hashtag-where-unique.input'
+import { Int } from '@nestjs/graphql'
+import { HashtagScalarFieldEnum } from './hashtag-scalar-field.enum'
+
+@ArgsType()
+export class FindManyHashtagArgs {
+  @Field(() => HashtagWhereInput, { nullable: true })
+  @Type(() => HashtagWhereInput)
+  where?: HashtagWhereInput
+
+  @Field(() => [HashtagOrderByWithRelationInput], { nullable: true })
+  orderBy?: Array<HashtagOrderByWithRelationInput>
+
+  @Field(() => HashtagWhereUniqueInput, { nullable: true })
+  cursor?: Prisma.AtLeast<HashtagWhereUniqueInput, 'id' | 'tag'>
+
+  @Field(() => Int, { nullable: true })
+  take?: number
+
+  @Field(() => Int, { nullable: true })
+  skip?: number
+
+  @Field(() => [HashtagScalarFieldEnum], { nullable: true })
+  distinct?: Array<keyof typeof HashtagScalarFieldEnum>
+}

--- a/api/src/@generated/hashtag/find-unique-hashtag-or-throw.args.ts
+++ b/api/src/@generated/hashtag/find-unique-hashtag-or-throw.args.ts
@@ -1,0 +1,12 @@
+import { Field } from '@nestjs/graphql'
+import { ArgsType } from '@nestjs/graphql'
+import { Prisma } from '@prisma/client'
+import { HashtagWhereUniqueInput } from './hashtag-where-unique.input'
+import { Type } from 'class-transformer'
+
+@ArgsType()
+export class FindUniqueHashtagOrThrowArgs {
+  @Field(() => HashtagWhereUniqueInput, { nullable: false })
+  @Type(() => HashtagWhereUniqueInput)
+  where!: Prisma.AtLeast<HashtagWhereUniqueInput, 'id' | 'tag'>
+}

--- a/api/src/@generated/hashtag/find-unique-hashtag.args.ts
+++ b/api/src/@generated/hashtag/find-unique-hashtag.args.ts
@@ -1,0 +1,12 @@
+import { Field } from '@nestjs/graphql'
+import { ArgsType } from '@nestjs/graphql'
+import { Prisma } from '@prisma/client'
+import { HashtagWhereUniqueInput } from './hashtag-where-unique.input'
+import { Type } from 'class-transformer'
+
+@ArgsType()
+export class FindUniqueHashtagArgs {
+  @Field(() => HashtagWhereUniqueInput, { nullable: false })
+  @Type(() => HashtagWhereUniqueInput)
+  where!: Prisma.AtLeast<HashtagWhereUniqueInput, 'id' | 'tag'>
+}

--- a/api/src/@generated/hashtag/hashtag-aggregate.args.ts
+++ b/api/src/@generated/hashtag/hashtag-aggregate.args.ts
@@ -1,0 +1,47 @@
+import { Field } from '@nestjs/graphql'
+import { ArgsType } from '@nestjs/graphql'
+import { HashtagWhereInput } from './hashtag-where.input'
+import { Type } from 'class-transformer'
+import { HashtagOrderByWithRelationInput } from './hashtag-order-by-with-relation.input'
+import { Prisma } from '@prisma/client'
+import { HashtagWhereUniqueInput } from './hashtag-where-unique.input'
+import { Int } from '@nestjs/graphql'
+import { HashtagCountAggregateInput } from './hashtag-count-aggregate.input'
+import { HashtagAvgAggregateInput } from './hashtag-avg-aggregate.input'
+import { HashtagSumAggregateInput } from './hashtag-sum-aggregate.input'
+import { HashtagMinAggregateInput } from './hashtag-min-aggregate.input'
+import { HashtagMaxAggregateInput } from './hashtag-max-aggregate.input'
+
+@ArgsType()
+export class HashtagAggregateArgs {
+  @Field(() => HashtagWhereInput, { nullable: true })
+  @Type(() => HashtagWhereInput)
+  where?: HashtagWhereInput
+
+  @Field(() => [HashtagOrderByWithRelationInput], { nullable: true })
+  orderBy?: Array<HashtagOrderByWithRelationInput>
+
+  @Field(() => HashtagWhereUniqueInput, { nullable: true })
+  cursor?: Prisma.AtLeast<HashtagWhereUniqueInput, 'id' | 'tag'>
+
+  @Field(() => Int, { nullable: true })
+  take?: number
+
+  @Field(() => Int, { nullable: true })
+  skip?: number
+
+  @Field(() => HashtagCountAggregateInput, { nullable: true })
+  _count?: HashtagCountAggregateInput
+
+  @Field(() => HashtagAvgAggregateInput, { nullable: true })
+  _avg?: HashtagAvgAggregateInput
+
+  @Field(() => HashtagSumAggregateInput, { nullable: true })
+  _sum?: HashtagSumAggregateInput
+
+  @Field(() => HashtagMinAggregateInput, { nullable: true })
+  _min?: HashtagMinAggregateInput
+
+  @Field(() => HashtagMaxAggregateInput, { nullable: true })
+  _max?: HashtagMaxAggregateInput
+}

--- a/api/src/@generated/hashtag/hashtag-avg-aggregate.input.ts
+++ b/api/src/@generated/hashtag/hashtag-avg-aggregate.input.ts
@@ -1,0 +1,8 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+
+@InputType()
+export class HashtagAvgAggregateInput {
+  @Field(() => Boolean, { nullable: true })
+  id?: true
+}

--- a/api/src/@generated/hashtag/hashtag-avg-aggregate.output.ts
+++ b/api/src/@generated/hashtag/hashtag-avg-aggregate.output.ts
@@ -1,0 +1,9 @@
+import { Field } from '@nestjs/graphql'
+import { ObjectType } from '@nestjs/graphql'
+import { Float } from '@nestjs/graphql'
+
+@ObjectType()
+export class HashtagAvgAggregate {
+  @Field(() => Float, { nullable: true })
+  id?: number
+}

--- a/api/src/@generated/hashtag/hashtag-avg-order-by-aggregate.input.ts
+++ b/api/src/@generated/hashtag/hashtag-avg-order-by-aggregate.input.ts
@@ -1,0 +1,9 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { SortOrder } from '../prisma/sort-order.enum'
+
+@InputType()
+export class HashtagAvgOrderByAggregateInput {
+  @Field(() => SortOrder, { nullable: true })
+  id?: keyof typeof SortOrder
+}

--- a/api/src/@generated/hashtag/hashtag-count-aggregate.input.ts
+++ b/api/src/@generated/hashtag/hashtag-count-aggregate.input.ts
@@ -1,0 +1,20 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+
+@InputType()
+export class HashtagCountAggregateInput {
+  @Field(() => Boolean, { nullable: true })
+  id?: true
+
+  @Field(() => Boolean, { nullable: true })
+  tag?: true
+
+  @Field(() => Boolean, { nullable: true })
+  createdAt?: true
+
+  @Field(() => Boolean, { nullable: true })
+  updatedAt?: true
+
+  @Field(() => Boolean, { nullable: true })
+  _all?: true
+}

--- a/api/src/@generated/hashtag/hashtag-count-aggregate.output.ts
+++ b/api/src/@generated/hashtag/hashtag-count-aggregate.output.ts
@@ -1,0 +1,21 @@
+import { Field } from '@nestjs/graphql'
+import { ObjectType } from '@nestjs/graphql'
+import { Int } from '@nestjs/graphql'
+
+@ObjectType()
+export class HashtagCountAggregate {
+  @Field(() => Int, { nullable: false })
+  id!: number
+
+  @Field(() => Int, { nullable: false })
+  tag!: number
+
+  @Field(() => Int, { nullable: false })
+  createdAt!: number
+
+  @Field(() => Int, { nullable: false })
+  updatedAt!: number
+
+  @Field(() => Int, { nullable: false })
+  _all!: number
+}

--- a/api/src/@generated/hashtag/hashtag-count-order-by-aggregate.input.ts
+++ b/api/src/@generated/hashtag/hashtag-count-order-by-aggregate.input.ts
@@ -1,0 +1,18 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { SortOrder } from '../prisma/sort-order.enum'
+
+@InputType()
+export class HashtagCountOrderByAggregateInput {
+  @Field(() => SortOrder, { nullable: true })
+  id?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  tag?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  createdAt?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  updatedAt?: keyof typeof SortOrder
+}

--- a/api/src/@generated/hashtag/hashtag-count.output.ts
+++ b/api/src/@generated/hashtag/hashtag-count.output.ts
@@ -1,0 +1,9 @@
+import { Field } from '@nestjs/graphql'
+import { ObjectType } from '@nestjs/graphql'
+import { Int } from '@nestjs/graphql'
+
+@ObjectType()
+export class HashtagCount {
+  @Field(() => Int, { nullable: false })
+  posts?: number
+}

--- a/api/src/@generated/hashtag/hashtag-create-many.input.ts
+++ b/api/src/@generated/hashtag/hashtag-create-many.input.ts
@@ -1,0 +1,18 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { Int } from '@nestjs/graphql'
+
+@InputType()
+export class HashtagCreateManyInput {
+  @Field(() => Int, { nullable: true })
+  id?: number
+
+  @Field(() => String, { nullable: false })
+  tag!: string
+
+  @Field(() => Date, { nullable: true })
+  createdAt?: Date | string
+
+  @Field(() => Date, { nullable: true })
+  updatedAt?: Date | string
+}

--- a/api/src/@generated/hashtag/hashtag-create-nested-many-without-posts.input.ts
+++ b/api/src/@generated/hashtag/hashtag-create-nested-many-without-posts.input.ts
@@ -1,0 +1,22 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { HashtagCreateWithoutPostsInput } from './hashtag-create-without-posts.input'
+import { Type } from 'class-transformer'
+import { HashtagCreateOrConnectWithoutPostsInput } from './hashtag-create-or-connect-without-posts.input'
+import { Prisma } from '@prisma/client'
+import { HashtagWhereUniqueInput } from './hashtag-where-unique.input'
+
+@InputType()
+export class HashtagCreateNestedManyWithoutPostsInput {
+  @Field(() => [HashtagCreateWithoutPostsInput], { nullable: true })
+  @Type(() => HashtagCreateWithoutPostsInput)
+  create?: Array<HashtagCreateWithoutPostsInput>
+
+  @Field(() => [HashtagCreateOrConnectWithoutPostsInput], { nullable: true })
+  @Type(() => HashtagCreateOrConnectWithoutPostsInput)
+  connectOrCreate?: Array<HashtagCreateOrConnectWithoutPostsInput>
+
+  @Field(() => [HashtagWhereUniqueInput], { nullable: true })
+  @Type(() => HashtagWhereUniqueInput)
+  connect?: Array<Prisma.AtLeast<HashtagWhereUniqueInput, 'id' | 'tag'>>
+}

--- a/api/src/@generated/hashtag/hashtag-create-or-connect-without-posts.input.ts
+++ b/api/src/@generated/hashtag/hashtag-create-or-connect-without-posts.input.ts
@@ -1,0 +1,17 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { Prisma } from '@prisma/client'
+import { HashtagWhereUniqueInput } from './hashtag-where-unique.input'
+import { Type } from 'class-transformer'
+import { HashtagCreateWithoutPostsInput } from './hashtag-create-without-posts.input'
+
+@InputType()
+export class HashtagCreateOrConnectWithoutPostsInput {
+  @Field(() => HashtagWhereUniqueInput, { nullable: false })
+  @Type(() => HashtagWhereUniqueInput)
+  where!: Prisma.AtLeast<HashtagWhereUniqueInput, 'id' | 'tag'>
+
+  @Field(() => HashtagCreateWithoutPostsInput, { nullable: false })
+  @Type(() => HashtagCreateWithoutPostsInput)
+  create!: HashtagCreateWithoutPostsInput
+}

--- a/api/src/@generated/hashtag/hashtag-create-without-posts.input.ts
+++ b/api/src/@generated/hashtag/hashtag-create-without-posts.input.ts
@@ -1,0 +1,14 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+
+@InputType()
+export class HashtagCreateWithoutPostsInput {
+  @Field(() => String, { nullable: false })
+  tag!: string
+
+  @Field(() => Date, { nullable: true })
+  createdAt?: Date | string
+
+  @Field(() => Date, { nullable: true })
+  updatedAt?: Date | string
+}

--- a/api/src/@generated/hashtag/hashtag-create.input.ts
+++ b/api/src/@generated/hashtag/hashtag-create.input.ts
@@ -1,0 +1,18 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { PostCreateNestedManyWithoutHashtagsInput } from '../post/post-create-nested-many-without-hashtags.input'
+
+@InputType()
+export class HashtagCreateInput {
+  @Field(() => String, { nullable: false })
+  tag!: string
+
+  @Field(() => Date, { nullable: true })
+  createdAt?: Date | string
+
+  @Field(() => Date, { nullable: true })
+  updatedAt?: Date | string
+
+  @Field(() => PostCreateNestedManyWithoutHashtagsInput, { nullable: true })
+  posts?: PostCreateNestedManyWithoutHashtagsInput
+}

--- a/api/src/@generated/hashtag/hashtag-group-by.args.ts
+++ b/api/src/@generated/hashtag/hashtag-group-by.args.ts
@@ -1,0 +1,50 @@
+import { Field } from '@nestjs/graphql'
+import { ArgsType } from '@nestjs/graphql'
+import { HashtagWhereInput } from './hashtag-where.input'
+import { Type } from 'class-transformer'
+import { HashtagOrderByWithAggregationInput } from './hashtag-order-by-with-aggregation.input'
+import { HashtagScalarFieldEnum } from './hashtag-scalar-field.enum'
+import { HashtagScalarWhereWithAggregatesInput } from './hashtag-scalar-where-with-aggregates.input'
+import { Int } from '@nestjs/graphql'
+import { HashtagCountAggregateInput } from './hashtag-count-aggregate.input'
+import { HashtagAvgAggregateInput } from './hashtag-avg-aggregate.input'
+import { HashtagSumAggregateInput } from './hashtag-sum-aggregate.input'
+import { HashtagMinAggregateInput } from './hashtag-min-aggregate.input'
+import { HashtagMaxAggregateInput } from './hashtag-max-aggregate.input'
+
+@ArgsType()
+export class HashtagGroupByArgs {
+  @Field(() => HashtagWhereInput, { nullable: true })
+  @Type(() => HashtagWhereInput)
+  where?: HashtagWhereInput
+
+  @Field(() => [HashtagOrderByWithAggregationInput], { nullable: true })
+  orderBy?: Array<HashtagOrderByWithAggregationInput>
+
+  @Field(() => [HashtagScalarFieldEnum], { nullable: false })
+  by!: Array<keyof typeof HashtagScalarFieldEnum>
+
+  @Field(() => HashtagScalarWhereWithAggregatesInput, { nullable: true })
+  having?: HashtagScalarWhereWithAggregatesInput
+
+  @Field(() => Int, { nullable: true })
+  take?: number
+
+  @Field(() => Int, { nullable: true })
+  skip?: number
+
+  @Field(() => HashtagCountAggregateInput, { nullable: true })
+  _count?: HashtagCountAggregateInput
+
+  @Field(() => HashtagAvgAggregateInput, { nullable: true })
+  _avg?: HashtagAvgAggregateInput
+
+  @Field(() => HashtagSumAggregateInput, { nullable: true })
+  _sum?: HashtagSumAggregateInput
+
+  @Field(() => HashtagMinAggregateInput, { nullable: true })
+  _min?: HashtagMinAggregateInput
+
+  @Field(() => HashtagMaxAggregateInput, { nullable: true })
+  _max?: HashtagMaxAggregateInput
+}

--- a/api/src/@generated/hashtag/hashtag-group-by.output.ts
+++ b/api/src/@generated/hashtag/hashtag-group-by.output.ts
@@ -1,0 +1,38 @@
+import { Field } from '@nestjs/graphql'
+import { ObjectType } from '@nestjs/graphql'
+import { Int } from '@nestjs/graphql'
+import { HashtagCountAggregate } from './hashtag-count-aggregate.output'
+import { HashtagAvgAggregate } from './hashtag-avg-aggregate.output'
+import { HashtagSumAggregate } from './hashtag-sum-aggregate.output'
+import { HashtagMinAggregate } from './hashtag-min-aggregate.output'
+import { HashtagMaxAggregate } from './hashtag-max-aggregate.output'
+
+@ObjectType()
+export class HashtagGroupBy {
+  @Field(() => Int, { nullable: false })
+  id!: number
+
+  @Field(() => String, { nullable: false })
+  tag!: string
+
+  @Field(() => Date, { nullable: false })
+  createdAt!: Date | string
+
+  @Field(() => Date, { nullable: false })
+  updatedAt!: Date | string
+
+  @Field(() => HashtagCountAggregate, { nullable: true })
+  _count?: HashtagCountAggregate
+
+  @Field(() => HashtagAvgAggregate, { nullable: true })
+  _avg?: HashtagAvgAggregate
+
+  @Field(() => HashtagSumAggregate, { nullable: true })
+  _sum?: HashtagSumAggregate
+
+  @Field(() => HashtagMinAggregate, { nullable: true })
+  _min?: HashtagMinAggregate
+
+  @Field(() => HashtagMaxAggregate, { nullable: true })
+  _max?: HashtagMaxAggregate
+}

--- a/api/src/@generated/hashtag/hashtag-list-relation-filter.input.ts
+++ b/api/src/@generated/hashtag/hashtag-list-relation-filter.input.ts
@@ -1,0 +1,15 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { HashtagWhereInput } from './hashtag-where.input'
+
+@InputType()
+export class HashtagListRelationFilter {
+  @Field(() => HashtagWhereInput, { nullable: true })
+  every?: HashtagWhereInput
+
+  @Field(() => HashtagWhereInput, { nullable: true })
+  some?: HashtagWhereInput
+
+  @Field(() => HashtagWhereInput, { nullable: true })
+  none?: HashtagWhereInput
+}

--- a/api/src/@generated/hashtag/hashtag-max-aggregate.input.ts
+++ b/api/src/@generated/hashtag/hashtag-max-aggregate.input.ts
@@ -1,0 +1,17 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+
+@InputType()
+export class HashtagMaxAggregateInput {
+  @Field(() => Boolean, { nullable: true })
+  id?: true
+
+  @Field(() => Boolean, { nullable: true })
+  tag?: true
+
+  @Field(() => Boolean, { nullable: true })
+  createdAt?: true
+
+  @Field(() => Boolean, { nullable: true })
+  updatedAt?: true
+}

--- a/api/src/@generated/hashtag/hashtag-max-aggregate.output.ts
+++ b/api/src/@generated/hashtag/hashtag-max-aggregate.output.ts
@@ -1,0 +1,18 @@
+import { Field } from '@nestjs/graphql'
+import { ObjectType } from '@nestjs/graphql'
+import { Int } from '@nestjs/graphql'
+
+@ObjectType()
+export class HashtagMaxAggregate {
+  @Field(() => Int, { nullable: true })
+  id?: number
+
+  @Field(() => String, { nullable: true })
+  tag?: string
+
+  @Field(() => Date, { nullable: true })
+  createdAt?: Date | string
+
+  @Field(() => Date, { nullable: true })
+  updatedAt?: Date | string
+}

--- a/api/src/@generated/hashtag/hashtag-max-order-by-aggregate.input.ts
+++ b/api/src/@generated/hashtag/hashtag-max-order-by-aggregate.input.ts
@@ -1,0 +1,18 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { SortOrder } from '../prisma/sort-order.enum'
+
+@InputType()
+export class HashtagMaxOrderByAggregateInput {
+  @Field(() => SortOrder, { nullable: true })
+  id?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  tag?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  createdAt?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  updatedAt?: keyof typeof SortOrder
+}

--- a/api/src/@generated/hashtag/hashtag-min-aggregate.input.ts
+++ b/api/src/@generated/hashtag/hashtag-min-aggregate.input.ts
@@ -1,0 +1,17 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+
+@InputType()
+export class HashtagMinAggregateInput {
+  @Field(() => Boolean, { nullable: true })
+  id?: true
+
+  @Field(() => Boolean, { nullable: true })
+  tag?: true
+
+  @Field(() => Boolean, { nullable: true })
+  createdAt?: true
+
+  @Field(() => Boolean, { nullable: true })
+  updatedAt?: true
+}

--- a/api/src/@generated/hashtag/hashtag-min-aggregate.output.ts
+++ b/api/src/@generated/hashtag/hashtag-min-aggregate.output.ts
@@ -1,0 +1,18 @@
+import { Field } from '@nestjs/graphql'
+import { ObjectType } from '@nestjs/graphql'
+import { Int } from '@nestjs/graphql'
+
+@ObjectType()
+export class HashtagMinAggregate {
+  @Field(() => Int, { nullable: true })
+  id?: number
+
+  @Field(() => String, { nullable: true })
+  tag?: string
+
+  @Field(() => Date, { nullable: true })
+  createdAt?: Date | string
+
+  @Field(() => Date, { nullable: true })
+  updatedAt?: Date | string
+}

--- a/api/src/@generated/hashtag/hashtag-min-order-by-aggregate.input.ts
+++ b/api/src/@generated/hashtag/hashtag-min-order-by-aggregate.input.ts
@@ -1,0 +1,18 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { SortOrder } from '../prisma/sort-order.enum'
+
+@InputType()
+export class HashtagMinOrderByAggregateInput {
+  @Field(() => SortOrder, { nullable: true })
+  id?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  tag?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  createdAt?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  updatedAt?: keyof typeof SortOrder
+}

--- a/api/src/@generated/hashtag/hashtag-order-by-relation-aggregate.input.ts
+++ b/api/src/@generated/hashtag/hashtag-order-by-relation-aggregate.input.ts
@@ -1,0 +1,9 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { SortOrder } from '../prisma/sort-order.enum'
+
+@InputType()
+export class HashtagOrderByRelationAggregateInput {
+  @Field(() => SortOrder, { nullable: true })
+  _count?: keyof typeof SortOrder
+}

--- a/api/src/@generated/hashtag/hashtag-order-by-with-aggregation.input.ts
+++ b/api/src/@generated/hashtag/hashtag-order-by-with-aggregation.input.ts
@@ -1,0 +1,38 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { SortOrder } from '../prisma/sort-order.enum'
+import { HashtagCountOrderByAggregateInput } from './hashtag-count-order-by-aggregate.input'
+import { HashtagAvgOrderByAggregateInput } from './hashtag-avg-order-by-aggregate.input'
+import { HashtagMaxOrderByAggregateInput } from './hashtag-max-order-by-aggregate.input'
+import { HashtagMinOrderByAggregateInput } from './hashtag-min-order-by-aggregate.input'
+import { HashtagSumOrderByAggregateInput } from './hashtag-sum-order-by-aggregate.input'
+
+@InputType()
+export class HashtagOrderByWithAggregationInput {
+  @Field(() => SortOrder, { nullable: true })
+  id?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  tag?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  createdAt?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  updatedAt?: keyof typeof SortOrder
+
+  @Field(() => HashtagCountOrderByAggregateInput, { nullable: true })
+  _count?: HashtagCountOrderByAggregateInput
+
+  @Field(() => HashtagAvgOrderByAggregateInput, { nullable: true })
+  _avg?: HashtagAvgOrderByAggregateInput
+
+  @Field(() => HashtagMaxOrderByAggregateInput, { nullable: true })
+  _max?: HashtagMaxOrderByAggregateInput
+
+  @Field(() => HashtagMinOrderByAggregateInput, { nullable: true })
+  _min?: HashtagMinOrderByAggregateInput
+
+  @Field(() => HashtagSumOrderByAggregateInput, { nullable: true })
+  _sum?: HashtagSumOrderByAggregateInput
+}

--- a/api/src/@generated/hashtag/hashtag-order-by-with-relation.input.ts
+++ b/api/src/@generated/hashtag/hashtag-order-by-with-relation.input.ts
@@ -1,0 +1,22 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { SortOrder } from '../prisma/sort-order.enum'
+import { PostOrderByRelationAggregateInput } from '../post/post-order-by-relation-aggregate.input'
+
+@InputType()
+export class HashtagOrderByWithRelationInput {
+  @Field(() => SortOrder, { nullable: true })
+  id?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  tag?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  createdAt?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, { nullable: true })
+  updatedAt?: keyof typeof SortOrder
+
+  @Field(() => PostOrderByRelationAggregateInput, { nullable: true })
+  posts?: PostOrderByRelationAggregateInput
+}

--- a/api/src/@generated/hashtag/hashtag-scalar-field.enum.ts
+++ b/api/src/@generated/hashtag/hashtag-scalar-field.enum.ts
@@ -1,0 +1,10 @@
+import { registerEnumType } from '@nestjs/graphql'
+
+export enum HashtagScalarFieldEnum {
+  id = 'id',
+  tag = 'tag',
+  createdAt = 'createdAt',
+  updatedAt = 'updatedAt'
+}
+
+registerEnumType(HashtagScalarFieldEnum, { name: 'HashtagScalarFieldEnum', description: undefined })

--- a/api/src/@generated/hashtag/hashtag-scalar-where-with-aggregates.input.ts
+++ b/api/src/@generated/hashtag/hashtag-scalar-where-with-aggregates.input.ts
@@ -1,0 +1,29 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { IntWithAggregatesFilter } from '../prisma/int-with-aggregates-filter.input'
+import { StringWithAggregatesFilter } from '../prisma/string-with-aggregates-filter.input'
+import { DateTimeWithAggregatesFilter } from '../prisma/date-time-with-aggregates-filter.input'
+
+@InputType()
+export class HashtagScalarWhereWithAggregatesInput {
+  @Field(() => [HashtagScalarWhereWithAggregatesInput], { nullable: true })
+  AND?: Array<HashtagScalarWhereWithAggregatesInput>
+
+  @Field(() => [HashtagScalarWhereWithAggregatesInput], { nullable: true })
+  OR?: Array<HashtagScalarWhereWithAggregatesInput>
+
+  @Field(() => [HashtagScalarWhereWithAggregatesInput], { nullable: true })
+  NOT?: Array<HashtagScalarWhereWithAggregatesInput>
+
+  @Field(() => IntWithAggregatesFilter, { nullable: true })
+  id?: IntWithAggregatesFilter
+
+  @Field(() => StringWithAggregatesFilter, { nullable: true })
+  tag?: StringWithAggregatesFilter
+
+  @Field(() => DateTimeWithAggregatesFilter, { nullable: true })
+  createdAt?: DateTimeWithAggregatesFilter
+
+  @Field(() => DateTimeWithAggregatesFilter, { nullable: true })
+  updatedAt?: DateTimeWithAggregatesFilter
+}

--- a/api/src/@generated/hashtag/hashtag-scalar-where.input.ts
+++ b/api/src/@generated/hashtag/hashtag-scalar-where.input.ts
@@ -1,0 +1,29 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { IntFilter } from '../prisma/int-filter.input'
+import { StringFilter } from '../prisma/string-filter.input'
+import { DateTimeFilter } from '../prisma/date-time-filter.input'
+
+@InputType()
+export class HashtagScalarWhereInput {
+  @Field(() => [HashtagScalarWhereInput], { nullable: true })
+  AND?: Array<HashtagScalarWhereInput>
+
+  @Field(() => [HashtagScalarWhereInput], { nullable: true })
+  OR?: Array<HashtagScalarWhereInput>
+
+  @Field(() => [HashtagScalarWhereInput], { nullable: true })
+  NOT?: Array<HashtagScalarWhereInput>
+
+  @Field(() => IntFilter, { nullable: true })
+  id?: IntFilter
+
+  @Field(() => StringFilter, { nullable: true })
+  tag?: StringFilter
+
+  @Field(() => DateTimeFilter, { nullable: true })
+  createdAt?: DateTimeFilter
+
+  @Field(() => DateTimeFilter, { nullable: true })
+  updatedAt?: DateTimeFilter
+}

--- a/api/src/@generated/hashtag/hashtag-sum-aggregate.input.ts
+++ b/api/src/@generated/hashtag/hashtag-sum-aggregate.input.ts
@@ -1,0 +1,8 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+
+@InputType()
+export class HashtagSumAggregateInput {
+  @Field(() => Boolean, { nullable: true })
+  id?: true
+}

--- a/api/src/@generated/hashtag/hashtag-sum-aggregate.output.ts
+++ b/api/src/@generated/hashtag/hashtag-sum-aggregate.output.ts
@@ -1,0 +1,9 @@
+import { Field } from '@nestjs/graphql'
+import { ObjectType } from '@nestjs/graphql'
+import { Int } from '@nestjs/graphql'
+
+@ObjectType()
+export class HashtagSumAggregate {
+  @Field(() => Int, { nullable: true })
+  id?: number
+}

--- a/api/src/@generated/hashtag/hashtag-sum-order-by-aggregate.input.ts
+++ b/api/src/@generated/hashtag/hashtag-sum-order-by-aggregate.input.ts
@@ -1,0 +1,9 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { SortOrder } from '../prisma/sort-order.enum'
+
+@InputType()
+export class HashtagSumOrderByAggregateInput {
+  @Field(() => SortOrder, { nullable: true })
+  id?: keyof typeof SortOrder
+}

--- a/api/src/@generated/hashtag/hashtag-unchecked-create-nested-many-without-posts.input.ts
+++ b/api/src/@generated/hashtag/hashtag-unchecked-create-nested-many-without-posts.input.ts
@@ -1,0 +1,22 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { HashtagCreateWithoutPostsInput } from './hashtag-create-without-posts.input'
+import { Type } from 'class-transformer'
+import { HashtagCreateOrConnectWithoutPostsInput } from './hashtag-create-or-connect-without-posts.input'
+import { Prisma } from '@prisma/client'
+import { HashtagWhereUniqueInput } from './hashtag-where-unique.input'
+
+@InputType()
+export class HashtagUncheckedCreateNestedManyWithoutPostsInput {
+  @Field(() => [HashtagCreateWithoutPostsInput], { nullable: true })
+  @Type(() => HashtagCreateWithoutPostsInput)
+  create?: Array<HashtagCreateWithoutPostsInput>
+
+  @Field(() => [HashtagCreateOrConnectWithoutPostsInput], { nullable: true })
+  @Type(() => HashtagCreateOrConnectWithoutPostsInput)
+  connectOrCreate?: Array<HashtagCreateOrConnectWithoutPostsInput>
+
+  @Field(() => [HashtagWhereUniqueInput], { nullable: true })
+  @Type(() => HashtagWhereUniqueInput)
+  connect?: Array<Prisma.AtLeast<HashtagWhereUniqueInput, 'id' | 'tag'>>
+}

--- a/api/src/@generated/hashtag/hashtag-unchecked-create-without-posts.input.ts
+++ b/api/src/@generated/hashtag/hashtag-unchecked-create-without-posts.input.ts
@@ -1,0 +1,18 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { Int } from '@nestjs/graphql'
+
+@InputType()
+export class HashtagUncheckedCreateWithoutPostsInput {
+  @Field(() => Int, { nullable: true })
+  id?: number
+
+  @Field(() => String, { nullable: false })
+  tag!: string
+
+  @Field(() => Date, { nullable: true })
+  createdAt?: Date | string
+
+  @Field(() => Date, { nullable: true })
+  updatedAt?: Date | string
+}

--- a/api/src/@generated/hashtag/hashtag-unchecked-create.input.ts
+++ b/api/src/@generated/hashtag/hashtag-unchecked-create.input.ts
@@ -1,0 +1,22 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { Int } from '@nestjs/graphql'
+import { PostUncheckedCreateNestedManyWithoutHashtagsInput } from '../post/post-unchecked-create-nested-many-without-hashtags.input'
+
+@InputType()
+export class HashtagUncheckedCreateInput {
+  @Field(() => Int, { nullable: true })
+  id?: number
+
+  @Field(() => String, { nullable: false })
+  tag!: string
+
+  @Field(() => Date, { nullable: true })
+  createdAt?: Date | string
+
+  @Field(() => Date, { nullable: true })
+  updatedAt?: Date | string
+
+  @Field(() => PostUncheckedCreateNestedManyWithoutHashtagsInput, { nullable: true })
+  posts?: PostUncheckedCreateNestedManyWithoutHashtagsInput
+}

--- a/api/src/@generated/hashtag/hashtag-unchecked-update-many-without-posts-nested.input.ts
+++ b/api/src/@generated/hashtag/hashtag-unchecked-update-many-without-posts-nested.input.ts
@@ -1,0 +1,54 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { HashtagCreateWithoutPostsInput } from './hashtag-create-without-posts.input'
+import { Type } from 'class-transformer'
+import { HashtagCreateOrConnectWithoutPostsInput } from './hashtag-create-or-connect-without-posts.input'
+import { HashtagUpsertWithWhereUniqueWithoutPostsInput } from './hashtag-upsert-with-where-unique-without-posts.input'
+import { Prisma } from '@prisma/client'
+import { HashtagWhereUniqueInput } from './hashtag-where-unique.input'
+import { HashtagUpdateWithWhereUniqueWithoutPostsInput } from './hashtag-update-with-where-unique-without-posts.input'
+import { HashtagUpdateManyWithWhereWithoutPostsInput } from './hashtag-update-many-with-where-without-posts.input'
+import { HashtagScalarWhereInput } from './hashtag-scalar-where.input'
+
+@InputType()
+export class HashtagUncheckedUpdateManyWithoutPostsNestedInput {
+  @Field(() => [HashtagCreateWithoutPostsInput], { nullable: true })
+  @Type(() => HashtagCreateWithoutPostsInput)
+  create?: Array<HashtagCreateWithoutPostsInput>
+
+  @Field(() => [HashtagCreateOrConnectWithoutPostsInput], { nullable: true })
+  @Type(() => HashtagCreateOrConnectWithoutPostsInput)
+  connectOrCreate?: Array<HashtagCreateOrConnectWithoutPostsInput>
+
+  @Field(() => [HashtagUpsertWithWhereUniqueWithoutPostsInput], { nullable: true })
+  @Type(() => HashtagUpsertWithWhereUniqueWithoutPostsInput)
+  upsert?: Array<HashtagUpsertWithWhereUniqueWithoutPostsInput>
+
+  @Field(() => [HashtagWhereUniqueInput], { nullable: true })
+  @Type(() => HashtagWhereUniqueInput)
+  set?: Array<Prisma.AtLeast<HashtagWhereUniqueInput, 'id' | 'tag'>>
+
+  @Field(() => [HashtagWhereUniqueInput], { nullable: true })
+  @Type(() => HashtagWhereUniqueInput)
+  disconnect?: Array<Prisma.AtLeast<HashtagWhereUniqueInput, 'id' | 'tag'>>
+
+  @Field(() => [HashtagWhereUniqueInput], { nullable: true })
+  @Type(() => HashtagWhereUniqueInput)
+  delete?: Array<Prisma.AtLeast<HashtagWhereUniqueInput, 'id' | 'tag'>>
+
+  @Field(() => [HashtagWhereUniqueInput], { nullable: true })
+  @Type(() => HashtagWhereUniqueInput)
+  connect?: Array<Prisma.AtLeast<HashtagWhereUniqueInput, 'id' | 'tag'>>
+
+  @Field(() => [HashtagUpdateWithWhereUniqueWithoutPostsInput], { nullable: true })
+  @Type(() => HashtagUpdateWithWhereUniqueWithoutPostsInput)
+  update?: Array<HashtagUpdateWithWhereUniqueWithoutPostsInput>
+
+  @Field(() => [HashtagUpdateManyWithWhereWithoutPostsInput], { nullable: true })
+  @Type(() => HashtagUpdateManyWithWhereWithoutPostsInput)
+  updateMany?: Array<HashtagUpdateManyWithWhereWithoutPostsInput>
+
+  @Field(() => [HashtagScalarWhereInput], { nullable: true })
+  @Type(() => HashtagScalarWhereInput)
+  deleteMany?: Array<HashtagScalarWhereInput>
+}

--- a/api/src/@generated/hashtag/hashtag-unchecked-update-many-without-posts.input.ts
+++ b/api/src/@generated/hashtag/hashtag-unchecked-update-many-without-posts.input.ts
@@ -1,0 +1,20 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { IntFieldUpdateOperationsInput } from '../prisma/int-field-update-operations.input'
+import { StringFieldUpdateOperationsInput } from '../prisma/string-field-update-operations.input'
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input'
+
+@InputType()
+export class HashtagUncheckedUpdateManyWithoutPostsInput {
+  @Field(() => IntFieldUpdateOperationsInput, { nullable: true })
+  id?: IntFieldUpdateOperationsInput
+
+  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
+  tag?: StringFieldUpdateOperationsInput
+
+  @Field(() => DateTimeFieldUpdateOperationsInput, { nullable: true })
+  createdAt?: DateTimeFieldUpdateOperationsInput
+
+  @Field(() => DateTimeFieldUpdateOperationsInput, { nullable: true })
+  updatedAt?: DateTimeFieldUpdateOperationsInput
+}

--- a/api/src/@generated/hashtag/hashtag-unchecked-update-many.input.ts
+++ b/api/src/@generated/hashtag/hashtag-unchecked-update-many.input.ts
@@ -1,0 +1,20 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { IntFieldUpdateOperationsInput } from '../prisma/int-field-update-operations.input'
+import { StringFieldUpdateOperationsInput } from '../prisma/string-field-update-operations.input'
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input'
+
+@InputType()
+export class HashtagUncheckedUpdateManyInput {
+  @Field(() => IntFieldUpdateOperationsInput, { nullable: true })
+  id?: IntFieldUpdateOperationsInput
+
+  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
+  tag?: StringFieldUpdateOperationsInput
+
+  @Field(() => DateTimeFieldUpdateOperationsInput, { nullable: true })
+  createdAt?: DateTimeFieldUpdateOperationsInput
+
+  @Field(() => DateTimeFieldUpdateOperationsInput, { nullable: true })
+  updatedAt?: DateTimeFieldUpdateOperationsInput
+}

--- a/api/src/@generated/hashtag/hashtag-unchecked-update-without-posts.input.ts
+++ b/api/src/@generated/hashtag/hashtag-unchecked-update-without-posts.input.ts
@@ -1,0 +1,20 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { IntFieldUpdateOperationsInput } from '../prisma/int-field-update-operations.input'
+import { StringFieldUpdateOperationsInput } from '../prisma/string-field-update-operations.input'
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input'
+
+@InputType()
+export class HashtagUncheckedUpdateWithoutPostsInput {
+  @Field(() => IntFieldUpdateOperationsInput, { nullable: true })
+  id?: IntFieldUpdateOperationsInput
+
+  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
+  tag?: StringFieldUpdateOperationsInput
+
+  @Field(() => DateTimeFieldUpdateOperationsInput, { nullable: true })
+  createdAt?: DateTimeFieldUpdateOperationsInput
+
+  @Field(() => DateTimeFieldUpdateOperationsInput, { nullable: true })
+  updatedAt?: DateTimeFieldUpdateOperationsInput
+}

--- a/api/src/@generated/hashtag/hashtag-unchecked-update.input.ts
+++ b/api/src/@generated/hashtag/hashtag-unchecked-update.input.ts
@@ -1,0 +1,24 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { IntFieldUpdateOperationsInput } from '../prisma/int-field-update-operations.input'
+import { StringFieldUpdateOperationsInput } from '../prisma/string-field-update-operations.input'
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input'
+import { PostUncheckedUpdateManyWithoutHashtagsNestedInput } from '../post/post-unchecked-update-many-without-hashtags-nested.input'
+
+@InputType()
+export class HashtagUncheckedUpdateInput {
+  @Field(() => IntFieldUpdateOperationsInput, { nullable: true })
+  id?: IntFieldUpdateOperationsInput
+
+  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
+  tag?: StringFieldUpdateOperationsInput
+
+  @Field(() => DateTimeFieldUpdateOperationsInput, { nullable: true })
+  createdAt?: DateTimeFieldUpdateOperationsInput
+
+  @Field(() => DateTimeFieldUpdateOperationsInput, { nullable: true })
+  updatedAt?: DateTimeFieldUpdateOperationsInput
+
+  @Field(() => PostUncheckedUpdateManyWithoutHashtagsNestedInput, { nullable: true })
+  posts?: PostUncheckedUpdateManyWithoutHashtagsNestedInput
+}

--- a/api/src/@generated/hashtag/hashtag-update-many-mutation.input.ts
+++ b/api/src/@generated/hashtag/hashtag-update-many-mutation.input.ts
@@ -1,0 +1,16 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { StringFieldUpdateOperationsInput } from '../prisma/string-field-update-operations.input'
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input'
+
+@InputType()
+export class HashtagUpdateManyMutationInput {
+  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
+  tag?: StringFieldUpdateOperationsInput
+
+  @Field(() => DateTimeFieldUpdateOperationsInput, { nullable: true })
+  createdAt?: DateTimeFieldUpdateOperationsInput
+
+  @Field(() => DateTimeFieldUpdateOperationsInput, { nullable: true })
+  updatedAt?: DateTimeFieldUpdateOperationsInput
+}

--- a/api/src/@generated/hashtag/hashtag-update-many-with-where-without-posts.input.ts
+++ b/api/src/@generated/hashtag/hashtag-update-many-with-where-without-posts.input.ts
@@ -1,0 +1,16 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { HashtagScalarWhereInput } from './hashtag-scalar-where.input'
+import { Type } from 'class-transformer'
+import { HashtagUpdateManyMutationInput } from './hashtag-update-many-mutation.input'
+
+@InputType()
+export class HashtagUpdateManyWithWhereWithoutPostsInput {
+  @Field(() => HashtagScalarWhereInput, { nullable: false })
+  @Type(() => HashtagScalarWhereInput)
+  where!: HashtagScalarWhereInput
+
+  @Field(() => HashtagUpdateManyMutationInput, { nullable: false })
+  @Type(() => HashtagUpdateManyMutationInput)
+  data!: HashtagUpdateManyMutationInput
+}

--- a/api/src/@generated/hashtag/hashtag-update-many-without-posts-nested.input.ts
+++ b/api/src/@generated/hashtag/hashtag-update-many-without-posts-nested.input.ts
@@ -1,0 +1,54 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { HashtagCreateWithoutPostsInput } from './hashtag-create-without-posts.input'
+import { Type } from 'class-transformer'
+import { HashtagCreateOrConnectWithoutPostsInput } from './hashtag-create-or-connect-without-posts.input'
+import { HashtagUpsertWithWhereUniqueWithoutPostsInput } from './hashtag-upsert-with-where-unique-without-posts.input'
+import { Prisma } from '@prisma/client'
+import { HashtagWhereUniqueInput } from './hashtag-where-unique.input'
+import { HashtagUpdateWithWhereUniqueWithoutPostsInput } from './hashtag-update-with-where-unique-without-posts.input'
+import { HashtagUpdateManyWithWhereWithoutPostsInput } from './hashtag-update-many-with-where-without-posts.input'
+import { HashtagScalarWhereInput } from './hashtag-scalar-where.input'
+
+@InputType()
+export class HashtagUpdateManyWithoutPostsNestedInput {
+  @Field(() => [HashtagCreateWithoutPostsInput], { nullable: true })
+  @Type(() => HashtagCreateWithoutPostsInput)
+  create?: Array<HashtagCreateWithoutPostsInput>
+
+  @Field(() => [HashtagCreateOrConnectWithoutPostsInput], { nullable: true })
+  @Type(() => HashtagCreateOrConnectWithoutPostsInput)
+  connectOrCreate?: Array<HashtagCreateOrConnectWithoutPostsInput>
+
+  @Field(() => [HashtagUpsertWithWhereUniqueWithoutPostsInput], { nullable: true })
+  @Type(() => HashtagUpsertWithWhereUniqueWithoutPostsInput)
+  upsert?: Array<HashtagUpsertWithWhereUniqueWithoutPostsInput>
+
+  @Field(() => [HashtagWhereUniqueInput], { nullable: true })
+  @Type(() => HashtagWhereUniqueInput)
+  set?: Array<Prisma.AtLeast<HashtagWhereUniqueInput, 'id' | 'tag'>>
+
+  @Field(() => [HashtagWhereUniqueInput], { nullable: true })
+  @Type(() => HashtagWhereUniqueInput)
+  disconnect?: Array<Prisma.AtLeast<HashtagWhereUniqueInput, 'id' | 'tag'>>
+
+  @Field(() => [HashtagWhereUniqueInput], { nullable: true })
+  @Type(() => HashtagWhereUniqueInput)
+  delete?: Array<Prisma.AtLeast<HashtagWhereUniqueInput, 'id' | 'tag'>>
+
+  @Field(() => [HashtagWhereUniqueInput], { nullable: true })
+  @Type(() => HashtagWhereUniqueInput)
+  connect?: Array<Prisma.AtLeast<HashtagWhereUniqueInput, 'id' | 'tag'>>
+
+  @Field(() => [HashtagUpdateWithWhereUniqueWithoutPostsInput], { nullable: true })
+  @Type(() => HashtagUpdateWithWhereUniqueWithoutPostsInput)
+  update?: Array<HashtagUpdateWithWhereUniqueWithoutPostsInput>
+
+  @Field(() => [HashtagUpdateManyWithWhereWithoutPostsInput], { nullable: true })
+  @Type(() => HashtagUpdateManyWithWhereWithoutPostsInput)
+  updateMany?: Array<HashtagUpdateManyWithWhereWithoutPostsInput>
+
+  @Field(() => [HashtagScalarWhereInput], { nullable: true })
+  @Type(() => HashtagScalarWhereInput)
+  deleteMany?: Array<HashtagScalarWhereInput>
+}

--- a/api/src/@generated/hashtag/hashtag-update-with-where-unique-without-posts.input.ts
+++ b/api/src/@generated/hashtag/hashtag-update-with-where-unique-without-posts.input.ts
@@ -1,0 +1,17 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { Prisma } from '@prisma/client'
+import { HashtagWhereUniqueInput } from './hashtag-where-unique.input'
+import { Type } from 'class-transformer'
+import { HashtagUpdateWithoutPostsInput } from './hashtag-update-without-posts.input'
+
+@InputType()
+export class HashtagUpdateWithWhereUniqueWithoutPostsInput {
+  @Field(() => HashtagWhereUniqueInput, { nullable: false })
+  @Type(() => HashtagWhereUniqueInput)
+  where!: Prisma.AtLeast<HashtagWhereUniqueInput, 'id' | 'tag'>
+
+  @Field(() => HashtagUpdateWithoutPostsInput, { nullable: false })
+  @Type(() => HashtagUpdateWithoutPostsInput)
+  data!: HashtagUpdateWithoutPostsInput
+}

--- a/api/src/@generated/hashtag/hashtag-update-without-posts.input.ts
+++ b/api/src/@generated/hashtag/hashtag-update-without-posts.input.ts
@@ -1,0 +1,16 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { StringFieldUpdateOperationsInput } from '../prisma/string-field-update-operations.input'
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input'
+
+@InputType()
+export class HashtagUpdateWithoutPostsInput {
+  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
+  tag?: StringFieldUpdateOperationsInput
+
+  @Field(() => DateTimeFieldUpdateOperationsInput, { nullable: true })
+  createdAt?: DateTimeFieldUpdateOperationsInput
+
+  @Field(() => DateTimeFieldUpdateOperationsInput, { nullable: true })
+  updatedAt?: DateTimeFieldUpdateOperationsInput
+}

--- a/api/src/@generated/hashtag/hashtag-update.input.ts
+++ b/api/src/@generated/hashtag/hashtag-update.input.ts
@@ -1,0 +1,20 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { StringFieldUpdateOperationsInput } from '../prisma/string-field-update-operations.input'
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input'
+import { PostUpdateManyWithoutHashtagsNestedInput } from '../post/post-update-many-without-hashtags-nested.input'
+
+@InputType()
+export class HashtagUpdateInput {
+  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
+  tag?: StringFieldUpdateOperationsInput
+
+  @Field(() => DateTimeFieldUpdateOperationsInput, { nullable: true })
+  createdAt?: DateTimeFieldUpdateOperationsInput
+
+  @Field(() => DateTimeFieldUpdateOperationsInput, { nullable: true })
+  updatedAt?: DateTimeFieldUpdateOperationsInput
+
+  @Field(() => PostUpdateManyWithoutHashtagsNestedInput, { nullable: true })
+  posts?: PostUpdateManyWithoutHashtagsNestedInput
+}

--- a/api/src/@generated/hashtag/hashtag-upsert-with-where-unique-without-posts.input.ts
+++ b/api/src/@generated/hashtag/hashtag-upsert-with-where-unique-without-posts.input.ts
@@ -1,0 +1,22 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { Prisma } from '@prisma/client'
+import { HashtagWhereUniqueInput } from './hashtag-where-unique.input'
+import { Type } from 'class-transformer'
+import { HashtagUpdateWithoutPostsInput } from './hashtag-update-without-posts.input'
+import { HashtagCreateWithoutPostsInput } from './hashtag-create-without-posts.input'
+
+@InputType()
+export class HashtagUpsertWithWhereUniqueWithoutPostsInput {
+  @Field(() => HashtagWhereUniqueInput, { nullable: false })
+  @Type(() => HashtagWhereUniqueInput)
+  where!: Prisma.AtLeast<HashtagWhereUniqueInput, 'id' | 'tag'>
+
+  @Field(() => HashtagUpdateWithoutPostsInput, { nullable: false })
+  @Type(() => HashtagUpdateWithoutPostsInput)
+  update!: HashtagUpdateWithoutPostsInput
+
+  @Field(() => HashtagCreateWithoutPostsInput, { nullable: false })
+  @Type(() => HashtagCreateWithoutPostsInput)
+  create!: HashtagCreateWithoutPostsInput
+}

--- a/api/src/@generated/hashtag/hashtag-where-unique.input.ts
+++ b/api/src/@generated/hashtag/hashtag-where-unique.input.ts
@@ -1,0 +1,33 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { Int } from '@nestjs/graphql'
+import { HashtagWhereInput } from './hashtag-where.input'
+import { DateTimeFilter } from '../prisma/date-time-filter.input'
+import { PostListRelationFilter } from '../post/post-list-relation-filter.input'
+
+@InputType()
+export class HashtagWhereUniqueInput {
+  @Field(() => Int, { nullable: true })
+  id?: number
+
+  @Field(() => String, { nullable: true })
+  tag?: string
+
+  @Field(() => [HashtagWhereInput], { nullable: true })
+  AND?: Array<HashtagWhereInput>
+
+  @Field(() => [HashtagWhereInput], { nullable: true })
+  OR?: Array<HashtagWhereInput>
+
+  @Field(() => [HashtagWhereInput], { nullable: true })
+  NOT?: Array<HashtagWhereInput>
+
+  @Field(() => DateTimeFilter, { nullable: true })
+  createdAt?: DateTimeFilter
+
+  @Field(() => DateTimeFilter, { nullable: true })
+  updatedAt?: DateTimeFilter
+
+  @Field(() => PostListRelationFilter, { nullable: true })
+  posts?: PostListRelationFilter
+}

--- a/api/src/@generated/hashtag/hashtag-where.input.ts
+++ b/api/src/@generated/hashtag/hashtag-where.input.ts
@@ -1,0 +1,33 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { IntFilter } from '../prisma/int-filter.input'
+import { StringFilter } from '../prisma/string-filter.input'
+import { DateTimeFilter } from '../prisma/date-time-filter.input'
+import { PostListRelationFilter } from '../post/post-list-relation-filter.input'
+
+@InputType()
+export class HashtagWhereInput {
+  @Field(() => [HashtagWhereInput], { nullable: true })
+  AND?: Array<HashtagWhereInput>
+
+  @Field(() => [HashtagWhereInput], { nullable: true })
+  OR?: Array<HashtagWhereInput>
+
+  @Field(() => [HashtagWhereInput], { nullable: true })
+  NOT?: Array<HashtagWhereInput>
+
+  @Field(() => IntFilter, { nullable: true })
+  id?: IntFilter
+
+  @Field(() => StringFilter, { nullable: true })
+  tag?: StringFilter
+
+  @Field(() => DateTimeFilter, { nullable: true })
+  createdAt?: DateTimeFilter
+
+  @Field(() => DateTimeFilter, { nullable: true })
+  updatedAt?: DateTimeFilter
+
+  @Field(() => PostListRelationFilter, { nullable: true })
+  posts?: PostListRelationFilter
+}

--- a/api/src/@generated/hashtag/hashtag.model.ts
+++ b/api/src/@generated/hashtag/hashtag.model.ts
@@ -1,0 +1,26 @@
+import { Field } from '@nestjs/graphql'
+import { ObjectType } from '@nestjs/graphql'
+import { ID } from '@nestjs/graphql'
+import { Post } from '../post/post.model'
+import { HashtagCount } from './hashtag-count.output'
+
+@ObjectType()
+export class Hashtag {
+  @Field(() => ID, { nullable: false })
+  id!: number
+
+  @Field(() => String, { nullable: false })
+  tag!: string
+
+  @Field(() => Date, { nullable: false })
+  createdAt!: Date
+
+  @Field(() => Date, { nullable: false })
+  updatedAt!: Date
+
+  @Field(() => [Post], { nullable: true })
+  posts?: Array<Post>
+
+  @Field(() => HashtagCount, { nullable: false })
+  _count?: HashtagCount
+}

--- a/api/src/@generated/hashtag/update-many-hashtag.args.ts
+++ b/api/src/@generated/hashtag/update-many-hashtag.args.ts
@@ -1,0 +1,16 @@
+import { Field } from '@nestjs/graphql'
+import { ArgsType } from '@nestjs/graphql'
+import { HashtagUpdateManyMutationInput } from './hashtag-update-many-mutation.input'
+import { Type } from 'class-transformer'
+import { HashtagWhereInput } from './hashtag-where.input'
+
+@ArgsType()
+export class UpdateManyHashtagArgs {
+  @Field(() => HashtagUpdateManyMutationInput, { nullable: false })
+  @Type(() => HashtagUpdateManyMutationInput)
+  data!: HashtagUpdateManyMutationInput
+
+  @Field(() => HashtagWhereInput, { nullable: true })
+  @Type(() => HashtagWhereInput)
+  where?: HashtagWhereInput
+}

--- a/api/src/@generated/hashtag/update-one-hashtag.args.ts
+++ b/api/src/@generated/hashtag/update-one-hashtag.args.ts
@@ -1,0 +1,17 @@
+import { Field } from '@nestjs/graphql'
+import { ArgsType } from '@nestjs/graphql'
+import { HashtagUpdateInput } from './hashtag-update.input'
+import { Type } from 'class-transformer'
+import { Prisma } from '@prisma/client'
+import { HashtagWhereUniqueInput } from './hashtag-where-unique.input'
+
+@ArgsType()
+export class UpdateOneHashtagArgs {
+  @Field(() => HashtagUpdateInput, { nullable: false })
+  @Type(() => HashtagUpdateInput)
+  data!: HashtagUpdateInput
+
+  @Field(() => HashtagWhereUniqueInput, { nullable: false })
+  @Type(() => HashtagWhereUniqueInput)
+  where!: Prisma.AtLeast<HashtagWhereUniqueInput, 'id' | 'tag'>
+}

--- a/api/src/@generated/hashtag/upsert-one-hashtag.args.ts
+++ b/api/src/@generated/hashtag/upsert-one-hashtag.args.ts
@@ -1,0 +1,22 @@
+import { Field } from '@nestjs/graphql'
+import { ArgsType } from '@nestjs/graphql'
+import { Prisma } from '@prisma/client'
+import { HashtagWhereUniqueInput } from './hashtag-where-unique.input'
+import { Type } from 'class-transformer'
+import { HashtagCreateInput } from './hashtag-create.input'
+import { HashtagUpdateInput } from './hashtag-update.input'
+
+@ArgsType()
+export class UpsertOneHashtagArgs {
+  @Field(() => HashtagWhereUniqueInput, { nullable: false })
+  @Type(() => HashtagWhereUniqueInput)
+  where!: Prisma.AtLeast<HashtagWhereUniqueInput, 'id' | 'tag'>
+
+  @Field(() => HashtagCreateInput, { nullable: false })
+  @Type(() => HashtagCreateInput)
+  create!: HashtagCreateInput
+
+  @Field(() => HashtagUpdateInput, { nullable: false })
+  @Type(() => HashtagUpdateInput)
+  update!: HashtagUpdateInput
+}

--- a/api/src/@generated/post/post-count.output.ts
+++ b/api/src/@generated/post/post-count.output.ts
@@ -1,0 +1,9 @@
+import { Field } from '@nestjs/graphql'
+import { ObjectType } from '@nestjs/graphql'
+import { Int } from '@nestjs/graphql'
+
+@ObjectType()
+export class PostCount {
+  @Field(() => Int, { nullable: false })
+  hashtags?: number
+}

--- a/api/src/@generated/post/post-create-nested-many-without-hashtags.input.ts
+++ b/api/src/@generated/post/post-create-nested-many-without-hashtags.input.ts
@@ -1,0 +1,22 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { PostCreateWithoutHashtagsInput } from './post-create-without-hashtags.input'
+import { Type } from 'class-transformer'
+import { PostCreateOrConnectWithoutHashtagsInput } from './post-create-or-connect-without-hashtags.input'
+import { Prisma } from '@prisma/client'
+import { PostWhereUniqueInput } from './post-where-unique.input'
+
+@InputType()
+export class PostCreateNestedManyWithoutHashtagsInput {
+  @Field(() => [PostCreateWithoutHashtagsInput], { nullable: true })
+  @Type(() => PostCreateWithoutHashtagsInput)
+  create?: Array<PostCreateWithoutHashtagsInput>
+
+  @Field(() => [PostCreateOrConnectWithoutHashtagsInput], { nullable: true })
+  @Type(() => PostCreateOrConnectWithoutHashtagsInput)
+  connectOrCreate?: Array<PostCreateOrConnectWithoutHashtagsInput>
+
+  @Field(() => [PostWhereUniqueInput], { nullable: true })
+  @Type(() => PostWhereUniqueInput)
+  connect?: Array<Prisma.AtLeast<PostWhereUniqueInput, 'id'>>
+}

--- a/api/src/@generated/post/post-create-or-connect-without-hashtags.input.ts
+++ b/api/src/@generated/post/post-create-or-connect-without-hashtags.input.ts
@@ -1,0 +1,17 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { Prisma } from '@prisma/client'
+import { PostWhereUniqueInput } from './post-where-unique.input'
+import { Type } from 'class-transformer'
+import { PostCreateWithoutHashtagsInput } from './post-create-without-hashtags.input'
+
+@InputType()
+export class PostCreateOrConnectWithoutHashtagsInput {
+  @Field(() => PostWhereUniqueInput, { nullable: false })
+  @Type(() => PostWhereUniqueInput)
+  where!: Prisma.AtLeast<PostWhereUniqueInput, 'id'>
+
+  @Field(() => PostCreateWithoutHashtagsInput, { nullable: false })
+  @Type(() => PostCreateWithoutHashtagsInput)
+  create!: PostCreateWithoutHashtagsInput
+}

--- a/api/src/@generated/post/post-create-without-hashtags.input.ts
+++ b/api/src/@generated/post/post-create-without-hashtags.input.ts
@@ -1,0 +1,28 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { PostCreatemediaUrlsInput } from './post-createmedia-urls.input'
+import { UserCreateNestedOneWithoutPostsInput } from '../user/user-create-nested-one-without-posts.input'
+
+@InputType()
+export class PostCreateWithoutHashtagsInput {
+  @Field(() => String, { nullable: true })
+  title?: string
+
+  @Field(() => PostCreatemediaUrlsInput, { nullable: true })
+  mediaUrls?: PostCreatemediaUrlsInput
+
+  @Field(() => Boolean, { nullable: true })
+  isHideLikeAndCount?: boolean
+
+  @Field(() => Boolean, { nullable: true })
+  isTurnOffComment?: boolean
+
+  @Field(() => Date, { nullable: true })
+  createdAt?: Date | string
+
+  @Field(() => Date, { nullable: true })
+  updatedAt?: Date | string
+
+  @Field(() => UserCreateNestedOneWithoutPostsInput, { nullable: false })
+  user!: UserCreateNestedOneWithoutPostsInput
+}

--- a/api/src/@generated/post/post-create-without-user.input.ts
+++ b/api/src/@generated/post/post-create-without-user.input.ts
@@ -1,6 +1,7 @@
 import { Field } from '@nestjs/graphql'
 import { InputType } from '@nestjs/graphql'
 import { PostCreatemediaUrlsInput } from './post-createmedia-urls.input'
+import { HashtagCreateNestedManyWithoutPostsInput } from '../hashtag/hashtag-create-nested-many-without-posts.input'
 
 @InputType()
 export class PostCreateWithoutUserInput {
@@ -21,4 +22,7 @@ export class PostCreateWithoutUserInput {
 
   @Field(() => Date, { nullable: true })
   updatedAt?: Date | string
+
+  @Field(() => HashtagCreateNestedManyWithoutPostsInput, { nullable: true })
+  hashtags?: HashtagCreateNestedManyWithoutPostsInput
 }

--- a/api/src/@generated/post/post-create.input.ts
+++ b/api/src/@generated/post/post-create.input.ts
@@ -2,6 +2,7 @@ import { Field } from '@nestjs/graphql'
 import { InputType } from '@nestjs/graphql'
 import { PostCreatemediaUrlsInput } from './post-createmedia-urls.input'
 import { UserCreateNestedOneWithoutPostsInput } from '../user/user-create-nested-one-without-posts.input'
+import { HashtagCreateNestedManyWithoutPostsInput } from '../hashtag/hashtag-create-nested-many-without-posts.input'
 
 @InputType()
 export class PostCreateInput {
@@ -25,4 +26,7 @@ export class PostCreateInput {
 
   @Field(() => UserCreateNestedOneWithoutPostsInput, { nullable: false })
   user!: UserCreateNestedOneWithoutPostsInput
+
+  @Field(() => HashtagCreateNestedManyWithoutPostsInput, { nullable: true })
+  hashtags?: HashtagCreateNestedManyWithoutPostsInput
 }

--- a/api/src/@generated/post/post-order-by-with-relation.input.ts
+++ b/api/src/@generated/post/post-order-by-with-relation.input.ts
@@ -3,6 +3,7 @@ import { InputType } from '@nestjs/graphql'
 import { SortOrder } from '../prisma/sort-order.enum'
 import { SortOrderInput } from '../prisma/sort-order.input'
 import { UserOrderByWithRelationInput } from '../user/user-order-by-with-relation.input'
+import { HashtagOrderByRelationAggregateInput } from '../hashtag/hashtag-order-by-relation-aggregate.input'
 
 @InputType()
 export class PostOrderByWithRelationInput {
@@ -32,4 +33,7 @@ export class PostOrderByWithRelationInput {
 
   @Field(() => UserOrderByWithRelationInput, { nullable: true })
   user?: UserOrderByWithRelationInput
+
+  @Field(() => HashtagOrderByRelationAggregateInput, { nullable: true })
+  hashtags?: HashtagOrderByRelationAggregateInput
 }

--- a/api/src/@generated/post/post-unchecked-create-nested-many-without-hashtags.input.ts
+++ b/api/src/@generated/post/post-unchecked-create-nested-many-without-hashtags.input.ts
@@ -1,0 +1,22 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { PostCreateWithoutHashtagsInput } from './post-create-without-hashtags.input'
+import { Type } from 'class-transformer'
+import { PostCreateOrConnectWithoutHashtagsInput } from './post-create-or-connect-without-hashtags.input'
+import { Prisma } from '@prisma/client'
+import { PostWhereUniqueInput } from './post-where-unique.input'
+
+@InputType()
+export class PostUncheckedCreateNestedManyWithoutHashtagsInput {
+  @Field(() => [PostCreateWithoutHashtagsInput], { nullable: true })
+  @Type(() => PostCreateWithoutHashtagsInput)
+  create?: Array<PostCreateWithoutHashtagsInput>
+
+  @Field(() => [PostCreateOrConnectWithoutHashtagsInput], { nullable: true })
+  @Type(() => PostCreateOrConnectWithoutHashtagsInput)
+  connectOrCreate?: Array<PostCreateOrConnectWithoutHashtagsInput>
+
+  @Field(() => [PostWhereUniqueInput], { nullable: true })
+  @Type(() => PostWhereUniqueInput)
+  connect?: Array<Prisma.AtLeast<PostWhereUniqueInput, 'id'>>
+}

--- a/api/src/@generated/post/post-unchecked-create-without-hashtags.input.ts
+++ b/api/src/@generated/post/post-unchecked-create-without-hashtags.input.ts
@@ -1,0 +1,31 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { Int } from '@nestjs/graphql'
+import { PostCreatemediaUrlsInput } from './post-createmedia-urls.input'
+
+@InputType()
+export class PostUncheckedCreateWithoutHashtagsInput {
+  @Field(() => Int, { nullable: true })
+  id?: number
+
+  @Field(() => String, { nullable: true })
+  title?: string
+
+  @Field(() => PostCreatemediaUrlsInput, { nullable: true })
+  mediaUrls?: PostCreatemediaUrlsInput
+
+  @Field(() => Int, { nullable: false })
+  userId!: number
+
+  @Field(() => Boolean, { nullable: true })
+  isHideLikeAndCount?: boolean
+
+  @Field(() => Boolean, { nullable: true })
+  isTurnOffComment?: boolean
+
+  @Field(() => Date, { nullable: true })
+  createdAt?: Date | string
+
+  @Field(() => Date, { nullable: true })
+  updatedAt?: Date | string
+}

--- a/api/src/@generated/post/post-unchecked-create-without-user.input.ts
+++ b/api/src/@generated/post/post-unchecked-create-without-user.input.ts
@@ -2,6 +2,7 @@ import { Field } from '@nestjs/graphql'
 import { InputType } from '@nestjs/graphql'
 import { Int } from '@nestjs/graphql'
 import { PostCreatemediaUrlsInput } from './post-createmedia-urls.input'
+import { HashtagUncheckedCreateNestedManyWithoutPostsInput } from '../hashtag/hashtag-unchecked-create-nested-many-without-posts.input'
 
 @InputType()
 export class PostUncheckedCreateWithoutUserInput {
@@ -25,4 +26,7 @@ export class PostUncheckedCreateWithoutUserInput {
 
   @Field(() => Date, { nullable: true })
   updatedAt?: Date | string
+
+  @Field(() => HashtagUncheckedCreateNestedManyWithoutPostsInput, { nullable: true })
+  hashtags?: HashtagUncheckedCreateNestedManyWithoutPostsInput
 }

--- a/api/src/@generated/post/post-unchecked-create.input.ts
+++ b/api/src/@generated/post/post-unchecked-create.input.ts
@@ -2,6 +2,7 @@ import { Field } from '@nestjs/graphql'
 import { InputType } from '@nestjs/graphql'
 import { Int } from '@nestjs/graphql'
 import { PostCreatemediaUrlsInput } from './post-createmedia-urls.input'
+import { HashtagUncheckedCreateNestedManyWithoutPostsInput } from '../hashtag/hashtag-unchecked-create-nested-many-without-posts.input'
 
 @InputType()
 export class PostUncheckedCreateInput {
@@ -28,4 +29,7 @@ export class PostUncheckedCreateInput {
 
   @Field(() => Date, { nullable: true })
   updatedAt?: Date | string
+
+  @Field(() => HashtagUncheckedCreateNestedManyWithoutPostsInput, { nullable: true })
+  hashtags?: HashtagUncheckedCreateNestedManyWithoutPostsInput
 }

--- a/api/src/@generated/post/post-unchecked-update-many-without-hashtags-nested.input.ts
+++ b/api/src/@generated/post/post-unchecked-update-many-without-hashtags-nested.input.ts
@@ -1,0 +1,54 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { PostCreateWithoutHashtagsInput } from './post-create-without-hashtags.input'
+import { Type } from 'class-transformer'
+import { PostCreateOrConnectWithoutHashtagsInput } from './post-create-or-connect-without-hashtags.input'
+import { PostUpsertWithWhereUniqueWithoutHashtagsInput } from './post-upsert-with-where-unique-without-hashtags.input'
+import { Prisma } from '@prisma/client'
+import { PostWhereUniqueInput } from './post-where-unique.input'
+import { PostUpdateWithWhereUniqueWithoutHashtagsInput } from './post-update-with-where-unique-without-hashtags.input'
+import { PostUpdateManyWithWhereWithoutHashtagsInput } from './post-update-many-with-where-without-hashtags.input'
+import { PostScalarWhereInput } from './post-scalar-where.input'
+
+@InputType()
+export class PostUncheckedUpdateManyWithoutHashtagsNestedInput {
+  @Field(() => [PostCreateWithoutHashtagsInput], { nullable: true })
+  @Type(() => PostCreateWithoutHashtagsInput)
+  create?: Array<PostCreateWithoutHashtagsInput>
+
+  @Field(() => [PostCreateOrConnectWithoutHashtagsInput], { nullable: true })
+  @Type(() => PostCreateOrConnectWithoutHashtagsInput)
+  connectOrCreate?: Array<PostCreateOrConnectWithoutHashtagsInput>
+
+  @Field(() => [PostUpsertWithWhereUniqueWithoutHashtagsInput], { nullable: true })
+  @Type(() => PostUpsertWithWhereUniqueWithoutHashtagsInput)
+  upsert?: Array<PostUpsertWithWhereUniqueWithoutHashtagsInput>
+
+  @Field(() => [PostWhereUniqueInput], { nullable: true })
+  @Type(() => PostWhereUniqueInput)
+  set?: Array<Prisma.AtLeast<PostWhereUniqueInput, 'id'>>
+
+  @Field(() => [PostWhereUniqueInput], { nullable: true })
+  @Type(() => PostWhereUniqueInput)
+  disconnect?: Array<Prisma.AtLeast<PostWhereUniqueInput, 'id'>>
+
+  @Field(() => [PostWhereUniqueInput], { nullable: true })
+  @Type(() => PostWhereUniqueInput)
+  delete?: Array<Prisma.AtLeast<PostWhereUniqueInput, 'id'>>
+
+  @Field(() => [PostWhereUniqueInput], { nullable: true })
+  @Type(() => PostWhereUniqueInput)
+  connect?: Array<Prisma.AtLeast<PostWhereUniqueInput, 'id'>>
+
+  @Field(() => [PostUpdateWithWhereUniqueWithoutHashtagsInput], { nullable: true })
+  @Type(() => PostUpdateWithWhereUniqueWithoutHashtagsInput)
+  update?: Array<PostUpdateWithWhereUniqueWithoutHashtagsInput>
+
+  @Field(() => [PostUpdateManyWithWhereWithoutHashtagsInput], { nullable: true })
+  @Type(() => PostUpdateManyWithWhereWithoutHashtagsInput)
+  updateMany?: Array<PostUpdateManyWithWhereWithoutHashtagsInput>
+
+  @Field(() => [PostScalarWhereInput], { nullable: true })
+  @Type(() => PostScalarWhereInput)
+  deleteMany?: Array<PostScalarWhereInput>
+}

--- a/api/src/@generated/post/post-unchecked-update-many-without-hashtags.input.ts
+++ b/api/src/@generated/post/post-unchecked-update-many-without-hashtags.input.ts
@@ -1,0 +1,34 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { IntFieldUpdateOperationsInput } from '../prisma/int-field-update-operations.input'
+import { NullableStringFieldUpdateOperationsInput } from '../prisma/nullable-string-field-update-operations.input'
+import { PostUpdatemediaUrlsInput } from './post-updatemedia-urls.input'
+import { BoolFieldUpdateOperationsInput } from '../prisma/bool-field-update-operations.input'
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input'
+
+@InputType()
+export class PostUncheckedUpdateManyWithoutHashtagsInput {
+  @Field(() => IntFieldUpdateOperationsInput, { nullable: true })
+  id?: IntFieldUpdateOperationsInput
+
+  @Field(() => NullableStringFieldUpdateOperationsInput, { nullable: true })
+  title?: NullableStringFieldUpdateOperationsInput
+
+  @Field(() => PostUpdatemediaUrlsInput, { nullable: true })
+  mediaUrls?: PostUpdatemediaUrlsInput
+
+  @Field(() => IntFieldUpdateOperationsInput, { nullable: true })
+  userId?: IntFieldUpdateOperationsInput
+
+  @Field(() => BoolFieldUpdateOperationsInput, { nullable: true })
+  isHideLikeAndCount?: BoolFieldUpdateOperationsInput
+
+  @Field(() => BoolFieldUpdateOperationsInput, { nullable: true })
+  isTurnOffComment?: BoolFieldUpdateOperationsInput
+
+  @Field(() => DateTimeFieldUpdateOperationsInput, { nullable: true })
+  createdAt?: DateTimeFieldUpdateOperationsInput
+
+  @Field(() => DateTimeFieldUpdateOperationsInput, { nullable: true })
+  updatedAt?: DateTimeFieldUpdateOperationsInput
+}

--- a/api/src/@generated/post/post-unchecked-update-without-hashtags.input.ts
+++ b/api/src/@generated/post/post-unchecked-update-without-hashtags.input.ts
@@ -1,0 +1,34 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { IntFieldUpdateOperationsInput } from '../prisma/int-field-update-operations.input'
+import { NullableStringFieldUpdateOperationsInput } from '../prisma/nullable-string-field-update-operations.input'
+import { PostUpdatemediaUrlsInput } from './post-updatemedia-urls.input'
+import { BoolFieldUpdateOperationsInput } from '../prisma/bool-field-update-operations.input'
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input'
+
+@InputType()
+export class PostUncheckedUpdateWithoutHashtagsInput {
+  @Field(() => IntFieldUpdateOperationsInput, { nullable: true })
+  id?: IntFieldUpdateOperationsInput
+
+  @Field(() => NullableStringFieldUpdateOperationsInput, { nullable: true })
+  title?: NullableStringFieldUpdateOperationsInput
+
+  @Field(() => PostUpdatemediaUrlsInput, { nullable: true })
+  mediaUrls?: PostUpdatemediaUrlsInput
+
+  @Field(() => IntFieldUpdateOperationsInput, { nullable: true })
+  userId?: IntFieldUpdateOperationsInput
+
+  @Field(() => BoolFieldUpdateOperationsInput, { nullable: true })
+  isHideLikeAndCount?: BoolFieldUpdateOperationsInput
+
+  @Field(() => BoolFieldUpdateOperationsInput, { nullable: true })
+  isTurnOffComment?: BoolFieldUpdateOperationsInput
+
+  @Field(() => DateTimeFieldUpdateOperationsInput, { nullable: true })
+  createdAt?: DateTimeFieldUpdateOperationsInput
+
+  @Field(() => DateTimeFieldUpdateOperationsInput, { nullable: true })
+  updatedAt?: DateTimeFieldUpdateOperationsInput
+}

--- a/api/src/@generated/post/post-unchecked-update-without-user.input.ts
+++ b/api/src/@generated/post/post-unchecked-update-without-user.input.ts
@@ -5,6 +5,7 @@ import { NullableStringFieldUpdateOperationsInput } from '../prisma/nullable-str
 import { PostUpdatemediaUrlsInput } from './post-updatemedia-urls.input'
 import { BoolFieldUpdateOperationsInput } from '../prisma/bool-field-update-operations.input'
 import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input'
+import { HashtagUncheckedUpdateManyWithoutPostsNestedInput } from '../hashtag/hashtag-unchecked-update-many-without-posts-nested.input'
 
 @InputType()
 export class PostUncheckedUpdateWithoutUserInput {
@@ -28,4 +29,7 @@ export class PostUncheckedUpdateWithoutUserInput {
 
   @Field(() => DateTimeFieldUpdateOperationsInput, { nullable: true })
   updatedAt?: DateTimeFieldUpdateOperationsInput
+
+  @Field(() => HashtagUncheckedUpdateManyWithoutPostsNestedInput, { nullable: true })
+  hashtags?: HashtagUncheckedUpdateManyWithoutPostsNestedInput
 }

--- a/api/src/@generated/post/post-unchecked-update.input.ts
+++ b/api/src/@generated/post/post-unchecked-update.input.ts
@@ -5,6 +5,7 @@ import { NullableStringFieldUpdateOperationsInput } from '../prisma/nullable-str
 import { PostUpdatemediaUrlsInput } from './post-updatemedia-urls.input'
 import { BoolFieldUpdateOperationsInput } from '../prisma/bool-field-update-operations.input'
 import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input'
+import { HashtagUncheckedUpdateManyWithoutPostsNestedInput } from '../hashtag/hashtag-unchecked-update-many-without-posts-nested.input'
 
 @InputType()
 export class PostUncheckedUpdateInput {
@@ -31,4 +32,7 @@ export class PostUncheckedUpdateInput {
 
   @Field(() => DateTimeFieldUpdateOperationsInput, { nullable: true })
   updatedAt?: DateTimeFieldUpdateOperationsInput
+
+  @Field(() => HashtagUncheckedUpdateManyWithoutPostsNestedInput, { nullable: true })
+  hashtags?: HashtagUncheckedUpdateManyWithoutPostsNestedInput
 }

--- a/api/src/@generated/post/post-update-many-with-where-without-hashtags.input.ts
+++ b/api/src/@generated/post/post-update-many-with-where-without-hashtags.input.ts
@@ -1,0 +1,16 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { PostScalarWhereInput } from './post-scalar-where.input'
+import { Type } from 'class-transformer'
+import { PostUpdateManyMutationInput } from './post-update-many-mutation.input'
+
+@InputType()
+export class PostUpdateManyWithWhereWithoutHashtagsInput {
+  @Field(() => PostScalarWhereInput, { nullable: false })
+  @Type(() => PostScalarWhereInput)
+  where!: PostScalarWhereInput
+
+  @Field(() => PostUpdateManyMutationInput, { nullable: false })
+  @Type(() => PostUpdateManyMutationInput)
+  data!: PostUpdateManyMutationInput
+}

--- a/api/src/@generated/post/post-update-many-without-hashtags-nested.input.ts
+++ b/api/src/@generated/post/post-update-many-without-hashtags-nested.input.ts
@@ -1,0 +1,54 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { PostCreateWithoutHashtagsInput } from './post-create-without-hashtags.input'
+import { Type } from 'class-transformer'
+import { PostCreateOrConnectWithoutHashtagsInput } from './post-create-or-connect-without-hashtags.input'
+import { PostUpsertWithWhereUniqueWithoutHashtagsInput } from './post-upsert-with-where-unique-without-hashtags.input'
+import { Prisma } from '@prisma/client'
+import { PostWhereUniqueInput } from './post-where-unique.input'
+import { PostUpdateWithWhereUniqueWithoutHashtagsInput } from './post-update-with-where-unique-without-hashtags.input'
+import { PostUpdateManyWithWhereWithoutHashtagsInput } from './post-update-many-with-where-without-hashtags.input'
+import { PostScalarWhereInput } from './post-scalar-where.input'
+
+@InputType()
+export class PostUpdateManyWithoutHashtagsNestedInput {
+  @Field(() => [PostCreateWithoutHashtagsInput], { nullable: true })
+  @Type(() => PostCreateWithoutHashtagsInput)
+  create?: Array<PostCreateWithoutHashtagsInput>
+
+  @Field(() => [PostCreateOrConnectWithoutHashtagsInput], { nullable: true })
+  @Type(() => PostCreateOrConnectWithoutHashtagsInput)
+  connectOrCreate?: Array<PostCreateOrConnectWithoutHashtagsInput>
+
+  @Field(() => [PostUpsertWithWhereUniqueWithoutHashtagsInput], { nullable: true })
+  @Type(() => PostUpsertWithWhereUniqueWithoutHashtagsInput)
+  upsert?: Array<PostUpsertWithWhereUniqueWithoutHashtagsInput>
+
+  @Field(() => [PostWhereUniqueInput], { nullable: true })
+  @Type(() => PostWhereUniqueInput)
+  set?: Array<Prisma.AtLeast<PostWhereUniqueInput, 'id'>>
+
+  @Field(() => [PostWhereUniqueInput], { nullable: true })
+  @Type(() => PostWhereUniqueInput)
+  disconnect?: Array<Prisma.AtLeast<PostWhereUniqueInput, 'id'>>
+
+  @Field(() => [PostWhereUniqueInput], { nullable: true })
+  @Type(() => PostWhereUniqueInput)
+  delete?: Array<Prisma.AtLeast<PostWhereUniqueInput, 'id'>>
+
+  @Field(() => [PostWhereUniqueInput], { nullable: true })
+  @Type(() => PostWhereUniqueInput)
+  connect?: Array<Prisma.AtLeast<PostWhereUniqueInput, 'id'>>
+
+  @Field(() => [PostUpdateWithWhereUniqueWithoutHashtagsInput], { nullable: true })
+  @Type(() => PostUpdateWithWhereUniqueWithoutHashtagsInput)
+  update?: Array<PostUpdateWithWhereUniqueWithoutHashtagsInput>
+
+  @Field(() => [PostUpdateManyWithWhereWithoutHashtagsInput], { nullable: true })
+  @Type(() => PostUpdateManyWithWhereWithoutHashtagsInput)
+  updateMany?: Array<PostUpdateManyWithWhereWithoutHashtagsInput>
+
+  @Field(() => [PostScalarWhereInput], { nullable: true })
+  @Type(() => PostScalarWhereInput)
+  deleteMany?: Array<PostScalarWhereInput>
+}

--- a/api/src/@generated/post/post-update-with-where-unique-without-hashtags.input.ts
+++ b/api/src/@generated/post/post-update-with-where-unique-without-hashtags.input.ts
@@ -1,0 +1,17 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { Prisma } from '@prisma/client'
+import { PostWhereUniqueInput } from './post-where-unique.input'
+import { Type } from 'class-transformer'
+import { PostUpdateWithoutHashtagsInput } from './post-update-without-hashtags.input'
+
+@InputType()
+export class PostUpdateWithWhereUniqueWithoutHashtagsInput {
+  @Field(() => PostWhereUniqueInput, { nullable: false })
+  @Type(() => PostWhereUniqueInput)
+  where!: Prisma.AtLeast<PostWhereUniqueInput, 'id'>
+
+  @Field(() => PostUpdateWithoutHashtagsInput, { nullable: false })
+  @Type(() => PostUpdateWithoutHashtagsInput)
+  data!: PostUpdateWithoutHashtagsInput
+}

--- a/api/src/@generated/post/post-update-without-hashtags.input.ts
+++ b/api/src/@generated/post/post-update-without-hashtags.input.ts
@@ -1,0 +1,31 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { NullableStringFieldUpdateOperationsInput } from '../prisma/nullable-string-field-update-operations.input'
+import { PostUpdatemediaUrlsInput } from './post-updatemedia-urls.input'
+import { BoolFieldUpdateOperationsInput } from '../prisma/bool-field-update-operations.input'
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input'
+import { UserUpdateOneRequiredWithoutPostsNestedInput } from '../user/user-update-one-required-without-posts-nested.input'
+
+@InputType()
+export class PostUpdateWithoutHashtagsInput {
+  @Field(() => NullableStringFieldUpdateOperationsInput, { nullable: true })
+  title?: NullableStringFieldUpdateOperationsInput
+
+  @Field(() => PostUpdatemediaUrlsInput, { nullable: true })
+  mediaUrls?: PostUpdatemediaUrlsInput
+
+  @Field(() => BoolFieldUpdateOperationsInput, { nullable: true })
+  isHideLikeAndCount?: BoolFieldUpdateOperationsInput
+
+  @Field(() => BoolFieldUpdateOperationsInput, { nullable: true })
+  isTurnOffComment?: BoolFieldUpdateOperationsInput
+
+  @Field(() => DateTimeFieldUpdateOperationsInput, { nullable: true })
+  createdAt?: DateTimeFieldUpdateOperationsInput
+
+  @Field(() => DateTimeFieldUpdateOperationsInput, { nullable: true })
+  updatedAt?: DateTimeFieldUpdateOperationsInput
+
+  @Field(() => UserUpdateOneRequiredWithoutPostsNestedInput, { nullable: true })
+  user?: UserUpdateOneRequiredWithoutPostsNestedInput
+}

--- a/api/src/@generated/post/post-update-without-user.input.ts
+++ b/api/src/@generated/post/post-update-without-user.input.ts
@@ -4,6 +4,7 @@ import { NullableStringFieldUpdateOperationsInput } from '../prisma/nullable-str
 import { PostUpdatemediaUrlsInput } from './post-updatemedia-urls.input'
 import { BoolFieldUpdateOperationsInput } from '../prisma/bool-field-update-operations.input'
 import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input'
+import { HashtagUpdateManyWithoutPostsNestedInput } from '../hashtag/hashtag-update-many-without-posts-nested.input'
 
 @InputType()
 export class PostUpdateWithoutUserInput {
@@ -24,4 +25,7 @@ export class PostUpdateWithoutUserInput {
 
   @Field(() => DateTimeFieldUpdateOperationsInput, { nullable: true })
   updatedAt?: DateTimeFieldUpdateOperationsInput
+
+  @Field(() => HashtagUpdateManyWithoutPostsNestedInput, { nullable: true })
+  hashtags?: HashtagUpdateManyWithoutPostsNestedInput
 }

--- a/api/src/@generated/post/post-update.input.ts
+++ b/api/src/@generated/post/post-update.input.ts
@@ -5,6 +5,7 @@ import { PostUpdatemediaUrlsInput } from './post-updatemedia-urls.input'
 import { BoolFieldUpdateOperationsInput } from '../prisma/bool-field-update-operations.input'
 import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input'
 import { UserUpdateOneRequiredWithoutPostsNestedInput } from '../user/user-update-one-required-without-posts-nested.input'
+import { HashtagUpdateManyWithoutPostsNestedInput } from '../hashtag/hashtag-update-many-without-posts-nested.input'
 
 @InputType()
 export class PostUpdateInput {
@@ -28,4 +29,7 @@ export class PostUpdateInput {
 
   @Field(() => UserUpdateOneRequiredWithoutPostsNestedInput, { nullable: true })
   user?: UserUpdateOneRequiredWithoutPostsNestedInput
+
+  @Field(() => HashtagUpdateManyWithoutPostsNestedInput, { nullable: true })
+  hashtags?: HashtagUpdateManyWithoutPostsNestedInput
 }

--- a/api/src/@generated/post/post-upsert-with-where-unique-without-hashtags.input.ts
+++ b/api/src/@generated/post/post-upsert-with-where-unique-without-hashtags.input.ts
@@ -1,0 +1,22 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { Prisma } from '@prisma/client'
+import { PostWhereUniqueInput } from './post-where-unique.input'
+import { Type } from 'class-transformer'
+import { PostUpdateWithoutHashtagsInput } from './post-update-without-hashtags.input'
+import { PostCreateWithoutHashtagsInput } from './post-create-without-hashtags.input'
+
+@InputType()
+export class PostUpsertWithWhereUniqueWithoutHashtagsInput {
+  @Field(() => PostWhereUniqueInput, { nullable: false })
+  @Type(() => PostWhereUniqueInput)
+  where!: Prisma.AtLeast<PostWhereUniqueInput, 'id'>
+
+  @Field(() => PostUpdateWithoutHashtagsInput, { nullable: false })
+  @Type(() => PostUpdateWithoutHashtagsInput)
+  update!: PostUpdateWithoutHashtagsInput
+
+  @Field(() => PostCreateWithoutHashtagsInput, { nullable: false })
+  @Type(() => PostCreateWithoutHashtagsInput)
+  create!: PostCreateWithoutHashtagsInput
+}

--- a/api/src/@generated/post/post-where-unique.input.ts
+++ b/api/src/@generated/post/post-where-unique.input.ts
@@ -8,6 +8,7 @@ import { IntFilter } from '../prisma/int-filter.input'
 import { BoolFilter } from '../prisma/bool-filter.input'
 import { DateTimeFilter } from '../prisma/date-time-filter.input'
 import { UserRelationFilter } from '../user/user-relation-filter.input'
+import { HashtagListRelationFilter } from '../hashtag/hashtag-list-relation-filter.input'
 
 @InputType()
 export class PostWhereUniqueInput {
@@ -46,4 +47,7 @@ export class PostWhereUniqueInput {
 
   @Field(() => UserRelationFilter, { nullable: true })
   user?: UserRelationFilter
+
+  @Field(() => HashtagListRelationFilter, { nullable: true })
+  hashtags?: HashtagListRelationFilter
 }

--- a/api/src/@generated/post/post-where.input.ts
+++ b/api/src/@generated/post/post-where.input.ts
@@ -6,6 +6,7 @@ import { StringNullableListFilter } from '../prisma/string-nullable-list-filter.
 import { BoolFilter } from '../prisma/bool-filter.input'
 import { DateTimeFilter } from '../prisma/date-time-filter.input'
 import { UserRelationFilter } from '../user/user-relation-filter.input'
+import { HashtagListRelationFilter } from '../hashtag/hashtag-list-relation-filter.input'
 
 @InputType()
 export class PostWhereInput {
@@ -44,4 +45,7 @@ export class PostWhereInput {
 
   @Field(() => UserRelationFilter, { nullable: true })
   user?: UserRelationFilter
+
+  @Field(() => HashtagListRelationFilter, { nullable: true })
+  hashtags?: HashtagListRelationFilter
 }

--- a/api/src/@generated/post/post.model.ts
+++ b/api/src/@generated/post/post.model.ts
@@ -3,6 +3,8 @@ import { ObjectType } from '@nestjs/graphql'
 import { ID } from '@nestjs/graphql'
 import { Int } from '@nestjs/graphql'
 import { User } from '../user/user.model'
+import { Hashtag } from '../hashtag/hashtag.model'
+import { PostCount } from './post-count.output'
 
 @ObjectType()
 export class Post {
@@ -32,4 +34,10 @@ export class Post {
 
   @Field(() => User, { nullable: false })
   user?: User
+
+  @Field(() => [Hashtag], { nullable: true })
+  hashtags?: Array<Hashtag>
+
+  @Field(() => PostCount, { nullable: false })
+  _count?: PostCount
 }

--- a/api/src/post/entities/hashtag.entity.ts
+++ b/api/src/post/entities/hashtag.entity.ts
@@ -1,0 +1,27 @@
+import { ID } from '@nestjs/graphql'
+import { Field } from '@nestjs/graphql'
+import { ObjectType } from '@nestjs/graphql'
+
+import { Post } from './post.entity'
+import { HashtagCount } from '~/@generated/hashtag/hashtag-count.output'
+
+@ObjectType()
+export class Hashtag {
+  @Field(() => ID, { nullable: false })
+  id!: number
+
+  @Field(() => String, { nullable: false })
+  tag!: string
+
+  @Field(() => Date, { nullable: false })
+  createdAt!: Date
+
+  @Field(() => Date, { nullable: false })
+  updatedAt!: Date
+
+  @Field(() => [Post], { nullable: true })
+  posts?: Array<Post>
+
+  @Field(() => HashtagCount, { nullable: false })
+  _count?: HashtagCount
+}

--- a/api/src/post/entities/post.entity.ts
+++ b/api/src/post/entities/post.entity.ts
@@ -1,6 +1,7 @@
 import { ObjectType, Field, Int, ID } from '@nestjs/graphql'
 
 import { User } from '~/user/user.entity'
+import { Hashtag } from './hashtag.entity'
 
 @ObjectType()
 export class Post {
@@ -21,6 +22,9 @@ export class Post {
 
   @Field(() => Int, { nullable: true })
   userId?: number
+
+  @Field(() => [Hashtag], { nullable: true })
+  hashtags?: Array<Hashtag>
 
   @Field(() => Date, { nullable: true })
   createdAt?: Date

--- a/api/src/post/post.service.ts
+++ b/api/src/post/post.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common'
+import { ForbiddenException, Injectable } from '@nestjs/common'
 
 import { Post } from '~/@generated/post/post.model'
 import { PrismaService } from '~/prisma/prisma.service'
@@ -11,6 +11,12 @@ export class PostService {
   constructor(private prisma: PrismaService) {}
 
   async create(createPostInput: PostCreateWithoutUserInput, userId: number): Promise<Post> {
+    const { mediaUrls } = createPostInput
+
+    if (mediaUrls.set.length === 0) {
+      throw new ForbiddenException('Photos/Videos is required field. Pleace re-upload!')
+    }
+
     return await this.prisma.post.create({
       data: {
         ...createPostInput,
@@ -20,16 +26,9 @@ export class PostService {
           }
         }
       },
-      select: {
-        id: true,
-        title: true,
-        userId: true,
-        mediaUrls: true,
-        createdAt: true,
-        updatedAt: true,
-        isHideLikeAndCount: true,
-        isTurnOffComment: true,
-        user: true
+      include: {
+        user: true,
+        hashtags: true
       }
     })
   }
@@ -37,16 +36,9 @@ export class PostService {
   async findAll(args: FindManyPostArgs): Promise<Post[]> {
     return await this.prisma.post.findMany({
       ...args,
-      select: {
-        id: true,
-        title: true,
-        userId: true,
-        mediaUrls: true,
-        createdAt: true,
-        updatedAt: true,
-        isHideLikeAndCount: true,
-        isTurnOffComment: true,
-        user: true
+      include: {
+        user: true,
+        hashtags: true
       }
     })
   }
@@ -54,16 +46,9 @@ export class PostService {
   async findOne(args: FindFirstPostOrThrowArgs): Promise<Post> {
     return await this.prisma.post.findFirstOrThrow({
       ...args,
-      select: {
-        id: true,
-        title: true,
-        userId: true,
-        mediaUrls: true,
-        createdAt: true,
-        updatedAt: true,
-        isHideLikeAndCount: true,
-        isTurnOffComment: true,
-        user: true
+      include: {
+        user: true,
+        hashtags: true
       }
     })
   }

--- a/api/src/schema.gql
+++ b/api/src/schema.gql
@@ -30,6 +30,68 @@ input EnumRoleFilter {
   notIn: [Role!]
 }
 
+type Hashtag {
+  _count: HashtagCount!
+  createdAt: DateTime!
+  id: ID!
+  posts: [Post!]
+  tag: String!
+  updatedAt: DateTime!
+}
+
+type HashtagCount {
+  posts: Int!
+}
+
+input HashtagCreateNestedManyWithoutPostsInput {
+  connect: [HashtagWhereUniqueInput!]
+  connectOrCreate: [HashtagCreateOrConnectWithoutPostsInput!]
+  create: [HashtagCreateWithoutPostsInput!]
+}
+
+input HashtagCreateOrConnectWithoutPostsInput {
+  create: HashtagCreateWithoutPostsInput!
+  where: HashtagWhereUniqueInput!
+}
+
+input HashtagCreateWithoutPostsInput {
+  createdAt: DateTime
+  tag: String!
+  updatedAt: DateTime
+}
+
+input HashtagListRelationFilter {
+  every: HashtagWhereInput
+  none: HashtagWhereInput
+  some: HashtagWhereInput
+}
+
+input HashtagOrderByRelationAggregateInput {
+  _count: SortOrder
+}
+
+input HashtagWhereInput {
+  AND: [HashtagWhereInput!]
+  NOT: [HashtagWhereInput!]
+  OR: [HashtagWhereInput!]
+  createdAt: DateTimeFilter
+  id: IntFilter
+  posts: PostListRelationFilter
+  tag: StringFilter
+  updatedAt: DateTimeFilter
+}
+
+input HashtagWhereUniqueInput {
+  AND: [HashtagWhereInput!]
+  NOT: [HashtagWhereInput!]
+  OR: [HashtagWhereInput!]
+  createdAt: DateTimeFilter
+  id: Int
+  posts: PostListRelationFilter
+  tag: String
+  updatedAt: DateTimeFilter
+}
+
 input IntFilter {
   equals: Int
   gt: Int
@@ -127,6 +189,7 @@ enum NullsOrder {
 
 type Post {
   createdAt: DateTime
+  hashtags: [Hashtag!]
   id: ID!
   isHideLikeAndCount: Boolean!
   isTurnOffComment: Boolean!
@@ -166,6 +229,7 @@ input PostCreateOrConnectWithoutUserInput {
 
 input PostCreateWithoutUserInput {
   createdAt: DateTime
+  hashtags: HashtagCreateNestedManyWithoutPostsInput
   isHideLikeAndCount: Boolean
   isTurnOffComment: Boolean
   mediaUrls: PostCreatemediaUrlsInput
@@ -189,6 +253,7 @@ input PostOrderByRelationAggregateInput {
 
 input PostOrderByWithRelationInput {
   createdAt: SortOrder
+  hashtags: HashtagOrderByRelationAggregateInput
   id: SortOrder
   isHideLikeAndCount: SortOrder
   isTurnOffComment: SortOrder
@@ -215,6 +280,7 @@ input PostWhereInput {
   NOT: [PostWhereInput!]
   OR: [PostWhereInput!]
   createdAt: DateTimeFilter
+  hashtags: HashtagListRelationFilter
   id: IntFilter
   isHideLikeAndCount: BoolFilter
   isTurnOffComment: BoolFilter
@@ -230,6 +296,7 @@ input PostWhereUniqueInput {
   NOT: [PostWhereInput!]
   OR: [PostWhereInput!]
   createdAt: DateTimeFilter
+  hashtags: HashtagListRelationFilter
   id: Int
   isHideLikeAndCount: BoolFilter
   isTurnOffComment: BoolFilter


### PR DESCRIPTION
## Issue Link

- https://www.notion.so/MM-30-BE-Implement-Post-Hashtags-e5c405b7e6b8459cbb972c9acaf32224?pvs=4

## Definition of Done

- [x] Added Many to Many relationship of hastags to posts
- [x] Added hashtags seeder 

## Notes

- N/A

## Pre-condition

### Docker Setup

- docker-compose up --build

### Local Setup

- cd client && npm install && npm run dev
- cd api && npm install && npm run dev
- goto the http://localhost:3030/graphql

## Expected Output

- It should now have a relationship of hashtags in the posts with many to many relationships

## Screenshots/Recordings

![image](https://github.com/Osomware/meme-me/assets/108642414/9b092aab-abc5-46a4-92b6-46b7ecbbc37f)
