### PR TITLE
MM-32 - [BE] Implement Search Hashtag

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -11,6 +11,7 @@ import { UserModule } from '~/user/user.module'
 import { PostModule } from './post/post.module'
 import { PrismaService } from '~/prisma/prisma.service'
 import { AccessTokenGuard } from '~/auth/guards/accessToken.guard'
+import { PostHashtagModule } from './post-hashtag/post-hashtag.module'
 
 @Module({
   imports: [
@@ -24,7 +25,8 @@ import { AccessTokenGuard } from '~/auth/guards/accessToken.guard'
     }),
     AuthModule,
     UserModule,
-    PostModule
+    PostModule,
+    PostHashtagModule
   ],
   controllers: [],
   providers: [PrismaService, { provide: APP_GUARD, useClass: AccessTokenGuard }]

--- a/api/src/post-hashtag/dto/create-post-hashtag.input.ts
+++ b/api/src/post-hashtag/dto/create-post-hashtag.input.ts
@@ -1,0 +1,7 @@
+import { InputType, Int, Field } from '@nestjs/graphql';
+
+@InputType()
+export class CreatePostHashtagInput {
+  @Field(() => Int, { description: 'Example field (placeholder)' })
+  exampleField: number;
+}

--- a/api/src/post-hashtag/dto/update-post-hashtag.input.ts
+++ b/api/src/post-hashtag/dto/update-post-hashtag.input.ts
@@ -1,0 +1,8 @@
+import { CreatePostHashtagInput } from './create-post-hashtag.input';
+import { InputType, Field, Int, PartialType } from '@nestjs/graphql';
+
+@InputType()
+export class UpdatePostHashtagInput extends PartialType(CreatePostHashtagInput) {
+  @Field(() => Int)
+  id: number;
+}

--- a/api/src/post-hashtag/entities/post-hashtag.entity.ts
+++ b/api/src/post-hashtag/entities/post-hashtag.entity.ts
@@ -1,0 +1,24 @@
+import { ObjectType, Field, ID } from '@nestjs/graphql'
+
+import { HashtagCount } from '~/@generated/hashtag/hashtag-count.output'
+
+@ObjectType()
+export class PostHashtag {
+  @Field(() => ID, { nullable: false })
+  id!: number
+
+  @Field(() => String, { nullable: false })
+  tag!: string
+
+  @Field(() => Date, { nullable: false })
+  createdAt!: Date
+
+  @Field(() => Date, { nullable: false })
+  updatedAt!: Date
+
+  @Field(() => [PostHashtag], { nullable: true })
+  postHashtags?: Array<PostHashtag>
+
+  @Field(() => HashtagCount, { nullable: false })
+  _count?: HashtagCount
+}

--- a/api/src/post-hashtag/post-hashtag.module.ts
+++ b/api/src/post-hashtag/post-hashtag.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common'
+
+import { PrismaService } from '~/prisma/prisma.service'
+import { PostHashtagService } from './post-hashtag.service'
+import { PostHashtagResolver } from './post-hashtag.resolver'
+
+@Module({
+  providers: [PostHashtagResolver, PostHashtagService, PrismaService]
+})
+export class PostHashtagModule {}

--- a/api/src/post-hashtag/post-hashtag.resolver.ts
+++ b/api/src/post-hashtag/post-hashtag.resolver.ts
@@ -1,0 +1,21 @@
+import { Resolver, Query, Args } from '@nestjs/graphql'
+
+import { PostHashtagService } from './post-hashtag.service'
+import { PostHashtag } from './entities/post-hashtag.entity'
+import { Hashtag } from '~/@generated/hashtag/hashtag.model'
+import { FindManyHashtagArgs } from '~/@generated/hashtag/find-many-hashtag.args'
+
+@Resolver(() => PostHashtag)
+export class PostHashtagResolver {
+  constructor(private readonly postHashtagService: PostHashtagService) {}
+
+  @Query(() => [PostHashtag], { name: 'getAllPostHashtag' })
+  async findAll(@Args() args: FindManyHashtagArgs): Promise<Hashtag[]> {
+    return this.postHashtagService.findAll(args)
+  }
+
+  @Query(() => [PostHashtag], { name: 'searchHashtag' })
+  async searchHashtags(@Args('query') query: string): Promise<Hashtag[]> {
+    return this.postHashtagService.search(query)
+  }
+}

--- a/api/src/post-hashtag/post-hashtag.service.ts
+++ b/api/src/post-hashtag/post-hashtag.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@nestjs/common'
+
+import { PrismaService } from '~/prisma/prisma.service'
+import { Hashtag } from '~/@generated/hashtag/hashtag.model'
+import { FindManyHashtagArgs } from '~/@generated/hashtag/find-many-hashtag.args'
+
+@Injectable()
+export class PostHashtagService {
+  constructor(private prisma: PrismaService) {}
+
+  async findAll(args: FindManyHashtagArgs): Promise<Hashtag[]> {
+    return await this.prisma.hashtag.findMany(args)
+  }
+
+  async search(query: string): Promise<Hashtag[]> {
+    return await this.prisma.hashtag.findMany({
+      where: {
+        tag: {
+          contains: query,
+          mode: 'insensitive'
+        }
+      }
+    })
+  }
+}

--- a/api/src/schema.gql
+++ b/api/src/schema.gql
@@ -60,9 +60,24 @@ input HashtagCreateWithoutPostHashtagsInput {
   updatedAt: DateTime
 }
 
+input HashtagOrderByWithRelationInput {
+  createdAt: SortOrder
+  id: SortOrder
+  postHashtags: PostHashtagOrderByRelationAggregateInput
+  tag: SortOrder
+  updatedAt: SortOrder
+}
+
 input HashtagRelationFilter {
   is: HashtagWhereInput
   isNot: HashtagWhereInput
+}
+
+enum HashtagScalarFieldEnum {
+  createdAt
+  id
+  tag
+  updatedAt
 }
 
 input HashtagWhereInput {
@@ -236,6 +251,15 @@ input PostCreatemediaUrlsInput {
   set: [String!]!
 }
 
+type PostHashtag {
+  _count: HashtagCount!
+  createdAt: DateTime!
+  id: ID!
+  postHashtags: [PostHashtag!]
+  tag: String!
+  updatedAt: DateTime!
+}
+
 input PostHashtagCreateManyPostInput {
   createdAt: DateTime
   hashtagId: Int!
@@ -383,6 +407,8 @@ type Query {
   findAllPost(cursor: PostWhereUniqueInput, distinct: [PostScalarFieldEnum!], orderBy: [PostOrderByWithRelationInput!], skip: Int, take: Int, where: PostWhereInput): [Post!]!
   findOnePost(cursor: PostWhereUniqueInput, distinct: [PostScalarFieldEnum!], orderBy: [PostOrderByWithRelationInput!], skip: Int, take: Int, where: PostWhereInput): Post!
   findOneUser(cursor: UserWhereUniqueInput, distinct: [UserScalarFieldEnum!], orderBy: [UserOrderByWithRelationInput!], skip: Int, take: Int, where: UserWhereInput): User!
+  getAllPostHashtag(cursor: HashtagWhereUniqueInput, distinct: [HashtagScalarFieldEnum!], orderBy: [HashtagOrderByWithRelationInput!], skip: Int, take: Int, where: HashtagWhereInput): [PostHashtag!]!
+  searchHashtag(query: String!): [PostHashtag!]!
 }
 
 enum QueryMode {


### PR DESCRIPTION
## Issue Link

- https://www.notion.so/MM-32-BE-Implement-Search-Hashtag-538e10921a5844a784064f338c4796b8?pvs=4

## Definition of Done

- [x] Generate Nest Resource for Post Hastag
- [x] Create Search Hashtag Graphql Query

## Notes

- N/A

## Pre-condition

### Docker Setup

- docker-compose up --build

### Local Setup

- cd client && npm install && npm run dev
- cd api && npm install && npm run dev
- goto the http://localhost:3030/graphql
```
query SearchHashtag($query: String!) {
  searchHashtag(query: $query) {
    id
    tag
  }
}
```

input 
```
{
  "query": <your string query>
}
```

## Expected Output

- It should now have the search functionality in backend for Hashtag

## Screenshots/Recordings
[search.webm](https://github.com/Osomware/meme-me/assets/108642414/40d98ad2-daf5-43ae-b1df-aece023e235f)

