### PR TITLE
MM-34 - [FE/BE] Implement Save Post with Tags

### DIFF
--- a/api/prisma/migrations/20230816061415_add_post_hastag_cascade/migration.sql
+++ b/api/prisma/migrations/20230816061415_add_post_hastag_cascade/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "PostHashtag" DROP CONSTRAINT "PostHashtag_postId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "PostHashtag" ADD CONSTRAINT "PostHashtag_postId_fkey" FOREIGN KEY ("postId") REFERENCES "Post"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -53,7 +53,7 @@ model Post {
 
 model PostHashtag {
   id        Int      @id @default(autoincrement())
-  post      Post     @relation(fields: [postId], references: [id])
+  post      Post     @relation(fields: [postId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   postId    Int
   hashtag   Hashtag  @relation(fields: [hashtagId], references: [id])
   hashtagId Int

--- a/api/src/post-hashtag/dto/create-post-hashtag.input.ts
+++ b/api/src/post-hashtag/dto/create-post-hashtag.input.ts
@@ -1,7 +1,7 @@
-import { InputType, Int, Field } from '@nestjs/graphql';
+import { InputType, Int, Field } from '@nestjs/graphql'
 
 @InputType()
 export class CreatePostHashtagInput {
   @Field(() => Int, { description: 'Example field (placeholder)' })
-  exampleField: number;
+  exampleField: number
 }

--- a/api/src/post-hashtag/dto/update-post-hashtag.input.ts
+++ b/api/src/post-hashtag/dto/update-post-hashtag.input.ts
@@ -1,8 +1,8 @@
-import { CreatePostHashtagInput } from './create-post-hashtag.input';
-import { InputType, Field, Int, PartialType } from '@nestjs/graphql';
+import { CreatePostHashtagInput } from './create-post-hashtag.input'
+import { InputType, Field, Int, PartialType } from '@nestjs/graphql'
 
 @InputType()
 export class UpdatePostHashtagInput extends PartialType(CreatePostHashtagInput) {
   @Field(() => Int)
-  id: number;
+  id: number
 }

--- a/client/src/components/molecules/EmojiPopoverPicker/index.tsx
+++ b/client/src/components/molecules/EmojiPopoverPicker/index.tsx
@@ -15,10 +15,11 @@ const EmojiPicker = dynamic(async () => await import('@emoji-mart/react'), {
 type Props = {
   handleEmojiSelect: (emoji: Emoji) => void
   panelPosition?: string
+  isSubmitting: boolean
 } & ComponentProps<'div'>
 
 const EmojiPopoverPicker: FC<Props> = (props): JSX.Element => {
-  const { handleEmojiSelect, panelPosition, ...rest } = props
+  const { handleEmojiSelect, panelPosition, isSubmitting, ...rest } = props
 
   return (
     <Popover as="div" className="">
@@ -29,8 +30,10 @@ const EmojiPopoverPicker: FC<Props> = (props): JSX.Element => {
             className={classNames(
               'text-slate-400 outline-none hover:text-slate-500',
               'transition duration-150 ease-in-out',
-              open ? '!text-slate-500' : ''
+              open ? '!text-slate-500' : '',
+              isSubmitting ? 'disabled:cursor-not-allowed disabled:opacity-50' : ''
             )}
+            disabled={isSubmitting}
           >
             <WinkingFace theme="outline" size="22" strokeWidth={2} />
           </Popover.Button>

--- a/client/src/components/organisms/UploadPostModal/index.tsx
+++ b/client/src/components/organisms/UploadPostModal/index.tsx
@@ -118,7 +118,17 @@ const UploadPostModal: FC<UploadPostModalProps> = ({ isOpen, closeModal }): JSX.
             set: data?.mediaUrls ?? []
           },
           isHideLikeAndCount: isHideCountPostAndLike,
-          isTurnOffComment
+          isTurnOffComment,
+          postHashtags: {
+            create: tags?.map((hashtag) => ({
+              hashtag: {
+                connectOrCreate: {
+                  where: { tag: hashtag.text },
+                  create: { tag: hashtag.text }
+                }
+              }
+            }))
+          }
         },
         {
           onSettled() {
@@ -289,7 +299,8 @@ const UploadPostModal: FC<UploadPostModalProps> = ({ isOpen, closeModal }): JSX.
                   <div className="flex items-center justify-between text-secondary-200">
                     <EmojiPopoverPicker
                       {...{
-                        handleEmojiSelect
+                        handleEmojiSelect,
+                        isSubmitting
                       }}
                     />
                     <span className="text-xs font-normal">{`${
@@ -346,7 +357,8 @@ const UploadPostModal: FC<UploadPostModalProps> = ({ isOpen, closeModal }): JSX.
                               'Only you will see the total number of likes and views on this post. You change this alter by going to the ... menu at the top of the post. To hide like counts on other’s post, go to your account settings.',
                             checked: isHideCountPostAndLike,
                             onChange: setIsHideCountPostAndLike,
-                            isActive: isHideCountPostAndLike
+                            isActive: isHideCountPostAndLike,
+                            disabled: isSubmitting
                           }}
                         />
                         <SwitchGroupTemplate
@@ -356,7 +368,8 @@ const UploadPostModal: FC<UploadPostModalProps> = ({ isOpen, closeModal }): JSX.
                               'You can change this later by going to the ... menu at the top of your post.',
                             checked: isTurnOffComment,
                             onChange: setTurnOffComment,
-                            isActive: isTurnOffComment
+                            isActive: isTurnOffComment,
+                            disabled: isSubmitting
                           }}
                         />
                       </Disclosure.Panel>

--- a/client/src/components/templates/SwitchGroupTemplate/index.tsx
+++ b/client/src/components/templates/SwitchGroupTemplate/index.tsx
@@ -8,10 +8,11 @@ export type SwitchGroupTemplateProps = {
   onChange: Dispatch<SetStateAction<boolean>>
   isActive: boolean
   content: string
+  disabled: boolean
 }
 
 const SwitchGroupTemplate: FC<SwitchGroupTemplateProps> = (props): JSX.Element => {
-  const { label, checked, onChange, isActive, content } = props
+  const { label, checked, onChange, isActive, content, disabled } = props
 
   return (
     <section>
@@ -21,11 +22,13 @@ const SwitchGroupTemplate: FC<SwitchGroupTemplateProps> = (props): JSX.Element =
           <Switch
             checked={checked}
             onChange={onChange}
+            disabled={disabled}
             className={clsx(
               isActive ? 'bg-primary' : 'bg-secondary-200',
               'relative inline-flex h-6 w-12 items-center rounded-full transition-colors',
               'focus:outline-none focus:ring-2 shrink-0',
-              'focus:ring-offset-2 focus:ring-primary-200'
+              'focus:ring-offset-2 focus:ring-primary-200',
+              disabled ? 'disabled:cursor-not-allowed disabled:opacity-50' : ''
             )}
           >
             <span

--- a/client/src/utils/types/input.ts
+++ b/client/src/utils/types/input.ts
@@ -5,4 +5,18 @@ export type PostRequestInput = {
   }
   isHideLikeAndCount: boolean
   isTurnOffComment: boolean
+  postHashtags: {
+    create: Array<{
+      hashtag: {
+        connectOrCreate: {
+          where: {
+            tag: string
+          }
+          create: {
+            tag: string
+          }
+        }
+      }
+    }>
+  }
 }


### PR DESCRIPTION
## Issue Link

- https://www.notion.so/MM-34-FE-BE-Implement-Save-Post-with-Tags-10e148efc06042cc986d68ef4b6df15b?pvs=4

## Definition of Done

- [x] Modified PostHashtag Model with Cascade constraints 
- [x] Save Post with Tags `connectOrCreate` implementation 
- [x] Disabled Fields during Post Submission except Tags component 

## Notes

- Tags are not displayed in the Home Feeds yet

## Pre-condition

### Docker Setup

- docker-compose up --build

### Local Setup

- cd client && npm install && npm run dev
- cd api && npm install && npm run dev
- go to the home page and create some post with tags

## Expected Output

- It should now have an integration of Post with Multiple Tags (optional field)

## Screenshots/Recordings
[newgono.webm](https://github.com/Osomware/meme-me/assets/108642414/af7b6c5d-0c52-4ed7-bd05-0b852562a810)

