### PR TITLE
MM-36 - [FE] Display User profile By Username

### DIFF
--- a/client/src/components/atoms/Skeletons/ProfilePageSkeletonLoading/index.tsx
+++ b/client/src/components/atoms/Skeletons/ProfilePageSkeletonLoading/index.tsx
@@ -1,0 +1,52 @@
+import clsx from 'clsx'
+import React, { FC } from 'react'
+
+type SkeletonProps = {
+  width: string
+  height: string
+}
+
+const Skeleton: FC<SkeletonProps> = ({ width, height }) => {
+  return <div className={clsx('bg-secondary-100/30 rounded-full', width, height)}></div>
+}
+
+const ProfilePageSkeletonLoading: FC = () => {
+  return (
+    <div role="status" className="animate-pulse w-full">
+      <header className="flex items-center space-x-2 px-4 py-3">
+        <Skeleton width="w-48" height="h-2" />
+      </header>
+      <hr />
+      <div className="flex flex-col gap-y-4 md:flex-row items-center mt-4 space-x-3 max-w-3xl w-full mx-auto px-4 md:px-8 py-8">
+        <svg
+          className="w-28 h-28 text-secondary-100/30"
+          aria-hidden="true"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="currentColor"
+          viewBox="0 0 20 20"
+        >
+          <path d="M10 0a10 10 0 1 0 10 10A10.011 10.011 0 0 0 10 0Zm0 5a3 3 0 1 1 0 6 3 3 0 0 1 0-6Zm0 13a8.949 8.949 0 0 1-4.951-1.488A3.987 3.987 0 0 1 9 13h2a3.987 3.987 0 0 1 3.951 3.512A8.949 8.949 0 0 1 10 18Z" />
+        </svg>
+        <div>
+          <Skeleton width="w-48" height="h-2.5" />
+          <Skeleton width="w-48" height="h-2" />
+        </div>
+      </div>
+      <hr />
+      <div className="max-w-3xl w-full mx-auto">
+        <div className="sm:ml-[184px] md:ml-40 py-3 flex items-center justify-evenly sm:justify-normal gap-x-4 md:gap-x-8">
+          <Skeleton width="w-12" height="h-2" />
+          <Skeleton width="w-12" height="h-2" />
+          <Skeleton width="w-12" height="h-2" />
+        </div>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 max-w-3xl w-full mx-auto gap-2 px-4">
+        {Array.from({ length: 9 }).map((_, index) => (
+          <Skeleton key={index} width="w-full" height="h-52 rounded-sm mb-12" />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default ProfilePageSkeletonLoading

--- a/client/src/graphql/queries/userQuery.ts
+++ b/client/src/graphql/queries/userQuery.ts
@@ -1,13 +1,13 @@
 import { gql } from 'graphql-request'
 
 export const USER_QUERY = gql`
-  query GetCurrentUser($id: Int!) {
-    findOne(id: $id) {
+  query FindOneUser($where: UserWhereInput) {
+    findOneUser(where: $where) {
+      email
       id
       name
-      email
-      username
       role
+      username
     }
   }
 `

--- a/client/src/hooks/useUser.ts
+++ b/client/src/hooks/useUser.ts
@@ -5,20 +5,35 @@ import { IUser } from '~/utils/interface/User'
 import { USER_QUERY } from '~/graphql/queries/userQuery'
 
 type Result = {
-  findOne: IUser
+  findOneUser: IUser
 }
 
 type UserQueryType = UseQueryResult<Result, unknown>
 
 type ReturnType = {
-  getCurrentUser: (id: number, isReady?: boolean) => UserQueryType
+  getCurrentUser: (username: string, isReady?: boolean) => UserQueryType
+}
+
+export const userKeys = {
+  all: ['users'] as const,
+  lists: () => [...userKeys.all, 'list'] as const,
+  list: (filters: string) => [...userKeys.lists(), { filters }] as const,
+  details: () => [...userKeys.all, 'detail'] as const,
+  detail: (username: string) => [...userKeys.details(), username] as const
 }
 
 const useUser = (): ReturnType => {
-  const getCurrentUser = (id: number, isReady?: boolean): UserQueryType =>
+  const getCurrentUser = (username: string, isReady?: boolean): UserQueryType =>
     useQuery<Result, Error>({
-      queryKey: ['user'],
-      queryFn: async () => await gqlClient.request(USER_QUERY, { id }),
+      queryKey: userKeys.detail(username),
+      queryFn: async () =>
+        await gqlClient.request(USER_QUERY, {
+          where: {
+            username: {
+              equals: username
+            }
+          }
+        }),
       select: (data: Result) => data,
       enabled: isReady as boolean
     })

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -1,5 +1,6 @@
-import React from 'react'
 import type { NextPage } from 'next'
+import Alert from '~/components/atoms/Alert'
+import React, { FC, ReactNode } from 'react'
 
 import usePost from '~/hooks/usePost'
 import PostList from '~/components/molecules/PostList'
@@ -12,11 +13,57 @@ import PostSkeletonLoading from '~/components/atoms/Skeletons/PostSkeletonLoadin
 
 const Home: NextPage = (): JSX.Element => {
   const { getAllPosts } = usePost()
-  const { data: dataPosts, isLoading: isLoadingPosts } = getAllPosts()
+  const { data: dataPosts, isLoading: isLoadingPosts, isError } = getAllPosts()
 
   // SCREEN SIZE CONDITION HOOKS
   const isMaxWidth = useScreenCondition('(max-width: 1380px)')
 
+  if (isLoadingPosts) {
+    return (
+      <PageLayout
+        {...{
+          isMaxWidth
+        }}
+      >
+        <PostSkeletonLoading />
+      </PageLayout>
+    )
+  }
+
+  if (isError) {
+    return (
+      <PageLayout
+        {...{
+          isMaxWidth
+        }}
+      >
+        <div className="py-6">
+          <Alert type="error" message="Something went wrong fetching data" />
+        </div>
+      </PageLayout>
+    )
+  }
+
+  return (
+    <PageLayout
+      {...{
+        isMaxWidth
+      }}
+    >
+      <>
+        {dataPosts?.findAllPost.length === 0 ? (
+          <div className="mt-3">
+            <p className="py-2 text-center text-sm text-secondary-200">No Post</p>
+          </div>
+        ) : (
+          <PostList posts={dataPosts?.findAllPost ?? []} />
+        )}
+      </>
+    </PageLayout>
+  )
+}
+
+const PageLayout: FC<{ children: ReactNode; isMaxWidth: boolean }> = ({ children, isMaxWidth }) => {
   return (
     <HomeLayout metaTitle="Home" className="flex">
       <article className="max-w-3xl w-full mx-auto px-8 py-6">
@@ -27,20 +74,7 @@ const Home: NextPage = (): JSX.Element => {
           <h2 className="text-secondary font-bold">Feeds</h2>
           <FeedFilterTab />
         </div>
-
-        {isLoadingPosts ? (
-          <PostSkeletonLoading />
-        ) : (
-          <>
-            {dataPosts?.findAllPost.length === 0 ? (
-              <div className="mt-3">
-                <p className="py-2 text-center text-sm text-secondary-200">No Post</p>
-              </div>
-            ) : (
-              <PostList posts={dataPosts?.findAllPost ?? []} />
-            )}
-          </>
-        )}
+        {children}
       </article>
       {!isMaxWidth && (
         <aside className="border-l border-stroke-3 h-full w-80 shrink-0 sticky top-0 mx-1">


### PR DESCRIPTION
## Issue Link

- https://www.notion.so/MM-36-FE-Display-User-profile-By-Username-02da78d037d743a8baaebfa48f8c6009?pvs=4

## Definition of Done

- [x] Fix Homepage Loading and Error Implementation
- [x] Fetch User by Username  

## Notes

- If you are the authenticated user you will view the settings and update button

## Pre-condition

### Docker Setup

- docker-compose up --build

### Local Setup

- cd client && npm install && npm run dev
- cd api && npm install && npm run dev
- goto the http://localhost:3030/graphql

## Expected Output

- It should now have a profile display in each authenticated user by username
- Only authenticated user are able to view the user profile

## Screenshots/Recordings

[fetch user by username.webm](https://github.com/Osomware/meme-me/assets/108642414/4bb435df-6481-48db-b1a8-e12616ad48cb)
