### PR TITLE
MM-37 - [FE/BE] Fix Display Hashtag in Post Modal

### DIFF
--- a/api/src/post/post.service.ts
+++ b/api/src/post/post.service.ts
@@ -52,7 +52,11 @@ export class PostService {
       ...args,
       include: {
         user: true,
-        postHashtags: true
+        postHashtags: {
+          include: {
+            hashtag: true
+          }
+        }
       }
     })
   }

--- a/client/src/components/molecules/CopyLink/index.tsx
+++ b/client/src/components/molecules/CopyLink/index.tsx
@@ -11,9 +11,7 @@ const CopyLink: FC<CopyLinkProps> = ({ url }): JSX.Element => {
 
   const copyLink = (): void => {
     if (inputRef.current !== null) {
-      inputRef.current.select()
-      inputRef.current.setSelectionRange(0, 99999)
-      document.execCommand('copy')
+      void navigator.clipboard.writeText(inputRef.current.value)
       toast.success('Link copied to clipboard!')
     }
   }

--- a/client/src/components/organisms/Post/index.tsx
+++ b/client/src/components/organisms/Post/index.tsx
@@ -35,19 +35,19 @@ const Post: FC<PostProps> = ({ post, state: { setIsModalOpen } }): JSX.Element =
   const reactions = [
     {
       type: 'heart',
-      count: '2.6M'
+      count: '0'
     },
     {
       type: 'comment',
-      count: '16.4K'
+      count: '0'
     },
     {
       type: 'bookmark',
-      count: '448.3K'
+      count: '0'
     },
     {
       type: 'share',
-      count: '14.1K'
+      count: '0'
     }
   ]
 
@@ -106,15 +106,22 @@ const Post: FC<PostProps> = ({ post, state: { setIsModalOpen } }): JSX.Element =
             <div className="relative shrink-0 max-w-[355px] w-[355px]">
               <div
                 className={clsx(
-                  'h-[470px] border-4 flex justify-center items-center border-white',
-                  'shadow overflow-hidden rounded-2xl bg-black'
+                  'h-[470px] border-[5px] flex justify-center items-center border-white',
+                  'shadow overflow-hidden rounded-lg bg-black'
                 )}
               >
                 <Carousel>
                   {mediaUrls.map((asset, idx) => {
                     if (asset.endsWith('.mp4')) {
                       return (
-                        <video key={idx} src={asset} autoPlay muted loop className="w-full">
+                        <video
+                          key={idx}
+                          src={asset}
+                          autoPlay
+                          muted
+                          loop
+                          className="w-full rounded-md"
+                        >
                           Your browser does not support the video tag.
                         </video>
                       )

--- a/client/src/graphql/queries/postsQuery.ts
+++ b/client/src/graphql/queries/postsQuery.ts
@@ -42,6 +42,11 @@ export const GET_ONE_POST_QUERY = gql`
         role
         username
       }
+      postHashtags {
+        hashtag {
+          tag
+        }
+      }
     }
   }
 `


### PR DESCRIPTION
## Issue Link

- https://www.notion.so/MM-37-FE-BE-Fix-Display-Hashtag-in-Post-Modal-074f6c4b237a499bae66c95812c8d9ce?pvs=4

## Definition of Done

- [x] Display hashtag in the Post Modal Title
- [x] Reset Post Reaction to 0 
- [x] Fix Copy Link into Proper link
- [x] Clear Replies to empty 

## Notes

- N/A

## Pre-condition

### Docker Setup

- docker-compose up --build

### Local Setup

- cd client && npm install && npm run dev
- cd api && npm install && npm run dev
- goto the homepage and click the Post Modal
- 
## Expected Output

- It should now have a Hashtags together with the title in Post Modal
- Fix copy link and reset reacts and comments

## Screenshots/Recordings
[bugfix.webm](https://github.com/Osomware/meme-me/assets/108642414/478e21fb-9422-4bcb-b55f-6071456a5e14)

