### PR TITLE
MM-40 - [FE] Implement Follow and Unfollow Functionality

### DIFF
--- a/api/src/auth/auth.service.ts
+++ b/api/src/auth/auth.service.ts
@@ -137,7 +137,15 @@ export class AuthService {
   }
 
   async findOne(args: FindFirstUserOrThrowArgs): Promise<User> {
-    return await this.prisma.user.findFirstOrThrow(args)
+    return await this.prisma.user.findFirstOrThrow({
+      ...args,
+      include: {
+        followers: true,
+        following: true,
+        posts: true,
+        _count: true
+      }
+    })
   }
 
   async getNewTokens(userId: number, rt: string): SignReturnType {

--- a/api/src/follow-user/follow-user.resolver.ts
+++ b/api/src/follow-user/follow-user.resolver.ts
@@ -1,4 +1,4 @@
-import { Resolver, Mutation, Args } from '@nestjs/graphql'
+import { Resolver, Mutation, Query, Args } from '@nestjs/graphql'
 
 import { Follow } from '@generated/follow/follow.model'
 import { FollowUserService } from './follow-user.service'
@@ -24,5 +24,13 @@ export class FollowUserResolver {
     @Args('targetUserIdInput') targetUserInput: TargetUserIdInput
   ): Promise<Follow> {
     return await this.followUserService.unFollowUser(userId, targetUserInput)
+  }
+
+  @Query(() => Boolean, { name: 'checkUserFollowed' })
+  async checkUserFollowed(
+    @CurrentUserId() userId: number,
+    @Args('targetUserIdInput') targetUserInput: TargetUserIdInput
+  ): Promise<Boolean> {
+    return await this.followUserService.checkUserFollowed(userId, targetUserInput)
   }
 }

--- a/api/src/follow-user/follow-user.service.ts
+++ b/api/src/follow-user/follow-user.service.ts
@@ -46,7 +46,7 @@ export class FollowUserService {
       throw new Error('You cannot unfollow yourself.')
     }
 
-    const targetUserFound = await this.prisma.user.findUnique({
+    const targetUserFound = await this.prisma.user.findMany({
       where: { id: targetUser.id }
     })
 
@@ -66,5 +66,18 @@ export class FollowUserService {
         following: true
       }
     })
+  }
+
+  async checkUserFollowed(userId: number, targetUser: TargetUserIdInput): Promise<Boolean> {
+    const followRelationship = await this.prisma.follow.findUnique({
+      where: {
+        followerId_followingId: {
+          followerId: userId,
+          followingId: targetUser.id
+        }
+      }
+    })
+
+    return !!followRelationship
   }
 }

--- a/api/src/schema.gql
+++ b/api/src/schema.gql
@@ -133,6 +133,15 @@ input FollowWhereUniqueInput {
   id: Int
 }
 
+type Followers {
+  createdAt: DateTime!
+  follower: User!
+  followerId: Int!
+  following: User!
+  followingId: Int!
+  id: ID!
+}
+
 type Hashtag {
   _count: HashtagCount!
   createdAt: DateTime!
@@ -519,6 +528,7 @@ input PostWhereUniqueInput {
 }
 
 type Query {
+  checkUserFollowed(targetUserIdInput: TargetUserIdInput!): Boolean!
   findAllPost(cursor: PostWhereUniqueInput, distinct: [PostScalarFieldEnum!], orderBy: [PostOrderByWithRelationInput!], skip: Int, take: Int, where: PostWhereInput): [Post!]!
   findOnePost(cursor: PostWhereUniqueInput, distinct: [PostScalarFieldEnum!], orderBy: [PostOrderByWithRelationInput!], skip: Int, take: Int, where: PostWhereInput): Post!
   findOneUser(cursor: UserWhereUniqueInput, distinct: [UserScalarFieldEnum!], orderBy: [UserOrderByWithRelationInput!], skip: Int, take: Int, where: UserWhereInput): User!
@@ -600,11 +610,25 @@ input TargetUserIdInput {
 }
 
 type User {
+  _count: UserCount!
+  createdAt: DateTime!
   email: String!
+  followers: [Followers!]
+  following: [Followers!]
   id: Int!
   name: String!
-  role: String!
+  password: String!
+  posts: [Post!]
+  refreshToken: String
+  role: Role!
+  updatedAt: DateTime!
   username: String!
+}
+
+type UserCount {
+  followers: Int!
+  following: Int!
+  posts: Int!
 }
 
 input UserCreateInput {

--- a/api/src/user/followers.entity.ts
+++ b/api/src/user/followers.entity.ts
@@ -1,0 +1,27 @@
+import { Field } from '@nestjs/graphql'
+import { ID } from '@nestjs/graphql'
+import { Int } from '@nestjs/graphql'
+import { ObjectType } from '@nestjs/graphql'
+
+import { User } from './user.entity'
+
+@ObjectType()
+export class Followers {
+  @Field(() => ID, { nullable: false })
+  id!: number
+
+  @Field(() => Int, { nullable: false })
+  followerId!: number
+
+  @Field(() => Int, { nullable: false })
+  followingId!: number
+
+  @Field(() => Date, { nullable: false })
+  createdAt!: Date
+
+  @Field(() => User, { nullable: false })
+  follower?: User
+
+  @Field(() => User, { nullable: false })
+  following?: User
+}

--- a/api/src/user/user.entity.ts
+++ b/api/src/user/user.entity.ts
@@ -1,19 +1,49 @@
 import { ObjectType, Field, Int } from '@nestjs/graphql'
 
+import { Followers } from './followers.entity'
+import { Role } from '@generated/prisma/role.enum'
+import { Post } from '~/post/entities/post.entity'
+import { Follow } from '@generated/follow/follow.model'
+import { UserCount } from '@generated/user/user-count.output'
+
 @ObjectType()
 export class User {
-  @Field(() => Int)
-  id: number
+  @Field(() => Int!, { nullable: false })
+  id!: number
 
-  @Field()
-  name: string
+  @Field(() => String, { nullable: false })
+  email!: string
 
-  @Field()
-  username: string
+  @Field(() => String, { nullable: false })
+  username!: string
 
-  @Field()
-  email: string
+  @Field(() => String, { nullable: false })
+  name!: string
 
-  @Field()
-  role: string
+  @Field(() => String, { nullable: false })
+  password!: string
+
+  @Field(() => String, { nullable: true })
+  refreshToken!: string | null
+
+  @Field(() => Role, { nullable: false, defaultValue: 'USER' })
+  role!: keyof typeof Role
+
+  @Field(() => Date, { nullable: false })
+  createdAt!: Date
+
+  @Field(() => Date, { nullable: false })
+  updatedAt!: Date
+
+  @Field(() => [Post], { nullable: true })
+  posts?: Array<Post>
+
+  @Field(() => [Followers], { nullable: true })
+  followers?: Array<Follow>
+
+  @Field(() => [Followers], { nullable: true })
+  following?: Array<Follow>
+
+  @Field(() => UserCount, { nullable: false })
+  _count?: UserCount
 }

--- a/client/src/components/molecules/PostList/index.tsx
+++ b/client/src/components/molecules/PostList/index.tsx
@@ -1,9 +1,12 @@
 import { isEmpty } from 'lodash'
 import { useRouter } from 'next/router'
+import useFollow from '~/hooks/useFollow'
 import React, { FC, useState } from 'react'
 
+import { useStore } from '~/utils/zustand'
 import Post from '~/components/organisms/Post'
 import { IPost } from '~/utils/interface/Post'
+import { useZustand } from '~/hooks/useZustand'
 import PostModal from '~/components/organisms/PostModal'
 
 type PostListProps = {
@@ -15,24 +18,42 @@ const PostList: FC<PostListProps> = ({ posts }): JSX.Element => {
   const postId = router.query?.postId
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false)
 
+  // * ZUSTAND STORE HOOKS
+  const store = useZustand(useStore, (state) => state)
+
+  // * FOLLOW HOOKS
+  const { checkIsFollowed } = useFollow()
+
   const closeModal = (): void => {
     setIsModalOpen(false)
     void router.replace(router.pathname, undefined, { shallow: true })
   }
 
+  const followStatuses = posts.map((post) => {
+    return checkIsFollowed(post?.user?.id)
+  })
+
   return (
     <div className="-mt-2 divide-y divide-stroke-2 py-4">
-      {posts?.map((post) => (
-        <Post
-          key={post.id}
-          {...{
-            post,
-            state: {
-              setIsModalOpen
-            }
-          }}
-        />
-      ))}
+      {posts?.map((post, index) => {
+        const followCheckResult = followStatuses[index].data
+        const isFollowed = followCheckResult?.checkUserFollowed ?? false
+        const isPostAuthor = post?.user?.id === store?.user?.id
+
+        return (
+          <Post
+            key={post.id}
+            {...{
+              post,
+              isPostAuthor,
+              isFollowed,
+              state: {
+                setIsModalOpen
+              }
+            }}
+          />
+        )
+      })}
 
       {/* View Sigle Post Dialog */}
       {isModalOpen && !isEmpty(postId) && (

--- a/client/src/graphql/mutations/follow.ts
+++ b/client/src/graphql/mutations/follow.ts
@@ -1,0 +1,22 @@
+import { gql } from 'graphql-request'
+
+export const FOLLOW_MUTATION = gql`
+  mutation FollowUser($targetUserIdInput: TargetUserIdInput!) {
+    followUser(targetUserIdInput: $targetUserIdInput) {
+      id
+      followerId
+      followingId
+    }
+  }
+`
+
+export const UNFOLLOW_MUTATION = gql`
+  mutation UnfollowUser($targetUserIdInput: TargetUserIdInput!) {
+    unfollowUser(targetUserIdInput: $targetUserIdInput) {
+      id
+      followingId
+      followerId
+      createdAt
+    }
+  }
+`

--- a/client/src/graphql/queries/followQuery.ts
+++ b/client/src/graphql/queries/followQuery.ts
@@ -1,0 +1,7 @@
+import { gql } from 'graphql-request'
+
+export const CHECK_IS_FOLLOWED = gql`
+  query CheckIsFollowed($targetUserIdInput: TargetUserIdInput!) {
+    checkUserFollowed(targetUserIdInput: $targetUserIdInput)
+  }
+`

--- a/client/src/graphql/queries/userQuery.ts
+++ b/client/src/graphql/queries/userQuery.ts
@@ -8,6 +8,11 @@ export const USER_QUERY = gql`
       name
       role
       username
+      _count {
+        followers
+        following
+        posts
+      }
     }
   }
 `

--- a/client/src/hooks/useFollow.ts
+++ b/client/src/hooks/useFollow.ts
@@ -1,0 +1,79 @@
+import { useMutation, UseMutationResult, useQuery, UseQueryResult } from '@tanstack/react-query'
+
+import { gqlClient } from '~/lib/gqlClient'
+import { TargetUserIdInput } from '~/utils/types/input'
+import { CHECK_IS_FOLLOWED } from '~/graphql/queries/followQuery'
+import { FOLLOW_MUTATION, UNFOLLOW_MUTATION } from '~/graphql/mutations/follow'
+import toast from 'react-hot-toast'
+
+type Response = {
+  id: number
+  followerId: number
+  followingId: number
+}
+
+type ResultQuery = {
+  checkUserFollowed: boolean
+}
+
+type FollowFetchQueryType = UseMutationResult<Response, unknown, TargetUserIdInput, unknown>
+
+type CheckIsFollowedQueryType = UseQueryResult<ResultQuery, Error>
+
+type ReturnType = {
+  handleFollow: () => FollowFetchQueryType
+  handleUnfollow: () => FollowFetchQueryType
+  checkIsFollowed: (id: number) => CheckIsFollowedQueryType
+}
+
+const useFollow = (): ReturnType => {
+  const handleFollow = (): FollowFetchQueryType =>
+    useMutation<Response, Error, TargetUserIdInput, unknown>({
+      mutationFn: async (targetUserIdInput: TargetUserIdInput) => {
+        return await gqlClient.request(FOLLOW_MUTATION, {
+          targetUserIdInput: {
+            id: targetUserIdInput.id
+          }
+        })
+      },
+      onError: (err: Error) => {
+        const [errorMessage] = err.message.split(/:\s/, 2)
+        toast.error(errorMessage)
+      }
+    })
+
+  const handleUnfollow = (): FollowFetchQueryType =>
+    useMutation<Response, Error, TargetUserIdInput, unknown>({
+      mutationFn: async (targetUserIdInput: TargetUserIdInput) => {
+        return await gqlClient.request(UNFOLLOW_MUTATION, {
+          targetUserIdInput: {
+            id: targetUserIdInput.id
+          }
+        })
+      },
+      onError: (err: Error) => {
+        const [errorMessage] = err.message.split(/:\s/, 2)
+        toast.error(errorMessage)
+      }
+    })
+
+  const checkIsFollowed = (id: number): CheckIsFollowedQueryType =>
+    useQuery<ResultQuery, Error>({
+      queryKey: ['follow', id],
+      queryFn: async () =>
+        await gqlClient.request(CHECK_IS_FOLLOWED, {
+          targetUserIdInput: {
+            id
+          }
+        }),
+      select: (data: ResultQuery) => data
+    })
+
+  return {
+    handleFollow,
+    handleUnfollow,
+    checkIsFollowed
+  }
+}
+
+export default useFollow

--- a/client/src/utils/interface/User.ts
+++ b/client/src/utils/interface/User.ts
@@ -4,4 +4,9 @@ export interface IUser {
   name: string
   username: string
   role: string
+  _count: {
+    followers: number
+    following: number
+    posts: number
+  }
 }

--- a/client/src/utils/types/input.ts
+++ b/client/src/utils/types/input.ts
@@ -20,3 +20,7 @@ export type PostRequestInput = {
     }>
   }
 }
+
+export type TargetUserIdInput = {
+  id: number
+}


### PR DESCRIPTION
## Issue Link

- https://www.notion.so/MM-40-FE-Implement-Follow-and-Unfollow-Functionality-ea0a7a63cab045dba5bd81928863f4a9?pvs=4

## Definition of Done

- [x] Modified User Entity
- [x] Create query that check if the user is already followed
- [x] Create followers entity
- [x] Implement Follow and Unfollow functionality both profile and home feeds  
- [x] Modified profile to have count of post, followers and following

## Notes

- BE and FE

## Pre-condition

### Docker Setup

- docker-compose up --build

### Local Setup

- cd client && npm install && npm run dev
- cd api && npm install && npm run dev
- goto the homepage and try to follow and unfollow as well as the profile page

## Expected Output

- It should now have a functionality that user can follow and unfollow
- Only authenticated user are the one who can follow/unfollow

## Screenshots/Recordings

[follow.webm](https://github.com/Osomware/meme-me/assets/108642414/e438b9c8-c4c3-417d-9c5e-bdf0e6c057a2)

