### PR TITLE
MM-[44] - [FE] Display User Posts in Profile Page

### DIFF
--- a/api/src/post/post.resolver.ts
+++ b/api/src/post/post.resolver.ts
@@ -28,4 +28,9 @@ export class PostResolver {
   findOne(@Args() args: FindFirstPostOrThrowArgs): Promise<Post> {
     return this.postService.findOne(args)
   }
+
+  @Query(() => [Post], { name: 'findAllPostByUsername' })
+  findAllByUsername(@Args() args: FindManyPostArgs): Promise<Post[]> {
+    return this.postService.findAllByUsername(args)
+  }
 }

--- a/api/src/post/post.service.ts
+++ b/api/src/post/post.service.ts
@@ -60,4 +60,18 @@ export class PostService {
       }
     })
   }
+
+  async findAllByUsername(args: FindManyPostArgs): Promise<Post[]> {
+    return await this.prisma.post.findMany({
+      ...args,
+      include: {
+        user: true,
+        postHashtags: {
+          include: {
+            hashtag: true
+          }
+        }
+      }
+    })
+  }
 }

--- a/api/src/schema.gql
+++ b/api/src/schema.gql
@@ -530,6 +530,7 @@ input PostWhereUniqueInput {
 type Query {
   checkUserFollowed(targetUserIdInput: TargetUserIdInput!): Boolean!
   findAllPost(cursor: PostWhereUniqueInput, distinct: [PostScalarFieldEnum!], orderBy: [PostOrderByWithRelationInput!], skip: Int, take: Int, where: PostWhereInput): [Post!]!
+  findAllPostByUsername(cursor: PostWhereUniqueInput, distinct: [PostScalarFieldEnum!], orderBy: [PostOrderByWithRelationInput!], skip: Int, take: Int, where: PostWhereInput): [Post!]!
   findOnePost(cursor: PostWhereUniqueInput, distinct: [PostScalarFieldEnum!], orderBy: [PostOrderByWithRelationInput!], skip: Int, take: Int, where: PostWhereInput): Post!
   findOneUser(cursor: UserWhereUniqueInput, distinct: [UserScalarFieldEnum!], orderBy: [UserOrderByWithRelationInput!], skip: Int, take: Int, where: UserWhereInput): User!
   getAllPostHashtag(cursor: HashtagWhereUniqueInput, distinct: [HashtagScalarFieldEnum!], orderBy: [HashtagOrderByWithRelationInput!], skip: Int, take: Int, where: HashtagWhereInput): [PostHashtag!]!

--- a/client/src/components/atoms/Skeletons/ProfilePageSkeletonLoading/index.tsx
+++ b/client/src/components/atoms/Skeletons/ProfilePageSkeletonLoading/index.tsx
@@ -6,7 +6,7 @@ type SkeletonProps = {
   height: string
 }
 
-const Skeleton: FC<SkeletonProps> = ({ width, height }) => {
+export const Skeleton: FC<SkeletonProps> = ({ width, height }) => {
   return <div className={clsx('bg-secondary-100/30 rounded-full', width, height)}></div>
 }
 
@@ -39,11 +39,6 @@ const ProfilePageSkeletonLoading: FC = () => {
           <Skeleton width="w-12" height="h-2" />
           <Skeleton width="w-12" height="h-2" />
         </div>
-      </div>
-      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 max-w-3xl w-full mx-auto gap-2 px-4">
-        {Array.from({ length: 9 }).map((_, index) => (
-          <Skeleton key={index} width="w-full" height="h-52 rounded-sm mb-12" />
-        ))}
       </div>
     </div>
   )

--- a/client/src/components/organisms/Post/index.tsx
+++ b/client/src/components/organisms/Post/index.tsx
@@ -105,7 +105,10 @@ const Post: FC<PostProps> = (props): JSX.Element => {
           postId: id
         }
       },
-      `/@${user?.username}/posts/${id}`
+      `/@${user?.username}/posts/${id}`,
+      {
+        shallow: true
+      }
     )
   }
 

--- a/client/src/graphql/queries/postsQuery.ts
+++ b/client/src/graphql/queries/postsQuery.ts
@@ -50,3 +50,13 @@ export const GET_ONE_POST_QUERY = gql`
     }
   }
 `
+
+export const GET_ALL_POST_BY_USERNAME_QUERY = gql`
+  query FindAllPostByUsername($where: PostWhereInput, $orderBy: [PostOrderByWithRelationInput!]) {
+    findAllPostByUsername(where: $where, orderBy: $orderBy) {
+      id
+      mediaUrls
+      createdAt
+    }
+  }
+`

--- a/client/src/pages/[@username]/index.tsx
+++ b/client/src/pages/[@username]/index.tsx
@@ -1,22 +1,127 @@
-import React from 'react'
+import clsx from 'clsx'
 import { NextPage } from 'next'
-import { Camera } from 'react-feather'
+import { isEmpty } from 'lodash'
+import React, { useState } from 'react'
 import { useRouter } from 'next/router'
+import { Camera, Heart, MessageCircle } from 'react-feather'
 
+import usePost from '~/hooks/usePost'
+import Alert from '~/components/atoms/Alert'
+import PostModal from '~/components/organisms/PostModal'
 import ProfileLayout from '~/components/templates/ProfileLayout'
+import { Skeleton } from '~/components/atoms/Skeletons/ProfilePageSkeletonLoading'
 
 const Username: NextPage = (): JSX.Element => {
   const router = useRouter()
   const { '@username': username } = router.query
+  const postId = router.query?.postId
+
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false)
+
+  const closeModal = (): void => {
+    setIsModalOpen(false)
+    void router.replace(`@${username?.slice(1) as string}`, undefined, { shallow: true })
+  }
+
+  // * POST HOOKS
+  const { getAllPostsByUsername } = usePost()
+  const {
+    data: userPosts,
+    isError,
+    isLoading
+  } = getAllPostsByUsername(username?.slice(1) as string)
+
+  if (isLoading) {
+    return (
+      <ProfileLayout metaTitle={`${username?.toString() ?? ''}`}>
+        <div className="mt-4 animate-pulse grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 max-w-4xl w-full mx-auto gap-2 px-4">
+          {Array.from({ length: 9 }).map((_, index) => (
+            <Skeleton key={index} width="w-full" height="h-52 rounded-sm" />
+          ))}
+        </div>
+      </ProfileLayout>
+    )
+  }
+
+  if (isError) {
+    return (
+      <ProfileLayout metaTitle={`${username?.toString() ?? ''}`}>
+        <Alert type="error" message="Something went wrong!" />
+      </ProfileLayout>
+    )
+  }
+
+  if (userPosts?.findAllPostByUsername?.length === 0) {
+    return (
+      <ProfileLayout metaTitle={`${username?.toString() ?? ''}`}>
+        <div className="mt-8 max-w-sm mx-auto flex flex-col items-center space-y-6">
+          <div className="rounded-full border-2 border-secondary-300 p-4">
+            <Camera className="w-6 h-6 stroke-1 text-secondary-300" />
+          </div>
+          <h1 className="text-2xl font-bold text-secondary-300">No Posts Yet</h1>
+        </div>
+      </ProfileLayout>
+    )
+  }
 
   return (
     <ProfileLayout metaTitle={`${username?.toString() ?? ''}`}>
-      <div className="mt-8 max-w-sm mx-auto flex flex-col items-center space-y-6">
-        <div className="rounded-full border-2 border-secondary-300 p-4">
-          <Camera className="w-6 h-6 stroke-1 text-secondary-300" />
-        </div>
-        <h1 className="text-2xl font-bold text-secondary-300">No Posts Yet</h1>
+      <div className="mt-4 grid grid-cols-2 sm:grid-cols-3 max-w-4xl w-full mx-auto gap-2 px-4 pb-8">
+        {userPosts?.findAllPostByUsername?.map((post, idx) => {
+          const handleViewPost = (): void => {
+            void router.replace({
+              pathname: router.asPath,
+              query: {
+                postId: post?.id
+              }
+            })
+            setIsModalOpen(true)
+          }
+
+          return (
+            <button
+              key={idx}
+              type="button"
+              onClick={handleViewPost}
+              className="group relative cursor-pointer outline-none"
+            >
+              <div className="group-hover:brightness-75 transition ease-in-out duration-75">
+                <img
+                  src={post?.mediaUrls[0]}
+                  className="w-full h-52 object-cover bg-black"
+                  alt=""
+                />
+              </div>
+              <div
+                className={clsx(
+                  'z-50 inset-0 absolute opacity-0 group-hover:opacity-100 flex',
+                  'items-center space-x-3 justify-center group-hover:brightness-100'
+                )}
+              >
+                <div className="inline-flex items-center space-x-0.5">
+                  <Heart className="w-4 h-4 stroke-white" fill="#fff" />
+                  <span className="text-xs font-semibold text-white">0</span>
+                </div>
+                <div className="inline-flex items-center space-x-0.5">
+                  <MessageCircle className="w-4 h-4 stroke-white" fill="#fff" />
+                  <span className="text-xs font-semibold text-white">0</span>
+                </div>
+              </div>
+            </button>
+          )
+        })}
       </div>
+
+      {/* View Sigle Post Dialog */}
+      {isModalOpen && !isEmpty(postId) && (
+        <PostModal
+          {...{
+            isOpen: isModalOpen,
+            closeModal,
+            postId
+          }}
+        />
+      )}
     </ProfileLayout>
   )
 }

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -51,7 +51,7 @@ const Home: NextPage = (): JSX.Element => {
       }}
     >
       <>
-        {dataPosts?.findAllPost.length === 0 ? (
+        {dataPosts?.findAllPost?.length === 0 ? (
           <div className="mt-3">
             <p className="py-2 text-center text-sm text-secondary-200">No Post</p>
           </div>


### PR DESCRIPTION
## Issue Link

- https://www.notion.so/MM-44-FE-Display-User-Posts-in-Profile-Page-d525acd14246445ab5d6f3af5a236a44?pvs=4

## Definition of Done

- [x] Display Posts in the User Profile
- [x] Show single Post with Post Modal

## Notes

- Still not working the shallow route as path
- The commend and message are set to 0

## Pre-condition

### Docker Setup

- docker-compose up --build

### Local Setup

- cd client && npm install && npm run dev
- cd api && npm install && npm run dev
- goto the user profile and you will view the profile with posts

## Expected Output

- It should now have a posts in the profile pages

## Screenshots/Recordings

[profile posts.webm](https://github.com/Osomware/meme-me/assets/108642414/f28b1336-a0e6-4ebe-86b4-119c5fff00de)

