### PR TITLE
MM-[45] - [FE] Fix User Cascade delete to following

### DIFF
--- a/api/prisma/migrations/20230901080552_add_follow_cascading/migration.sql
+++ b/api/prisma/migrations/20230901080552_add_follow_cascading/migration.sql
@@ -1,0 +1,11 @@
+-- DropForeignKey
+ALTER TABLE "Follow" DROP CONSTRAINT "Follow_followerId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Follow" DROP CONSTRAINT "Follow_followingId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "Follow" ADD CONSTRAINT "Follow_followerId_fkey" FOREIGN KEY ("followerId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Follow" ADD CONSTRAINT "Follow_followingId_fkey" FOREIGN KEY ("followingId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -38,9 +38,9 @@ model User {
 
 model Follow {
   id          Int      @id @default(autoincrement())
-  follower    User     @relation("FollowerRelation", fields: [followerId], references: [id])
+  follower    User     @relation("FollowerRelation", fields: [followerId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   followerId  Int
-  following   User     @relation("FollowingRelation", fields: [followingId], references: [id])
+  following   User     @relation("FollowingRelation", fields: [followingId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   followingId Int
   createdAt   DateTime @default(now())
 


### PR DESCRIPTION
## Issue Link

- https://www.notion.so/MM-45-FE-Fix-User-Cascade-delete-to-following-f27ab331a837490882ad85ea95f65c78?pvs=4

## Definition of Done

- [x] Add Migration to cascade the follow relationship

## Notes

- N/A

## Pre-condition

### Docker Setup

- docker-compose up --build

### Local Setup

- cd client && npm install && npm run dev
- cd api && npm install && npm run dev
- goto the http://localhost:3030/graphql

## Expected Output

- It should now no error when deleting user and it will cascade with follow relationship

## Screenshots/Recordings
![image](https://github.com/Osomware/meme-me/assets/108642414/730627da-38cc-41a0-8de8-40f3e09daf4d)
