### PR TITLE
MM-[46] - [FE] Modified Posts MediaUrls to add Key and Url object

### DIFF
--- a/api/@generated/media-file/aggregate-media-file.output.ts
+++ b/api/@generated/media-file/aggregate-media-file.output.ts
@@ -1,0 +1,26 @@
+import { Field } from '@nestjs/graphql';
+import { ObjectType } from '@nestjs/graphql';
+import { MediaFileCountAggregate } from './media-file-count-aggregate.output';
+import { MediaFileAvgAggregate } from './media-file-avg-aggregate.output';
+import { MediaFileSumAggregate } from './media-file-sum-aggregate.output';
+import { MediaFileMinAggregate } from './media-file-min-aggregate.output';
+import { MediaFileMaxAggregate } from './media-file-max-aggregate.output';
+
+@ObjectType()
+export class AggregateMediaFile {
+
+    @Field(() => MediaFileCountAggregate, {nullable:true})
+    _count?: MediaFileCountAggregate;
+
+    @Field(() => MediaFileAvgAggregate, {nullable:true})
+    _avg?: MediaFileAvgAggregate;
+
+    @Field(() => MediaFileSumAggregate, {nullable:true})
+    _sum?: MediaFileSumAggregate;
+
+    @Field(() => MediaFileMinAggregate, {nullable:true})
+    _min?: MediaFileMinAggregate;
+
+    @Field(() => MediaFileMaxAggregate, {nullable:true})
+    _max?: MediaFileMaxAggregate;
+}

--- a/api/@generated/media-file/create-many-media-file.args.ts
+++ b/api/@generated/media-file/create-many-media-file.args.ts
@@ -1,0 +1,15 @@
+import { Field } from '@nestjs/graphql';
+import { ArgsType } from '@nestjs/graphql';
+import { MediaFileCreateManyInput } from './media-file-create-many.input';
+import { Type } from 'class-transformer';
+
+@ArgsType()
+export class CreateManyMediaFileArgs {
+
+    @Field(() => [MediaFileCreateManyInput], {nullable:false})
+    @Type(() => MediaFileCreateManyInput)
+    data!: Array<MediaFileCreateManyInput>;
+
+    @Field(() => Boolean, {nullable:true})
+    skipDuplicates?: boolean;
+}

--- a/api/@generated/media-file/create-one-media-file.args.ts
+++ b/api/@generated/media-file/create-one-media-file.args.ts
@@ -1,0 +1,12 @@
+import { Field } from '@nestjs/graphql';
+import { ArgsType } from '@nestjs/graphql';
+import { MediaFileCreateInput } from './media-file-create.input';
+import { Type } from 'class-transformer';
+
+@ArgsType()
+export class CreateOneMediaFileArgs {
+
+    @Field(() => MediaFileCreateInput, {nullable:false})
+    @Type(() => MediaFileCreateInput)
+    data!: MediaFileCreateInput;
+}

--- a/api/@generated/media-file/delete-many-media-file.args.ts
+++ b/api/@generated/media-file/delete-many-media-file.args.ts
@@ -1,0 +1,12 @@
+import { Field } from '@nestjs/graphql';
+import { ArgsType } from '@nestjs/graphql';
+import { MediaFileWhereInput } from './media-file-where.input';
+import { Type } from 'class-transformer';
+
+@ArgsType()
+export class DeleteManyMediaFileArgs {
+
+    @Field(() => MediaFileWhereInput, {nullable:true})
+    @Type(() => MediaFileWhereInput)
+    where?: MediaFileWhereInput;
+}

--- a/api/@generated/media-file/delete-one-media-file.args.ts
+++ b/api/@generated/media-file/delete-one-media-file.args.ts
@@ -1,0 +1,13 @@
+import { Field } from '@nestjs/graphql';
+import { ArgsType } from '@nestjs/graphql';
+import { Prisma } from '@prisma/client';
+import { MediaFileWhereUniqueInput } from './media-file-where-unique.input';
+import { Type } from 'class-transformer';
+
+@ArgsType()
+export class DeleteOneMediaFileArgs {
+
+    @Field(() => MediaFileWhereUniqueInput, {nullable:false})
+    @Type(() => MediaFileWhereUniqueInput)
+    where!: Prisma.AtLeast<MediaFileWhereUniqueInput, 'id'>;
+}

--- a/api/@generated/media-file/find-first-media-file-or-throw.args.ts
+++ b/api/@generated/media-file/find-first-media-file-or-throw.args.ts
@@ -1,0 +1,32 @@
+import { Field } from '@nestjs/graphql';
+import { ArgsType } from '@nestjs/graphql';
+import { MediaFileWhereInput } from './media-file-where.input';
+import { Type } from 'class-transformer';
+import { MediaFileOrderByWithRelationInput } from './media-file-order-by-with-relation.input';
+import { Prisma } from '@prisma/client';
+import { MediaFileWhereUniqueInput } from './media-file-where-unique.input';
+import { Int } from '@nestjs/graphql';
+import { MediaFileScalarFieldEnum } from './media-file-scalar-field.enum';
+
+@ArgsType()
+export class FindFirstMediaFileOrThrowArgs {
+
+    @Field(() => MediaFileWhereInput, {nullable:true})
+    @Type(() => MediaFileWhereInput)
+    where?: MediaFileWhereInput;
+
+    @Field(() => [MediaFileOrderByWithRelationInput], {nullable:true})
+    orderBy?: Array<MediaFileOrderByWithRelationInput>;
+
+    @Field(() => MediaFileWhereUniqueInput, {nullable:true})
+    cursor?: Prisma.AtLeast<MediaFileWhereUniqueInput, 'id'>;
+
+    @Field(() => Int, {nullable:true})
+    take?: number;
+
+    @Field(() => Int, {nullable:true})
+    skip?: number;
+
+    @Field(() => [MediaFileScalarFieldEnum], {nullable:true})
+    distinct?: Array<keyof typeof MediaFileScalarFieldEnum>;
+}

--- a/api/@generated/media-file/find-first-media-file.args.ts
+++ b/api/@generated/media-file/find-first-media-file.args.ts
@@ -1,0 +1,32 @@
+import { Field } from '@nestjs/graphql';
+import { ArgsType } from '@nestjs/graphql';
+import { MediaFileWhereInput } from './media-file-where.input';
+import { Type } from 'class-transformer';
+import { MediaFileOrderByWithRelationInput } from './media-file-order-by-with-relation.input';
+import { Prisma } from '@prisma/client';
+import { MediaFileWhereUniqueInput } from './media-file-where-unique.input';
+import { Int } from '@nestjs/graphql';
+import { MediaFileScalarFieldEnum } from './media-file-scalar-field.enum';
+
+@ArgsType()
+export class FindFirstMediaFileArgs {
+
+    @Field(() => MediaFileWhereInput, {nullable:true})
+    @Type(() => MediaFileWhereInput)
+    where?: MediaFileWhereInput;
+
+    @Field(() => [MediaFileOrderByWithRelationInput], {nullable:true})
+    orderBy?: Array<MediaFileOrderByWithRelationInput>;
+
+    @Field(() => MediaFileWhereUniqueInput, {nullable:true})
+    cursor?: Prisma.AtLeast<MediaFileWhereUniqueInput, 'id'>;
+
+    @Field(() => Int, {nullable:true})
+    take?: number;
+
+    @Field(() => Int, {nullable:true})
+    skip?: number;
+
+    @Field(() => [MediaFileScalarFieldEnum], {nullable:true})
+    distinct?: Array<keyof typeof MediaFileScalarFieldEnum>;
+}

--- a/api/@generated/media-file/find-many-media-file.args.ts
+++ b/api/@generated/media-file/find-many-media-file.args.ts
@@ -1,0 +1,32 @@
+import { Field } from '@nestjs/graphql';
+import { ArgsType } from '@nestjs/graphql';
+import { MediaFileWhereInput } from './media-file-where.input';
+import { Type } from 'class-transformer';
+import { MediaFileOrderByWithRelationInput } from './media-file-order-by-with-relation.input';
+import { Prisma } from '@prisma/client';
+import { MediaFileWhereUniqueInput } from './media-file-where-unique.input';
+import { Int } from '@nestjs/graphql';
+import { MediaFileScalarFieldEnum } from './media-file-scalar-field.enum';
+
+@ArgsType()
+export class FindManyMediaFileArgs {
+
+    @Field(() => MediaFileWhereInput, {nullable:true})
+    @Type(() => MediaFileWhereInput)
+    where?: MediaFileWhereInput;
+
+    @Field(() => [MediaFileOrderByWithRelationInput], {nullable:true})
+    orderBy?: Array<MediaFileOrderByWithRelationInput>;
+
+    @Field(() => MediaFileWhereUniqueInput, {nullable:true})
+    cursor?: Prisma.AtLeast<MediaFileWhereUniqueInput, 'id'>;
+
+    @Field(() => Int, {nullable:true})
+    take?: number;
+
+    @Field(() => Int, {nullable:true})
+    skip?: number;
+
+    @Field(() => [MediaFileScalarFieldEnum], {nullable:true})
+    distinct?: Array<keyof typeof MediaFileScalarFieldEnum>;
+}

--- a/api/@generated/media-file/find-unique-media-file-or-throw.args.ts
+++ b/api/@generated/media-file/find-unique-media-file-or-throw.args.ts
@@ -1,0 +1,13 @@
+import { Field } from '@nestjs/graphql';
+import { ArgsType } from '@nestjs/graphql';
+import { Prisma } from '@prisma/client';
+import { MediaFileWhereUniqueInput } from './media-file-where-unique.input';
+import { Type } from 'class-transformer';
+
+@ArgsType()
+export class FindUniqueMediaFileOrThrowArgs {
+
+    @Field(() => MediaFileWhereUniqueInput, {nullable:false})
+    @Type(() => MediaFileWhereUniqueInput)
+    where!: Prisma.AtLeast<MediaFileWhereUniqueInput, 'id'>;
+}

--- a/api/@generated/media-file/find-unique-media-file.args.ts
+++ b/api/@generated/media-file/find-unique-media-file.args.ts
@@ -1,0 +1,13 @@
+import { Field } from '@nestjs/graphql';
+import { ArgsType } from '@nestjs/graphql';
+import { Prisma } from '@prisma/client';
+import { MediaFileWhereUniqueInput } from './media-file-where-unique.input';
+import { Type } from 'class-transformer';
+
+@ArgsType()
+export class FindUniqueMediaFileArgs {
+
+    @Field(() => MediaFileWhereUniqueInput, {nullable:false})
+    @Type(() => MediaFileWhereUniqueInput)
+    where!: Prisma.AtLeast<MediaFileWhereUniqueInput, 'id'>;
+}

--- a/api/@generated/media-file/media-file-aggregate.args.ts
+++ b/api/@generated/media-file/media-file-aggregate.args.ts
@@ -1,0 +1,48 @@
+import { Field } from '@nestjs/graphql';
+import { ArgsType } from '@nestjs/graphql';
+import { MediaFileWhereInput } from './media-file-where.input';
+import { Type } from 'class-transformer';
+import { MediaFileOrderByWithRelationInput } from './media-file-order-by-with-relation.input';
+import { Prisma } from '@prisma/client';
+import { MediaFileWhereUniqueInput } from './media-file-where-unique.input';
+import { Int } from '@nestjs/graphql';
+import { MediaFileCountAggregateInput } from './media-file-count-aggregate.input';
+import { MediaFileAvgAggregateInput } from './media-file-avg-aggregate.input';
+import { MediaFileSumAggregateInput } from './media-file-sum-aggregate.input';
+import { MediaFileMinAggregateInput } from './media-file-min-aggregate.input';
+import { MediaFileMaxAggregateInput } from './media-file-max-aggregate.input';
+
+@ArgsType()
+export class MediaFileAggregateArgs {
+
+    @Field(() => MediaFileWhereInput, {nullable:true})
+    @Type(() => MediaFileWhereInput)
+    where?: MediaFileWhereInput;
+
+    @Field(() => [MediaFileOrderByWithRelationInput], {nullable:true})
+    orderBy?: Array<MediaFileOrderByWithRelationInput>;
+
+    @Field(() => MediaFileWhereUniqueInput, {nullable:true})
+    cursor?: Prisma.AtLeast<MediaFileWhereUniqueInput, 'id'>;
+
+    @Field(() => Int, {nullable:true})
+    take?: number;
+
+    @Field(() => Int, {nullable:true})
+    skip?: number;
+
+    @Field(() => MediaFileCountAggregateInput, {nullable:true})
+    _count?: MediaFileCountAggregateInput;
+
+    @Field(() => MediaFileAvgAggregateInput, {nullable:true})
+    _avg?: MediaFileAvgAggregateInput;
+
+    @Field(() => MediaFileSumAggregateInput, {nullable:true})
+    _sum?: MediaFileSumAggregateInput;
+
+    @Field(() => MediaFileMinAggregateInput, {nullable:true})
+    _min?: MediaFileMinAggregateInput;
+
+    @Field(() => MediaFileMaxAggregateInput, {nullable:true})
+    _max?: MediaFileMaxAggregateInput;
+}

--- a/api/@generated/media-file/media-file-avg-aggregate.input.ts
+++ b/api/@generated/media-file/media-file-avg-aggregate.input.ts
@@ -1,0 +1,12 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+
+@InputType()
+export class MediaFileAvgAggregateInput {
+
+    @Field(() => Boolean, {nullable:true})
+    id?: true;
+
+    @Field(() => Boolean, {nullable:true})
+    postId?: true;
+}

--- a/api/@generated/media-file/media-file-avg-aggregate.output.ts
+++ b/api/@generated/media-file/media-file-avg-aggregate.output.ts
@@ -1,0 +1,13 @@
+import { Field } from '@nestjs/graphql';
+import { ObjectType } from '@nestjs/graphql';
+import { Float } from '@nestjs/graphql';
+
+@ObjectType()
+export class MediaFileAvgAggregate {
+
+    @Field(() => Float, {nullable:true})
+    id?: number;
+
+    @Field(() => Float, {nullable:true})
+    postId?: number;
+}

--- a/api/@generated/media-file/media-file-avg-order-by-aggregate.input.ts
+++ b/api/@generated/media-file/media-file-avg-order-by-aggregate.input.ts
@@ -1,0 +1,13 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { SortOrder } from '../prisma/sort-order.enum';
+
+@InputType()
+export class MediaFileAvgOrderByAggregateInput {
+
+    @Field(() => SortOrder, {nullable:true})
+    id?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    postId?: keyof typeof SortOrder;
+}

--- a/api/@generated/media-file/media-file-count-aggregate.input.ts
+++ b/api/@generated/media-file/media-file-count-aggregate.input.ts
@@ -1,0 +1,27 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+
+@InputType()
+export class MediaFileCountAggregateInput {
+
+    @Field(() => Boolean, {nullable:true})
+    id?: true;
+
+    @Field(() => Boolean, {nullable:true})
+    key?: true;
+
+    @Field(() => Boolean, {nullable:true})
+    url?: true;
+
+    @Field(() => Boolean, {nullable:true})
+    postId?: true;
+
+    @Field(() => Boolean, {nullable:true})
+    createdAt?: true;
+
+    @Field(() => Boolean, {nullable:true})
+    updatedAt?: true;
+
+    @Field(() => Boolean, {nullable:true})
+    _all?: true;
+}

--- a/api/@generated/media-file/media-file-count-aggregate.output.ts
+++ b/api/@generated/media-file/media-file-count-aggregate.output.ts
@@ -1,0 +1,28 @@
+import { Field } from '@nestjs/graphql';
+import { ObjectType } from '@nestjs/graphql';
+import { Int } from '@nestjs/graphql';
+
+@ObjectType()
+export class MediaFileCountAggregate {
+
+    @Field(() => Int, {nullable:false})
+    id!: number;
+
+    @Field(() => Int, {nullable:false})
+    key!: number;
+
+    @Field(() => Int, {nullable:false})
+    url!: number;
+
+    @Field(() => Int, {nullable:false})
+    postId!: number;
+
+    @Field(() => Int, {nullable:false})
+    createdAt!: number;
+
+    @Field(() => Int, {nullable:false})
+    updatedAt!: number;
+
+    @Field(() => Int, {nullable:false})
+    _all!: number;
+}

--- a/api/@generated/media-file/media-file-count-order-by-aggregate.input.ts
+++ b/api/@generated/media-file/media-file-count-order-by-aggregate.input.ts
@@ -1,0 +1,25 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { SortOrder } from '../prisma/sort-order.enum';
+
+@InputType()
+export class MediaFileCountOrderByAggregateInput {
+
+    @Field(() => SortOrder, {nullable:true})
+    id?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    key?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    url?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    postId?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    createdAt?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    updatedAt?: keyof typeof SortOrder;
+}

--- a/api/@generated/media-file/media-file-create-many-post-input-envelope.input.ts
+++ b/api/@generated/media-file/media-file-create-many-post-input-envelope.input.ts
@@ -1,0 +1,15 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { MediaFileCreateManyPostInput } from './media-file-create-many-post.input';
+import { Type } from 'class-transformer';
+
+@InputType()
+export class MediaFileCreateManyPostInputEnvelope {
+
+    @Field(() => [MediaFileCreateManyPostInput], {nullable:false})
+    @Type(() => MediaFileCreateManyPostInput)
+    data!: Array<MediaFileCreateManyPostInput>;
+
+    @Field(() => Boolean, {nullable:true})
+    skipDuplicates?: boolean;
+}

--- a/api/@generated/media-file/media-file-create-many-post.input.ts
+++ b/api/@generated/media-file/media-file-create-many-post.input.ts
@@ -1,0 +1,22 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { Int } from '@nestjs/graphql';
+
+@InputType()
+export class MediaFileCreateManyPostInput {
+
+    @Field(() => Int, {nullable:true})
+    id?: number;
+
+    @Field(() => String, {nullable:false})
+    key!: string;
+
+    @Field(() => String, {nullable:false})
+    url!: string;
+
+    @Field(() => Date, {nullable:true})
+    createdAt?: Date | string;
+
+    @Field(() => Date, {nullable:true})
+    updatedAt?: Date | string;
+}

--- a/api/@generated/media-file/media-file-create-many.input.ts
+++ b/api/@generated/media-file/media-file-create-many.input.ts
@@ -1,0 +1,25 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { Int } from '@nestjs/graphql';
+
+@InputType()
+export class MediaFileCreateManyInput {
+
+    @Field(() => Int, {nullable:true})
+    id?: number;
+
+    @Field(() => String, {nullable:false})
+    key!: string;
+
+    @Field(() => String, {nullable:false})
+    url!: string;
+
+    @Field(() => Int, {nullable:false})
+    postId!: number;
+
+    @Field(() => Date, {nullable:true})
+    createdAt?: Date | string;
+
+    @Field(() => Date, {nullable:true})
+    updatedAt?: Date | string;
+}

--- a/api/@generated/media-file/media-file-create-nested-many-without-post.input.ts
+++ b/api/@generated/media-file/media-file-create-nested-many-without-post.input.ts
@@ -1,0 +1,28 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { MediaFileCreateWithoutPostInput } from './media-file-create-without-post.input';
+import { Type } from 'class-transformer';
+import { MediaFileCreateOrConnectWithoutPostInput } from './media-file-create-or-connect-without-post.input';
+import { MediaFileCreateManyPostInputEnvelope } from './media-file-create-many-post-input-envelope.input';
+import { Prisma } from '@prisma/client';
+import { MediaFileWhereUniqueInput } from './media-file-where-unique.input';
+
+@InputType()
+export class MediaFileCreateNestedManyWithoutPostInput {
+
+    @Field(() => [MediaFileCreateWithoutPostInput], {nullable:true})
+    @Type(() => MediaFileCreateWithoutPostInput)
+    create?: Array<MediaFileCreateWithoutPostInput>;
+
+    @Field(() => [MediaFileCreateOrConnectWithoutPostInput], {nullable:true})
+    @Type(() => MediaFileCreateOrConnectWithoutPostInput)
+    connectOrCreate?: Array<MediaFileCreateOrConnectWithoutPostInput>;
+
+    @Field(() => MediaFileCreateManyPostInputEnvelope, {nullable:true})
+    @Type(() => MediaFileCreateManyPostInputEnvelope)
+    createMany?: MediaFileCreateManyPostInputEnvelope;
+
+    @Field(() => [MediaFileWhereUniqueInput], {nullable:true})
+    @Type(() => MediaFileWhereUniqueInput)
+    connect?: Array<Prisma.AtLeast<MediaFileWhereUniqueInput, 'id'>>;
+}

--- a/api/@generated/media-file/media-file-create-or-connect-without-post.input.ts
+++ b/api/@generated/media-file/media-file-create-or-connect-without-post.input.ts
@@ -1,0 +1,18 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { Prisma } from '@prisma/client';
+import { MediaFileWhereUniqueInput } from './media-file-where-unique.input';
+import { Type } from 'class-transformer';
+import { MediaFileCreateWithoutPostInput } from './media-file-create-without-post.input';
+
+@InputType()
+export class MediaFileCreateOrConnectWithoutPostInput {
+
+    @Field(() => MediaFileWhereUniqueInput, {nullable:false})
+    @Type(() => MediaFileWhereUniqueInput)
+    where!: Prisma.AtLeast<MediaFileWhereUniqueInput, 'id'>;
+
+    @Field(() => MediaFileCreateWithoutPostInput, {nullable:false})
+    @Type(() => MediaFileCreateWithoutPostInput)
+    create!: MediaFileCreateWithoutPostInput;
+}

--- a/api/@generated/media-file/media-file-create-without-post.input.ts
+++ b/api/@generated/media-file/media-file-create-without-post.input.ts
@@ -1,0 +1,18 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+
+@InputType()
+export class MediaFileCreateWithoutPostInput {
+
+    @Field(() => String, {nullable:false})
+    key!: string;
+
+    @Field(() => String, {nullable:false})
+    url!: string;
+
+    @Field(() => Date, {nullable:true})
+    createdAt?: Date | string;
+
+    @Field(() => Date, {nullable:true})
+    updatedAt?: Date | string;
+}

--- a/api/@generated/media-file/media-file-create.input.ts
+++ b/api/@generated/media-file/media-file-create.input.ts
@@ -1,0 +1,22 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { PostCreateNestedOneWithoutMediaFilesInput } from '../post/post-create-nested-one-without-media-files.input';
+
+@InputType()
+export class MediaFileCreateInput {
+
+    @Field(() => String, {nullable:false})
+    key!: string;
+
+    @Field(() => String, {nullable:false})
+    url!: string;
+
+    @Field(() => Date, {nullable:true})
+    createdAt?: Date | string;
+
+    @Field(() => Date, {nullable:true})
+    updatedAt?: Date | string;
+
+    @Field(() => PostCreateNestedOneWithoutMediaFilesInput, {nullable:false})
+    post!: PostCreateNestedOneWithoutMediaFilesInput;
+}

--- a/api/@generated/media-file/media-file-group-by.args.ts
+++ b/api/@generated/media-file/media-file-group-by.args.ts
@@ -1,0 +1,51 @@
+import { Field } from '@nestjs/graphql';
+import { ArgsType } from '@nestjs/graphql';
+import { MediaFileWhereInput } from './media-file-where.input';
+import { Type } from 'class-transformer';
+import { MediaFileOrderByWithAggregationInput } from './media-file-order-by-with-aggregation.input';
+import { MediaFileScalarFieldEnum } from './media-file-scalar-field.enum';
+import { MediaFileScalarWhereWithAggregatesInput } from './media-file-scalar-where-with-aggregates.input';
+import { Int } from '@nestjs/graphql';
+import { MediaFileCountAggregateInput } from './media-file-count-aggregate.input';
+import { MediaFileAvgAggregateInput } from './media-file-avg-aggregate.input';
+import { MediaFileSumAggregateInput } from './media-file-sum-aggregate.input';
+import { MediaFileMinAggregateInput } from './media-file-min-aggregate.input';
+import { MediaFileMaxAggregateInput } from './media-file-max-aggregate.input';
+
+@ArgsType()
+export class MediaFileGroupByArgs {
+
+    @Field(() => MediaFileWhereInput, {nullable:true})
+    @Type(() => MediaFileWhereInput)
+    where?: MediaFileWhereInput;
+
+    @Field(() => [MediaFileOrderByWithAggregationInput], {nullable:true})
+    orderBy?: Array<MediaFileOrderByWithAggregationInput>;
+
+    @Field(() => [MediaFileScalarFieldEnum], {nullable:false})
+    by!: Array<keyof typeof MediaFileScalarFieldEnum>;
+
+    @Field(() => MediaFileScalarWhereWithAggregatesInput, {nullable:true})
+    having?: MediaFileScalarWhereWithAggregatesInput;
+
+    @Field(() => Int, {nullable:true})
+    take?: number;
+
+    @Field(() => Int, {nullable:true})
+    skip?: number;
+
+    @Field(() => MediaFileCountAggregateInput, {nullable:true})
+    _count?: MediaFileCountAggregateInput;
+
+    @Field(() => MediaFileAvgAggregateInput, {nullable:true})
+    _avg?: MediaFileAvgAggregateInput;
+
+    @Field(() => MediaFileSumAggregateInput, {nullable:true})
+    _sum?: MediaFileSumAggregateInput;
+
+    @Field(() => MediaFileMinAggregateInput, {nullable:true})
+    _min?: MediaFileMinAggregateInput;
+
+    @Field(() => MediaFileMaxAggregateInput, {nullable:true})
+    _max?: MediaFileMaxAggregateInput;
+}

--- a/api/@generated/media-file/media-file-group-by.output.ts
+++ b/api/@generated/media-file/media-file-group-by.output.ts
@@ -1,0 +1,45 @@
+import { Field } from '@nestjs/graphql';
+import { ObjectType } from '@nestjs/graphql';
+import { Int } from '@nestjs/graphql';
+import { MediaFileCountAggregate } from './media-file-count-aggregate.output';
+import { MediaFileAvgAggregate } from './media-file-avg-aggregate.output';
+import { MediaFileSumAggregate } from './media-file-sum-aggregate.output';
+import { MediaFileMinAggregate } from './media-file-min-aggregate.output';
+import { MediaFileMaxAggregate } from './media-file-max-aggregate.output';
+
+@ObjectType()
+export class MediaFileGroupBy {
+
+    @Field(() => Int, {nullable:false})
+    id!: number;
+
+    @Field(() => String, {nullable:false})
+    key!: string;
+
+    @Field(() => String, {nullable:false})
+    url!: string;
+
+    @Field(() => Int, {nullable:false})
+    postId!: number;
+
+    @Field(() => Date, {nullable:false})
+    createdAt!: Date | string;
+
+    @Field(() => Date, {nullable:false})
+    updatedAt!: Date | string;
+
+    @Field(() => MediaFileCountAggregate, {nullable:true})
+    _count?: MediaFileCountAggregate;
+
+    @Field(() => MediaFileAvgAggregate, {nullable:true})
+    _avg?: MediaFileAvgAggregate;
+
+    @Field(() => MediaFileSumAggregate, {nullable:true})
+    _sum?: MediaFileSumAggregate;
+
+    @Field(() => MediaFileMinAggregate, {nullable:true})
+    _min?: MediaFileMinAggregate;
+
+    @Field(() => MediaFileMaxAggregate, {nullable:true})
+    _max?: MediaFileMaxAggregate;
+}

--- a/api/@generated/media-file/media-file-list-relation-filter.input.ts
+++ b/api/@generated/media-file/media-file-list-relation-filter.input.ts
@@ -1,0 +1,16 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { MediaFileWhereInput } from './media-file-where.input';
+
+@InputType()
+export class MediaFileListRelationFilter {
+
+    @Field(() => MediaFileWhereInput, {nullable:true})
+    every?: MediaFileWhereInput;
+
+    @Field(() => MediaFileWhereInput, {nullable:true})
+    some?: MediaFileWhereInput;
+
+    @Field(() => MediaFileWhereInput, {nullable:true})
+    none?: MediaFileWhereInput;
+}

--- a/api/@generated/media-file/media-file-max-aggregate.input.ts
+++ b/api/@generated/media-file/media-file-max-aggregate.input.ts
@@ -1,0 +1,24 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+
+@InputType()
+export class MediaFileMaxAggregateInput {
+
+    @Field(() => Boolean, {nullable:true})
+    id?: true;
+
+    @Field(() => Boolean, {nullable:true})
+    key?: true;
+
+    @Field(() => Boolean, {nullable:true})
+    url?: true;
+
+    @Field(() => Boolean, {nullable:true})
+    postId?: true;
+
+    @Field(() => Boolean, {nullable:true})
+    createdAt?: true;
+
+    @Field(() => Boolean, {nullable:true})
+    updatedAt?: true;
+}

--- a/api/@generated/media-file/media-file-max-aggregate.output.ts
+++ b/api/@generated/media-file/media-file-max-aggregate.output.ts
@@ -1,0 +1,25 @@
+import { Field } from '@nestjs/graphql';
+import { ObjectType } from '@nestjs/graphql';
+import { Int } from '@nestjs/graphql';
+
+@ObjectType()
+export class MediaFileMaxAggregate {
+
+    @Field(() => Int, {nullable:true})
+    id?: number;
+
+    @Field(() => String, {nullable:true})
+    key?: string;
+
+    @Field(() => String, {nullable:true})
+    url?: string;
+
+    @Field(() => Int, {nullable:true})
+    postId?: number;
+
+    @Field(() => Date, {nullable:true})
+    createdAt?: Date | string;
+
+    @Field(() => Date, {nullable:true})
+    updatedAt?: Date | string;
+}

--- a/api/@generated/media-file/media-file-max-order-by-aggregate.input.ts
+++ b/api/@generated/media-file/media-file-max-order-by-aggregate.input.ts
@@ -1,0 +1,25 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { SortOrder } from '../prisma/sort-order.enum';
+
+@InputType()
+export class MediaFileMaxOrderByAggregateInput {
+
+    @Field(() => SortOrder, {nullable:true})
+    id?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    key?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    url?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    postId?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    createdAt?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    updatedAt?: keyof typeof SortOrder;
+}

--- a/api/@generated/media-file/media-file-min-aggregate.input.ts
+++ b/api/@generated/media-file/media-file-min-aggregate.input.ts
@@ -1,0 +1,24 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+
+@InputType()
+export class MediaFileMinAggregateInput {
+
+    @Field(() => Boolean, {nullable:true})
+    id?: true;
+
+    @Field(() => Boolean, {nullable:true})
+    key?: true;
+
+    @Field(() => Boolean, {nullable:true})
+    url?: true;
+
+    @Field(() => Boolean, {nullable:true})
+    postId?: true;
+
+    @Field(() => Boolean, {nullable:true})
+    createdAt?: true;
+
+    @Field(() => Boolean, {nullable:true})
+    updatedAt?: true;
+}

--- a/api/@generated/media-file/media-file-min-aggregate.output.ts
+++ b/api/@generated/media-file/media-file-min-aggregate.output.ts
@@ -1,0 +1,25 @@
+import { Field } from '@nestjs/graphql';
+import { ObjectType } from '@nestjs/graphql';
+import { Int } from '@nestjs/graphql';
+
+@ObjectType()
+export class MediaFileMinAggregate {
+
+    @Field(() => Int, {nullable:true})
+    id?: number;
+
+    @Field(() => String, {nullable:true})
+    key?: string;
+
+    @Field(() => String, {nullable:true})
+    url?: string;
+
+    @Field(() => Int, {nullable:true})
+    postId?: number;
+
+    @Field(() => Date, {nullable:true})
+    createdAt?: Date | string;
+
+    @Field(() => Date, {nullable:true})
+    updatedAt?: Date | string;
+}

--- a/api/@generated/media-file/media-file-min-order-by-aggregate.input.ts
+++ b/api/@generated/media-file/media-file-min-order-by-aggregate.input.ts
@@ -1,0 +1,25 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { SortOrder } from '../prisma/sort-order.enum';
+
+@InputType()
+export class MediaFileMinOrderByAggregateInput {
+
+    @Field(() => SortOrder, {nullable:true})
+    id?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    key?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    url?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    postId?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    createdAt?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    updatedAt?: keyof typeof SortOrder;
+}

--- a/api/@generated/media-file/media-file-order-by-relation-aggregate.input.ts
+++ b/api/@generated/media-file/media-file-order-by-relation-aggregate.input.ts
@@ -1,0 +1,10 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { SortOrder } from '../prisma/sort-order.enum';
+
+@InputType()
+export class MediaFileOrderByRelationAggregateInput {
+
+    @Field(() => SortOrder, {nullable:true})
+    _count?: keyof typeof SortOrder;
+}

--- a/api/@generated/media-file/media-file-order-by-with-aggregation.input.ts
+++ b/api/@generated/media-file/media-file-order-by-with-aggregation.input.ts
@@ -1,0 +1,45 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { SortOrder } from '../prisma/sort-order.enum';
+import { MediaFileCountOrderByAggregateInput } from './media-file-count-order-by-aggregate.input';
+import { MediaFileAvgOrderByAggregateInput } from './media-file-avg-order-by-aggregate.input';
+import { MediaFileMaxOrderByAggregateInput } from './media-file-max-order-by-aggregate.input';
+import { MediaFileMinOrderByAggregateInput } from './media-file-min-order-by-aggregate.input';
+import { MediaFileSumOrderByAggregateInput } from './media-file-sum-order-by-aggregate.input';
+
+@InputType()
+export class MediaFileOrderByWithAggregationInput {
+
+    @Field(() => SortOrder, {nullable:true})
+    id?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    key?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    url?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    postId?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    createdAt?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    updatedAt?: keyof typeof SortOrder;
+
+    @Field(() => MediaFileCountOrderByAggregateInput, {nullable:true})
+    _count?: MediaFileCountOrderByAggregateInput;
+
+    @Field(() => MediaFileAvgOrderByAggregateInput, {nullable:true})
+    _avg?: MediaFileAvgOrderByAggregateInput;
+
+    @Field(() => MediaFileMaxOrderByAggregateInput, {nullable:true})
+    _max?: MediaFileMaxOrderByAggregateInput;
+
+    @Field(() => MediaFileMinOrderByAggregateInput, {nullable:true})
+    _min?: MediaFileMinOrderByAggregateInput;
+
+    @Field(() => MediaFileSumOrderByAggregateInput, {nullable:true})
+    _sum?: MediaFileSumOrderByAggregateInput;
+}

--- a/api/@generated/media-file/media-file-order-by-with-relation.input.ts
+++ b/api/@generated/media-file/media-file-order-by-with-relation.input.ts
@@ -1,0 +1,29 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { SortOrder } from '../prisma/sort-order.enum';
+import { PostOrderByWithRelationInput } from '../post/post-order-by-with-relation.input';
+
+@InputType()
+export class MediaFileOrderByWithRelationInput {
+
+    @Field(() => SortOrder, {nullable:true})
+    id?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    key?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    url?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    postId?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    createdAt?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    updatedAt?: keyof typeof SortOrder;
+
+    @Field(() => PostOrderByWithRelationInput, {nullable:true})
+    post?: PostOrderByWithRelationInput;
+}

--- a/api/@generated/media-file/media-file-scalar-field.enum.ts
+++ b/api/@generated/media-file/media-file-scalar-field.enum.ts
@@ -1,0 +1,13 @@
+import { registerEnumType } from '@nestjs/graphql';
+
+export enum MediaFileScalarFieldEnum {
+    id = "id",
+    key = "key",
+    url = "url",
+    postId = "postId",
+    createdAt = "createdAt",
+    updatedAt = "updatedAt"
+}
+
+
+registerEnumType(MediaFileScalarFieldEnum, { name: 'MediaFileScalarFieldEnum', description: undefined })

--- a/api/@generated/media-file/media-file-scalar-where-with-aggregates.input.ts
+++ b/api/@generated/media-file/media-file-scalar-where-with-aggregates.input.ts
@@ -1,0 +1,36 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { IntWithAggregatesFilter } from '../prisma/int-with-aggregates-filter.input';
+import { StringWithAggregatesFilter } from '../prisma/string-with-aggregates-filter.input';
+import { DateTimeWithAggregatesFilter } from '../prisma/date-time-with-aggregates-filter.input';
+
+@InputType()
+export class MediaFileScalarWhereWithAggregatesInput {
+
+    @Field(() => [MediaFileScalarWhereWithAggregatesInput], {nullable:true})
+    AND?: Array<MediaFileScalarWhereWithAggregatesInput>;
+
+    @Field(() => [MediaFileScalarWhereWithAggregatesInput], {nullable:true})
+    OR?: Array<MediaFileScalarWhereWithAggregatesInput>;
+
+    @Field(() => [MediaFileScalarWhereWithAggregatesInput], {nullable:true})
+    NOT?: Array<MediaFileScalarWhereWithAggregatesInput>;
+
+    @Field(() => IntWithAggregatesFilter, {nullable:true})
+    id?: IntWithAggregatesFilter;
+
+    @Field(() => StringWithAggregatesFilter, {nullable:true})
+    key?: StringWithAggregatesFilter;
+
+    @Field(() => StringWithAggregatesFilter, {nullable:true})
+    url?: StringWithAggregatesFilter;
+
+    @Field(() => IntWithAggregatesFilter, {nullable:true})
+    postId?: IntWithAggregatesFilter;
+
+    @Field(() => DateTimeWithAggregatesFilter, {nullable:true})
+    createdAt?: DateTimeWithAggregatesFilter;
+
+    @Field(() => DateTimeWithAggregatesFilter, {nullable:true})
+    updatedAt?: DateTimeWithAggregatesFilter;
+}

--- a/api/@generated/media-file/media-file-scalar-where.input.ts
+++ b/api/@generated/media-file/media-file-scalar-where.input.ts
@@ -1,0 +1,36 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { IntFilter } from '../prisma/int-filter.input';
+import { StringFilter } from '../prisma/string-filter.input';
+import { DateTimeFilter } from '../prisma/date-time-filter.input';
+
+@InputType()
+export class MediaFileScalarWhereInput {
+
+    @Field(() => [MediaFileScalarWhereInput], {nullable:true})
+    AND?: Array<MediaFileScalarWhereInput>;
+
+    @Field(() => [MediaFileScalarWhereInput], {nullable:true})
+    OR?: Array<MediaFileScalarWhereInput>;
+
+    @Field(() => [MediaFileScalarWhereInput], {nullable:true})
+    NOT?: Array<MediaFileScalarWhereInput>;
+
+    @Field(() => IntFilter, {nullable:true})
+    id?: IntFilter;
+
+    @Field(() => StringFilter, {nullable:true})
+    key?: StringFilter;
+
+    @Field(() => StringFilter, {nullable:true})
+    url?: StringFilter;
+
+    @Field(() => IntFilter, {nullable:true})
+    postId?: IntFilter;
+
+    @Field(() => DateTimeFilter, {nullable:true})
+    createdAt?: DateTimeFilter;
+
+    @Field(() => DateTimeFilter, {nullable:true})
+    updatedAt?: DateTimeFilter;
+}

--- a/api/@generated/media-file/media-file-sum-aggregate.input.ts
+++ b/api/@generated/media-file/media-file-sum-aggregate.input.ts
@@ -1,0 +1,12 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+
+@InputType()
+export class MediaFileSumAggregateInput {
+
+    @Field(() => Boolean, {nullable:true})
+    id?: true;
+
+    @Field(() => Boolean, {nullable:true})
+    postId?: true;
+}

--- a/api/@generated/media-file/media-file-sum-aggregate.output.ts
+++ b/api/@generated/media-file/media-file-sum-aggregate.output.ts
@@ -1,0 +1,13 @@
+import { Field } from '@nestjs/graphql';
+import { ObjectType } from '@nestjs/graphql';
+import { Int } from '@nestjs/graphql';
+
+@ObjectType()
+export class MediaFileSumAggregate {
+
+    @Field(() => Int, {nullable:true})
+    id?: number;
+
+    @Field(() => Int, {nullable:true})
+    postId?: number;
+}

--- a/api/@generated/media-file/media-file-sum-order-by-aggregate.input.ts
+++ b/api/@generated/media-file/media-file-sum-order-by-aggregate.input.ts
@@ -1,0 +1,13 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { SortOrder } from '../prisma/sort-order.enum';
+
+@InputType()
+export class MediaFileSumOrderByAggregateInput {
+
+    @Field(() => SortOrder, {nullable:true})
+    id?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    postId?: keyof typeof SortOrder;
+}

--- a/api/@generated/media-file/media-file-unchecked-create-nested-many-without-post.input.ts
+++ b/api/@generated/media-file/media-file-unchecked-create-nested-many-without-post.input.ts
@@ -1,0 +1,28 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { MediaFileCreateWithoutPostInput } from './media-file-create-without-post.input';
+import { Type } from 'class-transformer';
+import { MediaFileCreateOrConnectWithoutPostInput } from './media-file-create-or-connect-without-post.input';
+import { MediaFileCreateManyPostInputEnvelope } from './media-file-create-many-post-input-envelope.input';
+import { Prisma } from '@prisma/client';
+import { MediaFileWhereUniqueInput } from './media-file-where-unique.input';
+
+@InputType()
+export class MediaFileUncheckedCreateNestedManyWithoutPostInput {
+
+    @Field(() => [MediaFileCreateWithoutPostInput], {nullable:true})
+    @Type(() => MediaFileCreateWithoutPostInput)
+    create?: Array<MediaFileCreateWithoutPostInput>;
+
+    @Field(() => [MediaFileCreateOrConnectWithoutPostInput], {nullable:true})
+    @Type(() => MediaFileCreateOrConnectWithoutPostInput)
+    connectOrCreate?: Array<MediaFileCreateOrConnectWithoutPostInput>;
+
+    @Field(() => MediaFileCreateManyPostInputEnvelope, {nullable:true})
+    @Type(() => MediaFileCreateManyPostInputEnvelope)
+    createMany?: MediaFileCreateManyPostInputEnvelope;
+
+    @Field(() => [MediaFileWhereUniqueInput], {nullable:true})
+    @Type(() => MediaFileWhereUniqueInput)
+    connect?: Array<Prisma.AtLeast<MediaFileWhereUniqueInput, 'id'>>;
+}

--- a/api/@generated/media-file/media-file-unchecked-create-without-post.input.ts
+++ b/api/@generated/media-file/media-file-unchecked-create-without-post.input.ts
@@ -1,0 +1,22 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { Int } from '@nestjs/graphql';
+
+@InputType()
+export class MediaFileUncheckedCreateWithoutPostInput {
+
+    @Field(() => Int, {nullable:true})
+    id?: number;
+
+    @Field(() => String, {nullable:false})
+    key!: string;
+
+    @Field(() => String, {nullable:false})
+    url!: string;
+
+    @Field(() => Date, {nullable:true})
+    createdAt?: Date | string;
+
+    @Field(() => Date, {nullable:true})
+    updatedAt?: Date | string;
+}

--- a/api/@generated/media-file/media-file-unchecked-create.input.ts
+++ b/api/@generated/media-file/media-file-unchecked-create.input.ts
@@ -1,0 +1,25 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { Int } from '@nestjs/graphql';
+
+@InputType()
+export class MediaFileUncheckedCreateInput {
+
+    @Field(() => Int, {nullable:true})
+    id?: number;
+
+    @Field(() => String, {nullable:false})
+    key!: string;
+
+    @Field(() => String, {nullable:false})
+    url!: string;
+
+    @Field(() => Int, {nullable:false})
+    postId!: number;
+
+    @Field(() => Date, {nullable:true})
+    createdAt?: Date | string;
+
+    @Field(() => Date, {nullable:true})
+    updatedAt?: Date | string;
+}

--- a/api/@generated/media-file/media-file-unchecked-update-many-without-post-nested.input.ts
+++ b/api/@generated/media-file/media-file-unchecked-update-many-without-post-nested.input.ts
@@ -1,0 +1,60 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { MediaFileCreateWithoutPostInput } from './media-file-create-without-post.input';
+import { Type } from 'class-transformer';
+import { MediaFileCreateOrConnectWithoutPostInput } from './media-file-create-or-connect-without-post.input';
+import { MediaFileUpsertWithWhereUniqueWithoutPostInput } from './media-file-upsert-with-where-unique-without-post.input';
+import { MediaFileCreateManyPostInputEnvelope } from './media-file-create-many-post-input-envelope.input';
+import { Prisma } from '@prisma/client';
+import { MediaFileWhereUniqueInput } from './media-file-where-unique.input';
+import { MediaFileUpdateWithWhereUniqueWithoutPostInput } from './media-file-update-with-where-unique-without-post.input';
+import { MediaFileUpdateManyWithWhereWithoutPostInput } from './media-file-update-many-with-where-without-post.input';
+import { MediaFileScalarWhereInput } from './media-file-scalar-where.input';
+
+@InputType()
+export class MediaFileUncheckedUpdateManyWithoutPostNestedInput {
+
+    @Field(() => [MediaFileCreateWithoutPostInput], {nullable:true})
+    @Type(() => MediaFileCreateWithoutPostInput)
+    create?: Array<MediaFileCreateWithoutPostInput>;
+
+    @Field(() => [MediaFileCreateOrConnectWithoutPostInput], {nullable:true})
+    @Type(() => MediaFileCreateOrConnectWithoutPostInput)
+    connectOrCreate?: Array<MediaFileCreateOrConnectWithoutPostInput>;
+
+    @Field(() => [MediaFileUpsertWithWhereUniqueWithoutPostInput], {nullable:true})
+    @Type(() => MediaFileUpsertWithWhereUniqueWithoutPostInput)
+    upsert?: Array<MediaFileUpsertWithWhereUniqueWithoutPostInput>;
+
+    @Field(() => MediaFileCreateManyPostInputEnvelope, {nullable:true})
+    @Type(() => MediaFileCreateManyPostInputEnvelope)
+    createMany?: MediaFileCreateManyPostInputEnvelope;
+
+    @Field(() => [MediaFileWhereUniqueInput], {nullable:true})
+    @Type(() => MediaFileWhereUniqueInput)
+    set?: Array<Prisma.AtLeast<MediaFileWhereUniqueInput, 'id'>>;
+
+    @Field(() => [MediaFileWhereUniqueInput], {nullable:true})
+    @Type(() => MediaFileWhereUniqueInput)
+    disconnect?: Array<Prisma.AtLeast<MediaFileWhereUniqueInput, 'id'>>;
+
+    @Field(() => [MediaFileWhereUniqueInput], {nullable:true})
+    @Type(() => MediaFileWhereUniqueInput)
+    delete?: Array<Prisma.AtLeast<MediaFileWhereUniqueInput, 'id'>>;
+
+    @Field(() => [MediaFileWhereUniqueInput], {nullable:true})
+    @Type(() => MediaFileWhereUniqueInput)
+    connect?: Array<Prisma.AtLeast<MediaFileWhereUniqueInput, 'id'>>;
+
+    @Field(() => [MediaFileUpdateWithWhereUniqueWithoutPostInput], {nullable:true})
+    @Type(() => MediaFileUpdateWithWhereUniqueWithoutPostInput)
+    update?: Array<MediaFileUpdateWithWhereUniqueWithoutPostInput>;
+
+    @Field(() => [MediaFileUpdateManyWithWhereWithoutPostInput], {nullable:true})
+    @Type(() => MediaFileUpdateManyWithWhereWithoutPostInput)
+    updateMany?: Array<MediaFileUpdateManyWithWhereWithoutPostInput>;
+
+    @Field(() => [MediaFileScalarWhereInput], {nullable:true})
+    @Type(() => MediaFileScalarWhereInput)
+    deleteMany?: Array<MediaFileScalarWhereInput>;
+}

--- a/api/@generated/media-file/media-file-unchecked-update-many-without-post.input.ts
+++ b/api/@generated/media-file/media-file-unchecked-update-many-without-post.input.ts
@@ -1,0 +1,24 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { IntFieldUpdateOperationsInput } from '../prisma/int-field-update-operations.input';
+import { StringFieldUpdateOperationsInput } from '../prisma/string-field-update-operations.input';
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
+
+@InputType()
+export class MediaFileUncheckedUpdateManyWithoutPostInput {
+
+    @Field(() => IntFieldUpdateOperationsInput, {nullable:true})
+    id?: IntFieldUpdateOperationsInput;
+
+    @Field(() => StringFieldUpdateOperationsInput, {nullable:true})
+    key?: StringFieldUpdateOperationsInput;
+
+    @Field(() => StringFieldUpdateOperationsInput, {nullable:true})
+    url?: StringFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    createdAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    updatedAt?: DateTimeFieldUpdateOperationsInput;
+}

--- a/api/@generated/media-file/media-file-unchecked-update-many.input.ts
+++ b/api/@generated/media-file/media-file-unchecked-update-many.input.ts
@@ -1,0 +1,27 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { IntFieldUpdateOperationsInput } from '../prisma/int-field-update-operations.input';
+import { StringFieldUpdateOperationsInput } from '../prisma/string-field-update-operations.input';
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
+
+@InputType()
+export class MediaFileUncheckedUpdateManyInput {
+
+    @Field(() => IntFieldUpdateOperationsInput, {nullable:true})
+    id?: IntFieldUpdateOperationsInput;
+
+    @Field(() => StringFieldUpdateOperationsInput, {nullable:true})
+    key?: StringFieldUpdateOperationsInput;
+
+    @Field(() => StringFieldUpdateOperationsInput, {nullable:true})
+    url?: StringFieldUpdateOperationsInput;
+
+    @Field(() => IntFieldUpdateOperationsInput, {nullable:true})
+    postId?: IntFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    createdAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    updatedAt?: DateTimeFieldUpdateOperationsInput;
+}

--- a/api/@generated/media-file/media-file-unchecked-update-without-post.input.ts
+++ b/api/@generated/media-file/media-file-unchecked-update-without-post.input.ts
@@ -1,0 +1,24 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { IntFieldUpdateOperationsInput } from '../prisma/int-field-update-operations.input';
+import { StringFieldUpdateOperationsInput } from '../prisma/string-field-update-operations.input';
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
+
+@InputType()
+export class MediaFileUncheckedUpdateWithoutPostInput {
+
+    @Field(() => IntFieldUpdateOperationsInput, {nullable:true})
+    id?: IntFieldUpdateOperationsInput;
+
+    @Field(() => StringFieldUpdateOperationsInput, {nullable:true})
+    key?: StringFieldUpdateOperationsInput;
+
+    @Field(() => StringFieldUpdateOperationsInput, {nullable:true})
+    url?: StringFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    createdAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    updatedAt?: DateTimeFieldUpdateOperationsInput;
+}

--- a/api/@generated/media-file/media-file-unchecked-update.input.ts
+++ b/api/@generated/media-file/media-file-unchecked-update.input.ts
@@ -1,0 +1,27 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { IntFieldUpdateOperationsInput } from '../prisma/int-field-update-operations.input';
+import { StringFieldUpdateOperationsInput } from '../prisma/string-field-update-operations.input';
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
+
+@InputType()
+export class MediaFileUncheckedUpdateInput {
+
+    @Field(() => IntFieldUpdateOperationsInput, {nullable:true})
+    id?: IntFieldUpdateOperationsInput;
+
+    @Field(() => StringFieldUpdateOperationsInput, {nullable:true})
+    key?: StringFieldUpdateOperationsInput;
+
+    @Field(() => StringFieldUpdateOperationsInput, {nullable:true})
+    url?: StringFieldUpdateOperationsInput;
+
+    @Field(() => IntFieldUpdateOperationsInput, {nullable:true})
+    postId?: IntFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    createdAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    updatedAt?: DateTimeFieldUpdateOperationsInput;
+}

--- a/api/@generated/media-file/media-file-update-many-mutation.input.ts
+++ b/api/@generated/media-file/media-file-update-many-mutation.input.ts
@@ -1,0 +1,20 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { StringFieldUpdateOperationsInput } from '../prisma/string-field-update-operations.input';
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
+
+@InputType()
+export class MediaFileUpdateManyMutationInput {
+
+    @Field(() => StringFieldUpdateOperationsInput, {nullable:true})
+    key?: StringFieldUpdateOperationsInput;
+
+    @Field(() => StringFieldUpdateOperationsInput, {nullable:true})
+    url?: StringFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    createdAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    updatedAt?: DateTimeFieldUpdateOperationsInput;
+}

--- a/api/@generated/media-file/media-file-update-many-with-where-without-post.input.ts
+++ b/api/@generated/media-file/media-file-update-many-with-where-without-post.input.ts
@@ -1,0 +1,17 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { MediaFileScalarWhereInput } from './media-file-scalar-where.input';
+import { Type } from 'class-transformer';
+import { MediaFileUpdateManyMutationInput } from './media-file-update-many-mutation.input';
+
+@InputType()
+export class MediaFileUpdateManyWithWhereWithoutPostInput {
+
+    @Field(() => MediaFileScalarWhereInput, {nullable:false})
+    @Type(() => MediaFileScalarWhereInput)
+    where!: MediaFileScalarWhereInput;
+
+    @Field(() => MediaFileUpdateManyMutationInput, {nullable:false})
+    @Type(() => MediaFileUpdateManyMutationInput)
+    data!: MediaFileUpdateManyMutationInput;
+}

--- a/api/@generated/media-file/media-file-update-many-without-post-nested.input.ts
+++ b/api/@generated/media-file/media-file-update-many-without-post-nested.input.ts
@@ -1,0 +1,60 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { MediaFileCreateWithoutPostInput } from './media-file-create-without-post.input';
+import { Type } from 'class-transformer';
+import { MediaFileCreateOrConnectWithoutPostInput } from './media-file-create-or-connect-without-post.input';
+import { MediaFileUpsertWithWhereUniqueWithoutPostInput } from './media-file-upsert-with-where-unique-without-post.input';
+import { MediaFileCreateManyPostInputEnvelope } from './media-file-create-many-post-input-envelope.input';
+import { Prisma } from '@prisma/client';
+import { MediaFileWhereUniqueInput } from './media-file-where-unique.input';
+import { MediaFileUpdateWithWhereUniqueWithoutPostInput } from './media-file-update-with-where-unique-without-post.input';
+import { MediaFileUpdateManyWithWhereWithoutPostInput } from './media-file-update-many-with-where-without-post.input';
+import { MediaFileScalarWhereInput } from './media-file-scalar-where.input';
+
+@InputType()
+export class MediaFileUpdateManyWithoutPostNestedInput {
+
+    @Field(() => [MediaFileCreateWithoutPostInput], {nullable:true})
+    @Type(() => MediaFileCreateWithoutPostInput)
+    create?: Array<MediaFileCreateWithoutPostInput>;
+
+    @Field(() => [MediaFileCreateOrConnectWithoutPostInput], {nullable:true})
+    @Type(() => MediaFileCreateOrConnectWithoutPostInput)
+    connectOrCreate?: Array<MediaFileCreateOrConnectWithoutPostInput>;
+
+    @Field(() => [MediaFileUpsertWithWhereUniqueWithoutPostInput], {nullable:true})
+    @Type(() => MediaFileUpsertWithWhereUniqueWithoutPostInput)
+    upsert?: Array<MediaFileUpsertWithWhereUniqueWithoutPostInput>;
+
+    @Field(() => MediaFileCreateManyPostInputEnvelope, {nullable:true})
+    @Type(() => MediaFileCreateManyPostInputEnvelope)
+    createMany?: MediaFileCreateManyPostInputEnvelope;
+
+    @Field(() => [MediaFileWhereUniqueInput], {nullable:true})
+    @Type(() => MediaFileWhereUniqueInput)
+    set?: Array<Prisma.AtLeast<MediaFileWhereUniqueInput, 'id'>>;
+
+    @Field(() => [MediaFileWhereUniqueInput], {nullable:true})
+    @Type(() => MediaFileWhereUniqueInput)
+    disconnect?: Array<Prisma.AtLeast<MediaFileWhereUniqueInput, 'id'>>;
+
+    @Field(() => [MediaFileWhereUniqueInput], {nullable:true})
+    @Type(() => MediaFileWhereUniqueInput)
+    delete?: Array<Prisma.AtLeast<MediaFileWhereUniqueInput, 'id'>>;
+
+    @Field(() => [MediaFileWhereUniqueInput], {nullable:true})
+    @Type(() => MediaFileWhereUniqueInput)
+    connect?: Array<Prisma.AtLeast<MediaFileWhereUniqueInput, 'id'>>;
+
+    @Field(() => [MediaFileUpdateWithWhereUniqueWithoutPostInput], {nullable:true})
+    @Type(() => MediaFileUpdateWithWhereUniqueWithoutPostInput)
+    update?: Array<MediaFileUpdateWithWhereUniqueWithoutPostInput>;
+
+    @Field(() => [MediaFileUpdateManyWithWhereWithoutPostInput], {nullable:true})
+    @Type(() => MediaFileUpdateManyWithWhereWithoutPostInput)
+    updateMany?: Array<MediaFileUpdateManyWithWhereWithoutPostInput>;
+
+    @Field(() => [MediaFileScalarWhereInput], {nullable:true})
+    @Type(() => MediaFileScalarWhereInput)
+    deleteMany?: Array<MediaFileScalarWhereInput>;
+}

--- a/api/@generated/media-file/media-file-update-with-where-unique-without-post.input.ts
+++ b/api/@generated/media-file/media-file-update-with-where-unique-without-post.input.ts
@@ -1,0 +1,18 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { Prisma } from '@prisma/client';
+import { MediaFileWhereUniqueInput } from './media-file-where-unique.input';
+import { Type } from 'class-transformer';
+import { MediaFileUpdateWithoutPostInput } from './media-file-update-without-post.input';
+
+@InputType()
+export class MediaFileUpdateWithWhereUniqueWithoutPostInput {
+
+    @Field(() => MediaFileWhereUniqueInput, {nullable:false})
+    @Type(() => MediaFileWhereUniqueInput)
+    where!: Prisma.AtLeast<MediaFileWhereUniqueInput, 'id'>;
+
+    @Field(() => MediaFileUpdateWithoutPostInput, {nullable:false})
+    @Type(() => MediaFileUpdateWithoutPostInput)
+    data!: MediaFileUpdateWithoutPostInput;
+}

--- a/api/@generated/media-file/media-file-update-without-post.input.ts
+++ b/api/@generated/media-file/media-file-update-without-post.input.ts
@@ -1,0 +1,20 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { StringFieldUpdateOperationsInput } from '../prisma/string-field-update-operations.input';
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
+
+@InputType()
+export class MediaFileUpdateWithoutPostInput {
+
+    @Field(() => StringFieldUpdateOperationsInput, {nullable:true})
+    key?: StringFieldUpdateOperationsInput;
+
+    @Field(() => StringFieldUpdateOperationsInput, {nullable:true})
+    url?: StringFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    createdAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    updatedAt?: DateTimeFieldUpdateOperationsInput;
+}

--- a/api/@generated/media-file/media-file-update.input.ts
+++ b/api/@generated/media-file/media-file-update.input.ts
@@ -1,0 +1,24 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { StringFieldUpdateOperationsInput } from '../prisma/string-field-update-operations.input';
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
+import { PostUpdateOneRequiredWithoutMediaFilesNestedInput } from '../post/post-update-one-required-without-media-files-nested.input';
+
+@InputType()
+export class MediaFileUpdateInput {
+
+    @Field(() => StringFieldUpdateOperationsInput, {nullable:true})
+    key?: StringFieldUpdateOperationsInput;
+
+    @Field(() => StringFieldUpdateOperationsInput, {nullable:true})
+    url?: StringFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    createdAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    updatedAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => PostUpdateOneRequiredWithoutMediaFilesNestedInput, {nullable:true})
+    post?: PostUpdateOneRequiredWithoutMediaFilesNestedInput;
+}

--- a/api/@generated/media-file/media-file-upsert-with-where-unique-without-post.input.ts
+++ b/api/@generated/media-file/media-file-upsert-with-where-unique-without-post.input.ts
@@ -1,0 +1,23 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { Prisma } from '@prisma/client';
+import { MediaFileWhereUniqueInput } from './media-file-where-unique.input';
+import { Type } from 'class-transformer';
+import { MediaFileUpdateWithoutPostInput } from './media-file-update-without-post.input';
+import { MediaFileCreateWithoutPostInput } from './media-file-create-without-post.input';
+
+@InputType()
+export class MediaFileUpsertWithWhereUniqueWithoutPostInput {
+
+    @Field(() => MediaFileWhereUniqueInput, {nullable:false})
+    @Type(() => MediaFileWhereUniqueInput)
+    where!: Prisma.AtLeast<MediaFileWhereUniqueInput, 'id'>;
+
+    @Field(() => MediaFileUpdateWithoutPostInput, {nullable:false})
+    @Type(() => MediaFileUpdateWithoutPostInput)
+    update!: MediaFileUpdateWithoutPostInput;
+
+    @Field(() => MediaFileCreateWithoutPostInput, {nullable:false})
+    @Type(() => MediaFileCreateWithoutPostInput)
+    create!: MediaFileCreateWithoutPostInput;
+}

--- a/api/@generated/media-file/media-file-where-unique.input.ts
+++ b/api/@generated/media-file/media-file-where-unique.input.ts
@@ -1,0 +1,42 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { Int } from '@nestjs/graphql';
+import { MediaFileWhereInput } from './media-file-where.input';
+import { StringFilter } from '../prisma/string-filter.input';
+import { IntFilter } from '../prisma/int-filter.input';
+import { DateTimeFilter } from '../prisma/date-time-filter.input';
+import { PostRelationFilter } from '../post/post-relation-filter.input';
+
+@InputType()
+export class MediaFileWhereUniqueInput {
+
+    @Field(() => Int, {nullable:true})
+    id?: number;
+
+    @Field(() => [MediaFileWhereInput], {nullable:true})
+    AND?: Array<MediaFileWhereInput>;
+
+    @Field(() => [MediaFileWhereInput], {nullable:true})
+    OR?: Array<MediaFileWhereInput>;
+
+    @Field(() => [MediaFileWhereInput], {nullable:true})
+    NOT?: Array<MediaFileWhereInput>;
+
+    @Field(() => StringFilter, {nullable:true})
+    key?: StringFilter;
+
+    @Field(() => StringFilter, {nullable:true})
+    url?: StringFilter;
+
+    @Field(() => IntFilter, {nullable:true})
+    postId?: IntFilter;
+
+    @Field(() => DateTimeFilter, {nullable:true})
+    createdAt?: DateTimeFilter;
+
+    @Field(() => DateTimeFilter, {nullable:true})
+    updatedAt?: DateTimeFilter;
+
+    @Field(() => PostRelationFilter, {nullable:true})
+    post?: PostRelationFilter;
+}

--- a/api/@generated/media-file/media-file-where.input.ts
+++ b/api/@generated/media-file/media-file-where.input.ts
@@ -1,0 +1,40 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { IntFilter } from '../prisma/int-filter.input';
+import { StringFilter } from '../prisma/string-filter.input';
+import { DateTimeFilter } from '../prisma/date-time-filter.input';
+import { PostRelationFilter } from '../post/post-relation-filter.input';
+
+@InputType()
+export class MediaFileWhereInput {
+
+    @Field(() => [MediaFileWhereInput], {nullable:true})
+    AND?: Array<MediaFileWhereInput>;
+
+    @Field(() => [MediaFileWhereInput], {nullable:true})
+    OR?: Array<MediaFileWhereInput>;
+
+    @Field(() => [MediaFileWhereInput], {nullable:true})
+    NOT?: Array<MediaFileWhereInput>;
+
+    @Field(() => IntFilter, {nullable:true})
+    id?: IntFilter;
+
+    @Field(() => StringFilter, {nullable:true})
+    key?: StringFilter;
+
+    @Field(() => StringFilter, {nullable:true})
+    url?: StringFilter;
+
+    @Field(() => IntFilter, {nullable:true})
+    postId?: IntFilter;
+
+    @Field(() => DateTimeFilter, {nullable:true})
+    createdAt?: DateTimeFilter;
+
+    @Field(() => DateTimeFilter, {nullable:true})
+    updatedAt?: DateTimeFilter;
+
+    @Field(() => PostRelationFilter, {nullable:true})
+    post?: PostRelationFilter;
+}

--- a/api/@generated/media-file/media-file.model.ts
+++ b/api/@generated/media-file/media-file.model.ts
@@ -1,0 +1,30 @@
+import { Field } from '@nestjs/graphql';
+import { ObjectType } from '@nestjs/graphql';
+import { ID } from '@nestjs/graphql';
+import { Int } from '@nestjs/graphql';
+import { Post } from '../post/post.model';
+
+@ObjectType()
+export class MediaFile {
+
+    @Field(() => ID, {nullable:false})
+    id!: number;
+
+    @Field(() => String, {nullable:false})
+    key!: string;
+
+    @Field(() => String, {nullable:false})
+    url!: string;
+
+    @Field(() => Int, {nullable:false})
+    postId!: number;
+
+    @Field(() => Date, {nullable:false})
+    createdAt!: Date;
+
+    @Field(() => Date, {nullable:false})
+    updatedAt!: Date;
+
+    @Field(() => Post, {nullable:false})
+    post?: Post;
+}

--- a/api/@generated/media-file/update-many-media-file.args.ts
+++ b/api/@generated/media-file/update-many-media-file.args.ts
@@ -1,0 +1,17 @@
+import { Field } from '@nestjs/graphql';
+import { ArgsType } from '@nestjs/graphql';
+import { MediaFileUpdateManyMutationInput } from './media-file-update-many-mutation.input';
+import { Type } from 'class-transformer';
+import { MediaFileWhereInput } from './media-file-where.input';
+
+@ArgsType()
+export class UpdateManyMediaFileArgs {
+
+    @Field(() => MediaFileUpdateManyMutationInput, {nullable:false})
+    @Type(() => MediaFileUpdateManyMutationInput)
+    data!: MediaFileUpdateManyMutationInput;
+
+    @Field(() => MediaFileWhereInput, {nullable:true})
+    @Type(() => MediaFileWhereInput)
+    where?: MediaFileWhereInput;
+}

--- a/api/@generated/media-file/update-one-media-file.args.ts
+++ b/api/@generated/media-file/update-one-media-file.args.ts
@@ -1,0 +1,18 @@
+import { Field } from '@nestjs/graphql';
+import { ArgsType } from '@nestjs/graphql';
+import { MediaFileUpdateInput } from './media-file-update.input';
+import { Type } from 'class-transformer';
+import { Prisma } from '@prisma/client';
+import { MediaFileWhereUniqueInput } from './media-file-where-unique.input';
+
+@ArgsType()
+export class UpdateOneMediaFileArgs {
+
+    @Field(() => MediaFileUpdateInput, {nullable:false})
+    @Type(() => MediaFileUpdateInput)
+    data!: MediaFileUpdateInput;
+
+    @Field(() => MediaFileWhereUniqueInput, {nullable:false})
+    @Type(() => MediaFileWhereUniqueInput)
+    where!: Prisma.AtLeast<MediaFileWhereUniqueInput, 'id'>;
+}

--- a/api/@generated/media-file/upsert-one-media-file.args.ts
+++ b/api/@generated/media-file/upsert-one-media-file.args.ts
@@ -1,0 +1,23 @@
+import { Field } from '@nestjs/graphql';
+import { ArgsType } from '@nestjs/graphql';
+import { Prisma } from '@prisma/client';
+import { MediaFileWhereUniqueInput } from './media-file-where-unique.input';
+import { Type } from 'class-transformer';
+import { MediaFileCreateInput } from './media-file-create.input';
+import { MediaFileUpdateInput } from './media-file-update.input';
+
+@ArgsType()
+export class UpsertOneMediaFileArgs {
+
+    @Field(() => MediaFileWhereUniqueInput, {nullable:false})
+    @Type(() => MediaFileWhereUniqueInput)
+    where!: Prisma.AtLeast<MediaFileWhereUniqueInput, 'id'>;
+
+    @Field(() => MediaFileCreateInput, {nullable:false})
+    @Type(() => MediaFileCreateInput)
+    create!: MediaFileCreateInput;
+
+    @Field(() => MediaFileUpdateInput, {nullable:false})
+    @Type(() => MediaFileUpdateInput)
+    update!: MediaFileUpdateInput;
+}

--- a/api/@generated/post/post-count-aggregate.input.ts
+++ b/api/@generated/post/post-count-aggregate.input.ts
@@ -11,9 +11,6 @@ export class PostCountAggregateInput {
     title?: true;
 
     @Field(() => Boolean, {nullable:true})
-    mediaUrls?: true;
-
-    @Field(() => Boolean, {nullable:true})
     userId?: true;
 
     @Field(() => Boolean, {nullable:true})

--- a/api/@generated/post/post-count-aggregate.output.ts
+++ b/api/@generated/post/post-count-aggregate.output.ts
@@ -12,9 +12,6 @@ export class PostCountAggregate {
     title!: number;
 
     @Field(() => Int, {nullable:false})
-    mediaUrls!: number;
-
-    @Field(() => Int, {nullable:false})
     userId!: number;
 
     @Field(() => Int, {nullable:false})

--- a/api/@generated/post/post-count-order-by-aggregate.input.ts
+++ b/api/@generated/post/post-count-order-by-aggregate.input.ts
@@ -12,9 +12,6 @@ export class PostCountOrderByAggregateInput {
     title?: keyof typeof SortOrder;
 
     @Field(() => SortOrder, {nullable:true})
-    mediaUrls?: keyof typeof SortOrder;
-
-    @Field(() => SortOrder, {nullable:true})
     userId?: keyof typeof SortOrder;
 
     @Field(() => SortOrder, {nullable:true})

--- a/api/@generated/post/post-count.output.ts
+++ b/api/@generated/post/post-count.output.ts
@@ -6,5 +6,8 @@ import { Int } from '@nestjs/graphql';
 export class PostCount {
 
     @Field(() => Int, {nullable:false})
+    mediaFiles?: number;
+
+    @Field(() => Int, {nullable:false})
     postHashtags?: number;
 }

--- a/api/@generated/post/post-create-many-user.input.ts
+++ b/api/@generated/post/post-create-many-user.input.ts
@@ -1,7 +1,6 @@
 import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
 import { Int } from '@nestjs/graphql';
-import { PostCreatemediaUrlsInput } from './post-createmedia-urls.input';
 
 @InputType()
 export class PostCreateManyUserInput {
@@ -11,9 +10,6 @@ export class PostCreateManyUserInput {
 
     @Field(() => String, {nullable:true})
     title?: string;
-
-    @Field(() => PostCreatemediaUrlsInput, {nullable:true})
-    mediaUrls?: PostCreatemediaUrlsInput;
 
     @Field(() => Boolean, {nullable:true})
     isHideLikeAndCount?: boolean;

--- a/api/@generated/post/post-create-many.input.ts
+++ b/api/@generated/post/post-create-many.input.ts
@@ -1,7 +1,6 @@
 import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
 import { Int } from '@nestjs/graphql';
-import { PostCreatemediaUrlsInput } from './post-createmedia-urls.input';
 
 @InputType()
 export class PostCreateManyInput {
@@ -11,9 +10,6 @@ export class PostCreateManyInput {
 
     @Field(() => String, {nullable:true})
     title?: string;
-
-    @Field(() => PostCreatemediaUrlsInput, {nullable:true})
-    mediaUrls?: PostCreatemediaUrlsInput;
 
     @Field(() => Int, {nullable:false})
     userId!: number;

--- a/api/@generated/post/post-create-nested-one-without-media-files.input.ts
+++ b/api/@generated/post/post-create-nested-one-without-media-files.input.ts
@@ -1,0 +1,23 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { PostCreateWithoutMediaFilesInput } from './post-create-without-media-files.input';
+import { Type } from 'class-transformer';
+import { PostCreateOrConnectWithoutMediaFilesInput } from './post-create-or-connect-without-media-files.input';
+import { Prisma } from '@prisma/client';
+import { PostWhereUniqueInput } from './post-where-unique.input';
+
+@InputType()
+export class PostCreateNestedOneWithoutMediaFilesInput {
+
+    @Field(() => PostCreateWithoutMediaFilesInput, {nullable:true})
+    @Type(() => PostCreateWithoutMediaFilesInput)
+    create?: PostCreateWithoutMediaFilesInput;
+
+    @Field(() => PostCreateOrConnectWithoutMediaFilesInput, {nullable:true})
+    @Type(() => PostCreateOrConnectWithoutMediaFilesInput)
+    connectOrCreate?: PostCreateOrConnectWithoutMediaFilesInput;
+
+    @Field(() => PostWhereUniqueInput, {nullable:true})
+    @Type(() => PostWhereUniqueInput)
+    connect?: Prisma.AtLeast<PostWhereUniqueInput, 'id'>;
+}

--- a/api/@generated/post/post-create-or-connect-without-media-files.input.ts
+++ b/api/@generated/post/post-create-or-connect-without-media-files.input.ts
@@ -1,0 +1,18 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { Prisma } from '@prisma/client';
+import { PostWhereUniqueInput } from './post-where-unique.input';
+import { Type } from 'class-transformer';
+import { PostCreateWithoutMediaFilesInput } from './post-create-without-media-files.input';
+
+@InputType()
+export class PostCreateOrConnectWithoutMediaFilesInput {
+
+    @Field(() => PostWhereUniqueInput, {nullable:false})
+    @Type(() => PostWhereUniqueInput)
+    where!: Prisma.AtLeast<PostWhereUniqueInput, 'id'>;
+
+    @Field(() => PostCreateWithoutMediaFilesInput, {nullable:false})
+    @Type(() => PostCreateWithoutMediaFilesInput)
+    create!: PostCreateWithoutMediaFilesInput;
+}

--- a/api/@generated/post/post-create-without-media-files.input.ts
+++ b/api/@generated/post/post-create-without-media-files.input.ts
@@ -1,0 +1,29 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { UserCreateNestedOneWithoutPostsInput } from '../user/user-create-nested-one-without-posts.input';
+import { PostHashtagCreateNestedManyWithoutPostInput } from '../post-hashtag/post-hashtag-create-nested-many-without-post.input';
+
+@InputType()
+export class PostCreateWithoutMediaFilesInput {
+
+    @Field(() => String, {nullable:true})
+    title?: string;
+
+    @Field(() => Boolean, {nullable:true})
+    isHideLikeAndCount?: boolean;
+
+    @Field(() => Boolean, {nullable:true})
+    isTurnOffComment?: boolean;
+
+    @Field(() => Date, {nullable:true})
+    createdAt?: Date | string;
+
+    @Field(() => Date, {nullable:true})
+    updatedAt?: Date | string;
+
+    @Field(() => UserCreateNestedOneWithoutPostsInput, {nullable:false})
+    user!: UserCreateNestedOneWithoutPostsInput;
+
+    @Field(() => PostHashtagCreateNestedManyWithoutPostInput, {nullable:true})
+    postHashtags?: PostHashtagCreateNestedManyWithoutPostInput;
+}

--- a/api/@generated/post/post-create-without-post-hashtags.input.ts
+++ b/api/@generated/post/post-create-without-post-hashtags.input.ts
@@ -1,6 +1,6 @@
 import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
-import { PostCreatemediaUrlsInput } from './post-createmedia-urls.input';
+import { MediaFileCreateNestedManyWithoutPostInput } from '../media-file/media-file-create-nested-many-without-post.input';
 import { UserCreateNestedOneWithoutPostsInput } from '../user/user-create-nested-one-without-posts.input';
 
 @InputType()
@@ -8,9 +8,6 @@ export class PostCreateWithoutPostHashtagsInput {
 
     @Field(() => String, {nullable:true})
     title?: string;
-
-    @Field(() => PostCreatemediaUrlsInput, {nullable:true})
-    mediaUrls?: PostCreatemediaUrlsInput;
 
     @Field(() => Boolean, {nullable:true})
     isHideLikeAndCount?: boolean;
@@ -23,6 +20,9 @@ export class PostCreateWithoutPostHashtagsInput {
 
     @Field(() => Date, {nullable:true})
     updatedAt?: Date | string;
+
+    @Field(() => MediaFileCreateNestedManyWithoutPostInput, {nullable:true})
+    mediaFiles?: MediaFileCreateNestedManyWithoutPostInput;
 
     @Field(() => UserCreateNestedOneWithoutPostsInput, {nullable:false})
     user!: UserCreateNestedOneWithoutPostsInput;

--- a/api/@generated/post/post-create-without-user.input.ts
+++ b/api/@generated/post/post-create-without-user.input.ts
@@ -1,6 +1,6 @@
 import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
-import { PostCreatemediaUrlsInput } from './post-createmedia-urls.input';
+import { MediaFileCreateNestedManyWithoutPostInput } from '../media-file/media-file-create-nested-many-without-post.input';
 import { PostHashtagCreateNestedManyWithoutPostInput } from '../post-hashtag/post-hashtag-create-nested-many-without-post.input';
 
 @InputType()
@@ -8,9 +8,6 @@ export class PostCreateWithoutUserInput {
 
     @Field(() => String, {nullable:true})
     title?: string;
-
-    @Field(() => PostCreatemediaUrlsInput, {nullable:true})
-    mediaUrls?: PostCreatemediaUrlsInput;
 
     @Field(() => Boolean, {nullable:true})
     isHideLikeAndCount?: boolean;
@@ -23,6 +20,9 @@ export class PostCreateWithoutUserInput {
 
     @Field(() => Date, {nullable:true})
     updatedAt?: Date | string;
+
+    @Field(() => MediaFileCreateNestedManyWithoutPostInput, {nullable:true})
+    mediaFiles?: MediaFileCreateNestedManyWithoutPostInput;
 
     @Field(() => PostHashtagCreateNestedManyWithoutPostInput, {nullable:true})
     postHashtags?: PostHashtagCreateNestedManyWithoutPostInput;

--- a/api/@generated/post/post-create.input.ts
+++ b/api/@generated/post/post-create.input.ts
@@ -1,6 +1,6 @@
 import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
-import { PostCreatemediaUrlsInput } from './post-createmedia-urls.input';
+import { MediaFileCreateNestedManyWithoutPostInput } from '../media-file/media-file-create-nested-many-without-post.input';
 import { UserCreateNestedOneWithoutPostsInput } from '../user/user-create-nested-one-without-posts.input';
 import { PostHashtagCreateNestedManyWithoutPostInput } from '../post-hashtag/post-hashtag-create-nested-many-without-post.input';
 
@@ -9,9 +9,6 @@ export class PostCreateInput {
 
     @Field(() => String, {nullable:true})
     title?: string;
-
-    @Field(() => PostCreatemediaUrlsInput, {nullable:true})
-    mediaUrls?: PostCreatemediaUrlsInput;
 
     @Field(() => Boolean, {nullable:true})
     isHideLikeAndCount?: boolean;
@@ -24,6 +21,9 @@ export class PostCreateInput {
 
     @Field(() => Date, {nullable:true})
     updatedAt?: Date | string;
+
+    @Field(() => MediaFileCreateNestedManyWithoutPostInput, {nullable:true})
+    mediaFiles?: MediaFileCreateNestedManyWithoutPostInput;
 
     @Field(() => UserCreateNestedOneWithoutPostsInput, {nullable:false})
     user!: UserCreateNestedOneWithoutPostsInput;

--- a/api/@generated/post/post-group-by.output.ts
+++ b/api/@generated/post/post-group-by.output.ts
@@ -16,9 +16,6 @@ export class PostGroupBy {
     @Field(() => String, {nullable:true})
     title?: string;
 
-    @Field(() => [String], {nullable:true})
-    mediaUrls?: Array<string>;
-
     @Field(() => Int, {nullable:false})
     userId!: number;
 

--- a/api/@generated/post/post-order-by-with-aggregation.input.ts
+++ b/api/@generated/post/post-order-by-with-aggregation.input.ts
@@ -18,9 +18,6 @@ export class PostOrderByWithAggregationInput {
     title?: SortOrderInput;
 
     @Field(() => SortOrder, {nullable:true})
-    mediaUrls?: keyof typeof SortOrder;
-
-    @Field(() => SortOrder, {nullable:true})
     userId?: keyof typeof SortOrder;
 
     @Field(() => SortOrder, {nullable:true})

--- a/api/@generated/post/post-order-by-with-relation.input.ts
+++ b/api/@generated/post/post-order-by-with-relation.input.ts
@@ -2,6 +2,7 @@ import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
 import { SortOrder } from '../prisma/sort-order.enum';
 import { SortOrderInput } from '../prisma/sort-order.input';
+import { MediaFileOrderByRelationAggregateInput } from '../media-file/media-file-order-by-relation-aggregate.input';
 import { UserOrderByWithRelationInput } from '../user/user-order-by-with-relation.input';
 import { PostHashtagOrderByRelationAggregateInput } from '../post-hashtag/post-hashtag-order-by-relation-aggregate.input';
 
@@ -13,9 +14,6 @@ export class PostOrderByWithRelationInput {
 
     @Field(() => SortOrderInput, {nullable:true})
     title?: SortOrderInput;
-
-    @Field(() => SortOrder, {nullable:true})
-    mediaUrls?: keyof typeof SortOrder;
 
     @Field(() => SortOrder, {nullable:true})
     userId?: keyof typeof SortOrder;
@@ -31,6 +29,9 @@ export class PostOrderByWithRelationInput {
 
     @Field(() => SortOrder, {nullable:true})
     updatedAt?: keyof typeof SortOrder;
+
+    @Field(() => MediaFileOrderByRelationAggregateInput, {nullable:true})
+    mediaFiles?: MediaFileOrderByRelationAggregateInput;
 
     @Field(() => UserOrderByWithRelationInput, {nullable:true})
     user?: UserOrderByWithRelationInput;

--- a/api/@generated/post/post-scalar-field.enum.ts
+++ b/api/@generated/post/post-scalar-field.enum.ts
@@ -3,7 +3,6 @@ import { registerEnumType } from '@nestjs/graphql';
 export enum PostScalarFieldEnum {
     id = "id",
     title = "title",
-    mediaUrls = "mediaUrls",
     userId = "userId",
     isHideLikeAndCount = "isHideLikeAndCount",
     isTurnOffComment = "isTurnOffComment",

--- a/api/@generated/post/post-scalar-where-with-aggregates.input.ts
+++ b/api/@generated/post/post-scalar-where-with-aggregates.input.ts
@@ -2,7 +2,6 @@ import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
 import { IntWithAggregatesFilter } from '../prisma/int-with-aggregates-filter.input';
 import { StringNullableWithAggregatesFilter } from '../prisma/string-nullable-with-aggregates-filter.input';
-import { StringNullableListFilter } from '../prisma/string-nullable-list-filter.input';
 import { BoolWithAggregatesFilter } from '../prisma/bool-with-aggregates-filter.input';
 import { DateTimeWithAggregatesFilter } from '../prisma/date-time-with-aggregates-filter.input';
 
@@ -23,9 +22,6 @@ export class PostScalarWhereWithAggregatesInput {
 
     @Field(() => StringNullableWithAggregatesFilter, {nullable:true})
     title?: StringNullableWithAggregatesFilter;
-
-    @Field(() => StringNullableListFilter, {nullable:true})
-    mediaUrls?: StringNullableListFilter;
 
     @Field(() => IntWithAggregatesFilter, {nullable:true})
     userId?: IntWithAggregatesFilter;

--- a/api/@generated/post/post-scalar-where.input.ts
+++ b/api/@generated/post/post-scalar-where.input.ts
@@ -2,7 +2,6 @@ import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
 import { IntFilter } from '../prisma/int-filter.input';
 import { StringNullableFilter } from '../prisma/string-nullable-filter.input';
-import { StringNullableListFilter } from '../prisma/string-nullable-list-filter.input';
 import { BoolFilter } from '../prisma/bool-filter.input';
 import { DateTimeFilter } from '../prisma/date-time-filter.input';
 
@@ -23,9 +22,6 @@ export class PostScalarWhereInput {
 
     @Field(() => StringNullableFilter, {nullable:true})
     title?: StringNullableFilter;
-
-    @Field(() => StringNullableListFilter, {nullable:true})
-    mediaUrls?: StringNullableListFilter;
 
     @Field(() => IntFilter, {nullable:true})
     userId?: IntFilter;

--- a/api/@generated/post/post-unchecked-create-without-media-files.input.ts
+++ b/api/@generated/post/post-unchecked-create-without-media-files.input.ts
@@ -1,0 +1,32 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { Int } from '@nestjs/graphql';
+import { PostHashtagUncheckedCreateNestedManyWithoutPostInput } from '../post-hashtag/post-hashtag-unchecked-create-nested-many-without-post.input';
+
+@InputType()
+export class PostUncheckedCreateWithoutMediaFilesInput {
+
+    @Field(() => Int, {nullable:true})
+    id?: number;
+
+    @Field(() => String, {nullable:true})
+    title?: string;
+
+    @Field(() => Int, {nullable:false})
+    userId!: number;
+
+    @Field(() => Boolean, {nullable:true})
+    isHideLikeAndCount?: boolean;
+
+    @Field(() => Boolean, {nullable:true})
+    isTurnOffComment?: boolean;
+
+    @Field(() => Date, {nullable:true})
+    createdAt?: Date | string;
+
+    @Field(() => Date, {nullable:true})
+    updatedAt?: Date | string;
+
+    @Field(() => PostHashtagUncheckedCreateNestedManyWithoutPostInput, {nullable:true})
+    postHashtags?: PostHashtagUncheckedCreateNestedManyWithoutPostInput;
+}

--- a/api/@generated/post/post-unchecked-create-without-post-hashtags.input.ts
+++ b/api/@generated/post/post-unchecked-create-without-post-hashtags.input.ts
@@ -1,7 +1,7 @@
 import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
 import { Int } from '@nestjs/graphql';
-import { PostCreatemediaUrlsInput } from './post-createmedia-urls.input';
+import { MediaFileUncheckedCreateNestedManyWithoutPostInput } from '../media-file/media-file-unchecked-create-nested-many-without-post.input';
 
 @InputType()
 export class PostUncheckedCreateWithoutPostHashtagsInput {
@@ -11,9 +11,6 @@ export class PostUncheckedCreateWithoutPostHashtagsInput {
 
     @Field(() => String, {nullable:true})
     title?: string;
-
-    @Field(() => PostCreatemediaUrlsInput, {nullable:true})
-    mediaUrls?: PostCreatemediaUrlsInput;
 
     @Field(() => Int, {nullable:false})
     userId!: number;
@@ -29,4 +26,7 @@ export class PostUncheckedCreateWithoutPostHashtagsInput {
 
     @Field(() => Date, {nullable:true})
     updatedAt?: Date | string;
+
+    @Field(() => MediaFileUncheckedCreateNestedManyWithoutPostInput, {nullable:true})
+    mediaFiles?: MediaFileUncheckedCreateNestedManyWithoutPostInput;
 }

--- a/api/@generated/post/post-unchecked-create-without-user.input.ts
+++ b/api/@generated/post/post-unchecked-create-without-user.input.ts
@@ -1,7 +1,7 @@
 import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
 import { Int } from '@nestjs/graphql';
-import { PostCreatemediaUrlsInput } from './post-createmedia-urls.input';
+import { MediaFileUncheckedCreateNestedManyWithoutPostInput } from '../media-file/media-file-unchecked-create-nested-many-without-post.input';
 import { PostHashtagUncheckedCreateNestedManyWithoutPostInput } from '../post-hashtag/post-hashtag-unchecked-create-nested-many-without-post.input';
 
 @InputType()
@@ -12,9 +12,6 @@ export class PostUncheckedCreateWithoutUserInput {
 
     @Field(() => String, {nullable:true})
     title?: string;
-
-    @Field(() => PostCreatemediaUrlsInput, {nullable:true})
-    mediaUrls?: PostCreatemediaUrlsInput;
 
     @Field(() => Boolean, {nullable:true})
     isHideLikeAndCount?: boolean;
@@ -27,6 +24,9 @@ export class PostUncheckedCreateWithoutUserInput {
 
     @Field(() => Date, {nullable:true})
     updatedAt?: Date | string;
+
+    @Field(() => MediaFileUncheckedCreateNestedManyWithoutPostInput, {nullable:true})
+    mediaFiles?: MediaFileUncheckedCreateNestedManyWithoutPostInput;
 
     @Field(() => PostHashtagUncheckedCreateNestedManyWithoutPostInput, {nullable:true})
     postHashtags?: PostHashtagUncheckedCreateNestedManyWithoutPostInput;

--- a/api/@generated/post/post-unchecked-create.input.ts
+++ b/api/@generated/post/post-unchecked-create.input.ts
@@ -1,7 +1,7 @@
 import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
 import { Int } from '@nestjs/graphql';
-import { PostCreatemediaUrlsInput } from './post-createmedia-urls.input';
+import { MediaFileUncheckedCreateNestedManyWithoutPostInput } from '../media-file/media-file-unchecked-create-nested-many-without-post.input';
 import { PostHashtagUncheckedCreateNestedManyWithoutPostInput } from '../post-hashtag/post-hashtag-unchecked-create-nested-many-without-post.input';
 
 @InputType()
@@ -12,9 +12,6 @@ export class PostUncheckedCreateInput {
 
     @Field(() => String, {nullable:true})
     title?: string;
-
-    @Field(() => PostCreatemediaUrlsInput, {nullable:true})
-    mediaUrls?: PostCreatemediaUrlsInput;
 
     @Field(() => Int, {nullable:false})
     userId!: number;
@@ -30,6 +27,9 @@ export class PostUncheckedCreateInput {
 
     @Field(() => Date, {nullable:true})
     updatedAt?: Date | string;
+
+    @Field(() => MediaFileUncheckedCreateNestedManyWithoutPostInput, {nullable:true})
+    mediaFiles?: MediaFileUncheckedCreateNestedManyWithoutPostInput;
 
     @Field(() => PostHashtagUncheckedCreateNestedManyWithoutPostInput, {nullable:true})
     postHashtags?: PostHashtagUncheckedCreateNestedManyWithoutPostInput;

--- a/api/@generated/post/post-unchecked-update-many-without-user.input.ts
+++ b/api/@generated/post/post-unchecked-update-many-without-user.input.ts
@@ -2,7 +2,6 @@ import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
 import { IntFieldUpdateOperationsInput } from '../prisma/int-field-update-operations.input';
 import { NullableStringFieldUpdateOperationsInput } from '../prisma/nullable-string-field-update-operations.input';
-import { PostUpdatemediaUrlsInput } from './post-updatemedia-urls.input';
 import { BoolFieldUpdateOperationsInput } from '../prisma/bool-field-update-operations.input';
 import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
 
@@ -14,9 +13,6 @@ export class PostUncheckedUpdateManyWithoutUserInput {
 
     @Field(() => NullableStringFieldUpdateOperationsInput, {nullable:true})
     title?: NullableStringFieldUpdateOperationsInput;
-
-    @Field(() => PostUpdatemediaUrlsInput, {nullable:true})
-    mediaUrls?: PostUpdatemediaUrlsInput;
 
     @Field(() => BoolFieldUpdateOperationsInput, {nullable:true})
     isHideLikeAndCount?: BoolFieldUpdateOperationsInput;

--- a/api/@generated/post/post-unchecked-update-many.input.ts
+++ b/api/@generated/post/post-unchecked-update-many.input.ts
@@ -2,7 +2,6 @@ import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
 import { IntFieldUpdateOperationsInput } from '../prisma/int-field-update-operations.input';
 import { NullableStringFieldUpdateOperationsInput } from '../prisma/nullable-string-field-update-operations.input';
-import { PostUpdatemediaUrlsInput } from './post-updatemedia-urls.input';
 import { BoolFieldUpdateOperationsInput } from '../prisma/bool-field-update-operations.input';
 import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
 
@@ -14,9 +13,6 @@ export class PostUncheckedUpdateManyInput {
 
     @Field(() => NullableStringFieldUpdateOperationsInput, {nullable:true})
     title?: NullableStringFieldUpdateOperationsInput;
-
-    @Field(() => PostUpdatemediaUrlsInput, {nullable:true})
-    mediaUrls?: PostUpdatemediaUrlsInput;
 
     @Field(() => IntFieldUpdateOperationsInput, {nullable:true})
     userId?: IntFieldUpdateOperationsInput;

--- a/api/@generated/post/post-unchecked-update-without-media-files.input.ts
+++ b/api/@generated/post/post-unchecked-update-without-media-files.input.ts
@@ -1,0 +1,35 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { IntFieldUpdateOperationsInput } from '../prisma/int-field-update-operations.input';
+import { NullableStringFieldUpdateOperationsInput } from '../prisma/nullable-string-field-update-operations.input';
+import { BoolFieldUpdateOperationsInput } from '../prisma/bool-field-update-operations.input';
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
+import { PostHashtagUncheckedUpdateManyWithoutPostNestedInput } from '../post-hashtag/post-hashtag-unchecked-update-many-without-post-nested.input';
+
+@InputType()
+export class PostUncheckedUpdateWithoutMediaFilesInput {
+
+    @Field(() => IntFieldUpdateOperationsInput, {nullable:true})
+    id?: IntFieldUpdateOperationsInput;
+
+    @Field(() => NullableStringFieldUpdateOperationsInput, {nullable:true})
+    title?: NullableStringFieldUpdateOperationsInput;
+
+    @Field(() => IntFieldUpdateOperationsInput, {nullable:true})
+    userId?: IntFieldUpdateOperationsInput;
+
+    @Field(() => BoolFieldUpdateOperationsInput, {nullable:true})
+    isHideLikeAndCount?: BoolFieldUpdateOperationsInput;
+
+    @Field(() => BoolFieldUpdateOperationsInput, {nullable:true})
+    isTurnOffComment?: BoolFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    createdAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    updatedAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => PostHashtagUncheckedUpdateManyWithoutPostNestedInput, {nullable:true})
+    postHashtags?: PostHashtagUncheckedUpdateManyWithoutPostNestedInput;
+}

--- a/api/@generated/post/post-unchecked-update-without-post-hashtags.input.ts
+++ b/api/@generated/post/post-unchecked-update-without-post-hashtags.input.ts
@@ -2,9 +2,9 @@ import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
 import { IntFieldUpdateOperationsInput } from '../prisma/int-field-update-operations.input';
 import { NullableStringFieldUpdateOperationsInput } from '../prisma/nullable-string-field-update-operations.input';
-import { PostUpdatemediaUrlsInput } from './post-updatemedia-urls.input';
 import { BoolFieldUpdateOperationsInput } from '../prisma/bool-field-update-operations.input';
 import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
+import { MediaFileUncheckedUpdateManyWithoutPostNestedInput } from '../media-file/media-file-unchecked-update-many-without-post-nested.input';
 
 @InputType()
 export class PostUncheckedUpdateWithoutPostHashtagsInput {
@@ -14,9 +14,6 @@ export class PostUncheckedUpdateWithoutPostHashtagsInput {
 
     @Field(() => NullableStringFieldUpdateOperationsInput, {nullable:true})
     title?: NullableStringFieldUpdateOperationsInput;
-
-    @Field(() => PostUpdatemediaUrlsInput, {nullable:true})
-    mediaUrls?: PostUpdatemediaUrlsInput;
 
     @Field(() => IntFieldUpdateOperationsInput, {nullable:true})
     userId?: IntFieldUpdateOperationsInput;
@@ -32,4 +29,7 @@ export class PostUncheckedUpdateWithoutPostHashtagsInput {
 
     @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
     updatedAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => MediaFileUncheckedUpdateManyWithoutPostNestedInput, {nullable:true})
+    mediaFiles?: MediaFileUncheckedUpdateManyWithoutPostNestedInput;
 }

--- a/api/@generated/post/post-unchecked-update-without-user.input.ts
+++ b/api/@generated/post/post-unchecked-update-without-user.input.ts
@@ -2,9 +2,9 @@ import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
 import { IntFieldUpdateOperationsInput } from '../prisma/int-field-update-operations.input';
 import { NullableStringFieldUpdateOperationsInput } from '../prisma/nullable-string-field-update-operations.input';
-import { PostUpdatemediaUrlsInput } from './post-updatemedia-urls.input';
 import { BoolFieldUpdateOperationsInput } from '../prisma/bool-field-update-operations.input';
 import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
+import { MediaFileUncheckedUpdateManyWithoutPostNestedInput } from '../media-file/media-file-unchecked-update-many-without-post-nested.input';
 import { PostHashtagUncheckedUpdateManyWithoutPostNestedInput } from '../post-hashtag/post-hashtag-unchecked-update-many-without-post-nested.input';
 
 @InputType()
@@ -15,9 +15,6 @@ export class PostUncheckedUpdateWithoutUserInput {
 
     @Field(() => NullableStringFieldUpdateOperationsInput, {nullable:true})
     title?: NullableStringFieldUpdateOperationsInput;
-
-    @Field(() => PostUpdatemediaUrlsInput, {nullable:true})
-    mediaUrls?: PostUpdatemediaUrlsInput;
 
     @Field(() => BoolFieldUpdateOperationsInput, {nullable:true})
     isHideLikeAndCount?: BoolFieldUpdateOperationsInput;
@@ -30,6 +27,9 @@ export class PostUncheckedUpdateWithoutUserInput {
 
     @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
     updatedAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => MediaFileUncheckedUpdateManyWithoutPostNestedInput, {nullable:true})
+    mediaFiles?: MediaFileUncheckedUpdateManyWithoutPostNestedInput;
 
     @Field(() => PostHashtagUncheckedUpdateManyWithoutPostNestedInput, {nullable:true})
     postHashtags?: PostHashtagUncheckedUpdateManyWithoutPostNestedInput;

--- a/api/@generated/post/post-unchecked-update.input.ts
+++ b/api/@generated/post/post-unchecked-update.input.ts
@@ -2,9 +2,9 @@ import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
 import { IntFieldUpdateOperationsInput } from '../prisma/int-field-update-operations.input';
 import { NullableStringFieldUpdateOperationsInput } from '../prisma/nullable-string-field-update-operations.input';
-import { PostUpdatemediaUrlsInput } from './post-updatemedia-urls.input';
 import { BoolFieldUpdateOperationsInput } from '../prisma/bool-field-update-operations.input';
 import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
+import { MediaFileUncheckedUpdateManyWithoutPostNestedInput } from '../media-file/media-file-unchecked-update-many-without-post-nested.input';
 import { PostHashtagUncheckedUpdateManyWithoutPostNestedInput } from '../post-hashtag/post-hashtag-unchecked-update-many-without-post-nested.input';
 
 @InputType()
@@ -15,9 +15,6 @@ export class PostUncheckedUpdateInput {
 
     @Field(() => NullableStringFieldUpdateOperationsInput, {nullable:true})
     title?: NullableStringFieldUpdateOperationsInput;
-
-    @Field(() => PostUpdatemediaUrlsInput, {nullable:true})
-    mediaUrls?: PostUpdatemediaUrlsInput;
 
     @Field(() => IntFieldUpdateOperationsInput, {nullable:true})
     userId?: IntFieldUpdateOperationsInput;
@@ -33,6 +30,9 @@ export class PostUncheckedUpdateInput {
 
     @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
     updatedAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => MediaFileUncheckedUpdateManyWithoutPostNestedInput, {nullable:true})
+    mediaFiles?: MediaFileUncheckedUpdateManyWithoutPostNestedInput;
 
     @Field(() => PostHashtagUncheckedUpdateManyWithoutPostNestedInput, {nullable:true})
     postHashtags?: PostHashtagUncheckedUpdateManyWithoutPostNestedInput;

--- a/api/@generated/post/post-update-many-mutation.input.ts
+++ b/api/@generated/post/post-update-many-mutation.input.ts
@@ -1,7 +1,6 @@
 import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
 import { NullableStringFieldUpdateOperationsInput } from '../prisma/nullable-string-field-update-operations.input';
-import { PostUpdatemediaUrlsInput } from './post-updatemedia-urls.input';
 import { BoolFieldUpdateOperationsInput } from '../prisma/bool-field-update-operations.input';
 import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
 
@@ -10,9 +9,6 @@ export class PostUpdateManyMutationInput {
 
     @Field(() => NullableStringFieldUpdateOperationsInput, {nullable:true})
     title?: NullableStringFieldUpdateOperationsInput;
-
-    @Field(() => PostUpdatemediaUrlsInput, {nullable:true})
-    mediaUrls?: PostUpdatemediaUrlsInput;
 
     @Field(() => BoolFieldUpdateOperationsInput, {nullable:true})
     isHideLikeAndCount?: BoolFieldUpdateOperationsInput;

--- a/api/@generated/post/post-update-one-required-without-media-files-nested.input.ts
+++ b/api/@generated/post/post-update-one-required-without-media-files-nested.input.ts
@@ -1,0 +1,33 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { PostCreateWithoutMediaFilesInput } from './post-create-without-media-files.input';
+import { Type } from 'class-transformer';
+import { PostCreateOrConnectWithoutMediaFilesInput } from './post-create-or-connect-without-media-files.input';
+import { PostUpsertWithoutMediaFilesInput } from './post-upsert-without-media-files.input';
+import { Prisma } from '@prisma/client';
+import { PostWhereUniqueInput } from './post-where-unique.input';
+import { PostUpdateToOneWithWhereWithoutMediaFilesInput } from './post-update-to-one-with-where-without-media-files.input';
+
+@InputType()
+export class PostUpdateOneRequiredWithoutMediaFilesNestedInput {
+
+    @Field(() => PostCreateWithoutMediaFilesInput, {nullable:true})
+    @Type(() => PostCreateWithoutMediaFilesInput)
+    create?: PostCreateWithoutMediaFilesInput;
+
+    @Field(() => PostCreateOrConnectWithoutMediaFilesInput, {nullable:true})
+    @Type(() => PostCreateOrConnectWithoutMediaFilesInput)
+    connectOrCreate?: PostCreateOrConnectWithoutMediaFilesInput;
+
+    @Field(() => PostUpsertWithoutMediaFilesInput, {nullable:true})
+    @Type(() => PostUpsertWithoutMediaFilesInput)
+    upsert?: PostUpsertWithoutMediaFilesInput;
+
+    @Field(() => PostWhereUniqueInput, {nullable:true})
+    @Type(() => PostWhereUniqueInput)
+    connect?: Prisma.AtLeast<PostWhereUniqueInput, 'id'>;
+
+    @Field(() => PostUpdateToOneWithWhereWithoutMediaFilesInput, {nullable:true})
+    @Type(() => PostUpdateToOneWithWhereWithoutMediaFilesInput)
+    update?: PostUpdateToOneWithWhereWithoutMediaFilesInput;
+}

--- a/api/@generated/post/post-update-to-one-with-where-without-media-files.input.ts
+++ b/api/@generated/post/post-update-to-one-with-where-without-media-files.input.ts
@@ -1,0 +1,17 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { PostWhereInput } from './post-where.input';
+import { Type } from 'class-transformer';
+import { PostUpdateWithoutMediaFilesInput } from './post-update-without-media-files.input';
+
+@InputType()
+export class PostUpdateToOneWithWhereWithoutMediaFilesInput {
+
+    @Field(() => PostWhereInput, {nullable:true})
+    @Type(() => PostWhereInput)
+    where?: PostWhereInput;
+
+    @Field(() => PostUpdateWithoutMediaFilesInput, {nullable:false})
+    @Type(() => PostUpdateWithoutMediaFilesInput)
+    data!: PostUpdateWithoutMediaFilesInput;
+}

--- a/api/@generated/post/post-update-without-media-files.input.ts
+++ b/api/@generated/post/post-update-without-media-files.input.ts
@@ -1,0 +1,32 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { NullableStringFieldUpdateOperationsInput } from '../prisma/nullable-string-field-update-operations.input';
+import { BoolFieldUpdateOperationsInput } from '../prisma/bool-field-update-operations.input';
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
+import { UserUpdateOneRequiredWithoutPostsNestedInput } from '../user/user-update-one-required-without-posts-nested.input';
+import { PostHashtagUpdateManyWithoutPostNestedInput } from '../post-hashtag/post-hashtag-update-many-without-post-nested.input';
+
+@InputType()
+export class PostUpdateWithoutMediaFilesInput {
+
+    @Field(() => NullableStringFieldUpdateOperationsInput, {nullable:true})
+    title?: NullableStringFieldUpdateOperationsInput;
+
+    @Field(() => BoolFieldUpdateOperationsInput, {nullable:true})
+    isHideLikeAndCount?: BoolFieldUpdateOperationsInput;
+
+    @Field(() => BoolFieldUpdateOperationsInput, {nullable:true})
+    isTurnOffComment?: BoolFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    createdAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    updatedAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => UserUpdateOneRequiredWithoutPostsNestedInput, {nullable:true})
+    user?: UserUpdateOneRequiredWithoutPostsNestedInput;
+
+    @Field(() => PostHashtagUpdateManyWithoutPostNestedInput, {nullable:true})
+    postHashtags?: PostHashtagUpdateManyWithoutPostNestedInput;
+}

--- a/api/@generated/post/post-update-without-post-hashtags.input.ts
+++ b/api/@generated/post/post-update-without-post-hashtags.input.ts
@@ -1,9 +1,9 @@
 import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
 import { NullableStringFieldUpdateOperationsInput } from '../prisma/nullable-string-field-update-operations.input';
-import { PostUpdatemediaUrlsInput } from './post-updatemedia-urls.input';
 import { BoolFieldUpdateOperationsInput } from '../prisma/bool-field-update-operations.input';
 import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
+import { MediaFileUpdateManyWithoutPostNestedInput } from '../media-file/media-file-update-many-without-post-nested.input';
 import { UserUpdateOneRequiredWithoutPostsNestedInput } from '../user/user-update-one-required-without-posts-nested.input';
 
 @InputType()
@@ -11,9 +11,6 @@ export class PostUpdateWithoutPostHashtagsInput {
 
     @Field(() => NullableStringFieldUpdateOperationsInput, {nullable:true})
     title?: NullableStringFieldUpdateOperationsInput;
-
-    @Field(() => PostUpdatemediaUrlsInput, {nullable:true})
-    mediaUrls?: PostUpdatemediaUrlsInput;
 
     @Field(() => BoolFieldUpdateOperationsInput, {nullable:true})
     isHideLikeAndCount?: BoolFieldUpdateOperationsInput;
@@ -26,6 +23,9 @@ export class PostUpdateWithoutPostHashtagsInput {
 
     @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
     updatedAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => MediaFileUpdateManyWithoutPostNestedInput, {nullable:true})
+    mediaFiles?: MediaFileUpdateManyWithoutPostNestedInput;
 
     @Field(() => UserUpdateOneRequiredWithoutPostsNestedInput, {nullable:true})
     user?: UserUpdateOneRequiredWithoutPostsNestedInput;

--- a/api/@generated/post/post-update-without-user.input.ts
+++ b/api/@generated/post/post-update-without-user.input.ts
@@ -1,9 +1,9 @@
 import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
 import { NullableStringFieldUpdateOperationsInput } from '../prisma/nullable-string-field-update-operations.input';
-import { PostUpdatemediaUrlsInput } from './post-updatemedia-urls.input';
 import { BoolFieldUpdateOperationsInput } from '../prisma/bool-field-update-operations.input';
 import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
+import { MediaFileUpdateManyWithoutPostNestedInput } from '../media-file/media-file-update-many-without-post-nested.input';
 import { PostHashtagUpdateManyWithoutPostNestedInput } from '../post-hashtag/post-hashtag-update-many-without-post-nested.input';
 
 @InputType()
@@ -11,9 +11,6 @@ export class PostUpdateWithoutUserInput {
 
     @Field(() => NullableStringFieldUpdateOperationsInput, {nullable:true})
     title?: NullableStringFieldUpdateOperationsInput;
-
-    @Field(() => PostUpdatemediaUrlsInput, {nullable:true})
-    mediaUrls?: PostUpdatemediaUrlsInput;
 
     @Field(() => BoolFieldUpdateOperationsInput, {nullable:true})
     isHideLikeAndCount?: BoolFieldUpdateOperationsInput;
@@ -26,6 +23,9 @@ export class PostUpdateWithoutUserInput {
 
     @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
     updatedAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => MediaFileUpdateManyWithoutPostNestedInput, {nullable:true})
+    mediaFiles?: MediaFileUpdateManyWithoutPostNestedInput;
 
     @Field(() => PostHashtagUpdateManyWithoutPostNestedInput, {nullable:true})
     postHashtags?: PostHashtagUpdateManyWithoutPostNestedInput;

--- a/api/@generated/post/post-update.input.ts
+++ b/api/@generated/post/post-update.input.ts
@@ -1,9 +1,9 @@
 import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
 import { NullableStringFieldUpdateOperationsInput } from '../prisma/nullable-string-field-update-operations.input';
-import { PostUpdatemediaUrlsInput } from './post-updatemedia-urls.input';
 import { BoolFieldUpdateOperationsInput } from '../prisma/bool-field-update-operations.input';
 import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
+import { MediaFileUpdateManyWithoutPostNestedInput } from '../media-file/media-file-update-many-without-post-nested.input';
 import { UserUpdateOneRequiredWithoutPostsNestedInput } from '../user/user-update-one-required-without-posts-nested.input';
 import { PostHashtagUpdateManyWithoutPostNestedInput } from '../post-hashtag/post-hashtag-update-many-without-post-nested.input';
 
@@ -12,9 +12,6 @@ export class PostUpdateInput {
 
     @Field(() => NullableStringFieldUpdateOperationsInput, {nullable:true})
     title?: NullableStringFieldUpdateOperationsInput;
-
-    @Field(() => PostUpdatemediaUrlsInput, {nullable:true})
-    mediaUrls?: PostUpdatemediaUrlsInput;
 
     @Field(() => BoolFieldUpdateOperationsInput, {nullable:true})
     isHideLikeAndCount?: BoolFieldUpdateOperationsInput;
@@ -27,6 +24,9 @@ export class PostUpdateInput {
 
     @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
     updatedAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => MediaFileUpdateManyWithoutPostNestedInput, {nullable:true})
+    mediaFiles?: MediaFileUpdateManyWithoutPostNestedInput;
 
     @Field(() => UserUpdateOneRequiredWithoutPostsNestedInput, {nullable:true})
     user?: UserUpdateOneRequiredWithoutPostsNestedInput;

--- a/api/@generated/post/post-upsert-without-media-files.input.ts
+++ b/api/@generated/post/post-upsert-without-media-files.input.ts
@@ -1,0 +1,22 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { PostUpdateWithoutMediaFilesInput } from './post-update-without-media-files.input';
+import { Type } from 'class-transformer';
+import { PostCreateWithoutMediaFilesInput } from './post-create-without-media-files.input';
+import { PostWhereInput } from './post-where.input';
+
+@InputType()
+export class PostUpsertWithoutMediaFilesInput {
+
+    @Field(() => PostUpdateWithoutMediaFilesInput, {nullable:false})
+    @Type(() => PostUpdateWithoutMediaFilesInput)
+    update!: PostUpdateWithoutMediaFilesInput;
+
+    @Field(() => PostCreateWithoutMediaFilesInput, {nullable:false})
+    @Type(() => PostCreateWithoutMediaFilesInput)
+    create!: PostCreateWithoutMediaFilesInput;
+
+    @Field(() => PostWhereInput, {nullable:true})
+    @Type(() => PostWhereInput)
+    where?: PostWhereInput;
+}

--- a/api/@generated/post/post-where-unique.input.ts
+++ b/api/@generated/post/post-where-unique.input.ts
@@ -3,10 +3,10 @@ import { InputType } from '@nestjs/graphql';
 import { Int } from '@nestjs/graphql';
 import { PostWhereInput } from './post-where.input';
 import { StringNullableFilter } from '../prisma/string-nullable-filter.input';
-import { StringNullableListFilter } from '../prisma/string-nullable-list-filter.input';
 import { IntFilter } from '../prisma/int-filter.input';
 import { BoolFilter } from '../prisma/bool-filter.input';
 import { DateTimeFilter } from '../prisma/date-time-filter.input';
+import { MediaFileListRelationFilter } from '../media-file/media-file-list-relation-filter.input';
 import { UserRelationFilter } from '../user/user-relation-filter.input';
 import { PostHashtagListRelationFilter } from '../post-hashtag/post-hashtag-list-relation-filter.input';
 
@@ -28,9 +28,6 @@ export class PostWhereUniqueInput {
     @Field(() => StringNullableFilter, {nullable:true})
     title?: StringNullableFilter;
 
-    @Field(() => StringNullableListFilter, {nullable:true})
-    mediaUrls?: StringNullableListFilter;
-
     @Field(() => IntFilter, {nullable:true})
     userId?: IntFilter;
 
@@ -45,6 +42,9 @@ export class PostWhereUniqueInput {
 
     @Field(() => DateTimeFilter, {nullable:true})
     updatedAt?: DateTimeFilter;
+
+    @Field(() => MediaFileListRelationFilter, {nullable:true})
+    mediaFiles?: MediaFileListRelationFilter;
 
     @Field(() => UserRelationFilter, {nullable:true})
     user?: UserRelationFilter;

--- a/api/@generated/post/post-where.input.ts
+++ b/api/@generated/post/post-where.input.ts
@@ -2,9 +2,9 @@ import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
 import { IntFilter } from '../prisma/int-filter.input';
 import { StringNullableFilter } from '../prisma/string-nullable-filter.input';
-import { StringNullableListFilter } from '../prisma/string-nullable-list-filter.input';
 import { BoolFilter } from '../prisma/bool-filter.input';
 import { DateTimeFilter } from '../prisma/date-time-filter.input';
+import { MediaFileListRelationFilter } from '../media-file/media-file-list-relation-filter.input';
 import { UserRelationFilter } from '../user/user-relation-filter.input';
 import { PostHashtagListRelationFilter } from '../post-hashtag/post-hashtag-list-relation-filter.input';
 
@@ -26,9 +26,6 @@ export class PostWhereInput {
     @Field(() => StringNullableFilter, {nullable:true})
     title?: StringNullableFilter;
 
-    @Field(() => StringNullableListFilter, {nullable:true})
-    mediaUrls?: StringNullableListFilter;
-
     @Field(() => IntFilter, {nullable:true})
     userId?: IntFilter;
 
@@ -43,6 +40,9 @@ export class PostWhereInput {
 
     @Field(() => DateTimeFilter, {nullable:true})
     updatedAt?: DateTimeFilter;
+
+    @Field(() => MediaFileListRelationFilter, {nullable:true})
+    mediaFiles?: MediaFileListRelationFilter;
 
     @Field(() => UserRelationFilter, {nullable:true})
     user?: UserRelationFilter;

--- a/api/@generated/post/post.model.ts
+++ b/api/@generated/post/post.model.ts
@@ -2,6 +2,7 @@ import { Field } from '@nestjs/graphql';
 import { ObjectType } from '@nestjs/graphql';
 import { ID } from '@nestjs/graphql';
 import { Int } from '@nestjs/graphql';
+import { MediaFile } from '../media-file/media-file.model';
 import { User } from '../user/user.model';
 import { PostHashtag } from '../post-hashtag/post-hashtag.model';
 import { PostCount } from './post-count.output';
@@ -14,9 +15,6 @@ export class Post {
 
     @Field(() => String, {nullable:true})
     title!: string | null;
-
-    @Field(() => [String], {nullable:true})
-    mediaUrls!: Array<string>;
 
     @Field(() => Int, {nullable:false})
     userId!: number;
@@ -32,6 +30,9 @@ export class Post {
 
     @Field(() => Date, {nullable:false})
     updatedAt!: Date;
+
+    @Field(() => [MediaFile], {nullable:true})
+    mediaFiles?: Array<MediaFile>;
 
     @Field(() => User, {nullable:false})
     user?: User;

--- a/api/prisma/migrations/20230901085251_create_mediafile_model/migration.sql
+++ b/api/prisma/migrations/20230901085251_create_mediafile_model/migration.sql
@@ -1,0 +1,23 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `mediaUrls` on the `Post` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Post" DROP COLUMN "mediaUrls";
+
+-- CreateTable
+CREATE TABLE "MediaFile" (
+    "id" SERIAL NOT NULL,
+    "key" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "postId" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "MediaFile_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "MediaFile" ADD CONSTRAINT "MediaFile_postId_fkey" FOREIGN KEY ("postId") REFERENCES "Post"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -55,7 +55,7 @@ enum Role {
 model Post {
   id                 Int           @id @default(autoincrement())
   title              String?
-  mediaUrls          String[]
+  mediaFiles         MediaFile[]
   user               User          @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   userId             Int
   isHideLikeAndCount Boolean       @default(false)
@@ -63,6 +63,16 @@ model Post {
   postHashtags       PostHashtag[]
   createdAt          DateTime      @default(now())
   updatedAt          DateTime      @default(now())
+}
+
+model MediaFile {
+  id        Int      @id @default(autoincrement())
+  key       String
+  url       String
+  post      Post     @relation(fields: [postId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  postId    Int
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now())
 }
 
 model PostHashtag {

--- a/api/src/post/entities/mediaFile.entity.ts
+++ b/api/src/post/entities/mediaFile.entity.ts
@@ -1,0 +1,30 @@
+import { ID } from '@nestjs/graphql'
+import { Int } from '@nestjs/graphql'
+import { Field } from '@nestjs/graphql'
+import { ObjectType } from '@nestjs/graphql'
+
+import { Post } from './post.entity'
+
+@ObjectType()
+export class MediaFile {
+  @Field(() => ID, { nullable: false })
+  id!: number
+
+  @Field(() => String, { nullable: false })
+  key!: string
+
+  @Field(() => String, { nullable: false })
+  url!: string
+
+  @Field(() => Int, { nullable: false })
+  postId!: number
+
+  @Field(() => Date, { nullable: false })
+  createdAt!: Date
+
+  @Field(() => Date, { nullable: false })
+  updatedAt!: Date
+
+  @Field(() => Post, { nullable: false })
+  post?: Post
+}

--- a/api/src/post/entities/post.entity.ts
+++ b/api/src/post/entities/post.entity.ts
@@ -2,6 +2,7 @@ import { ObjectType, Field, Int, ID } from '@nestjs/graphql'
 
 import { User } from '~/user/user.entity'
 import { Hashtag } from './hashtag.entity'
+import { MediaFile } from './mediaFile.entity'
 import { PostHashtagEntity } from './post.hashtag.entity'
 
 @ObjectType()
@@ -12,8 +13,8 @@ export class Post {
   @Field(() => String, { nullable: true })
   title?: string | null
 
-  @Field(() => [String], { nullable: true })
-  mediaUrls?: Array<string>
+  @Field(() => [MediaFile], { nullable: true })
+  mediaFiles?: Array<MediaFile>
 
   @Field(() => Boolean, { nullable: false, defaultValue: false })
   isHideLikeAndCount!: boolean

--- a/api/src/post/post.service.ts
+++ b/api/src/post/post.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common'
+import { Injectable } from '@nestjs/common'
 
 import { Post } from '@generated/post/post.model'
 import { PrismaService } from '~/prisma/prisma.service'
@@ -11,12 +11,6 @@ export class PostService {
   constructor(private prisma: PrismaService) {}
 
   async create(createPostInput: PostCreateWithoutUserInput, userId: number): Promise<Post> {
-    const { mediaUrls } = createPostInput
-
-    if (mediaUrls.set.length === 0) {
-      throw new NotFoundException('Photos/Videos is required field. Pleace re-upload!')
-    }
-
     return await this.prisma.post.create({
       data: {
         ...createPostInput,
@@ -28,7 +22,8 @@ export class PostService {
       },
       include: {
         user: true,
-        postHashtags: true
+        postHashtags: true,
+        mediaFiles: true
       }
     })
   }
@@ -42,7 +37,8 @@ export class PostService {
           include: {
             hashtag: true
           }
-        }
+        },
+        mediaFiles: true
       }
     })
   }
@@ -56,7 +52,8 @@ export class PostService {
           include: {
             hashtag: true
           }
-        }
+        },
+        mediaFiles: true
       }
     })
   }
@@ -70,7 +67,8 @@ export class PostService {
           include: {
             hashtag: true
           }
-        }
+        },
+        mediaFiles: true
       }
     })
   }

--- a/api/src/schema.gql
+++ b/api/src/schema.gql
@@ -229,6 +229,84 @@ type LogoutResponse {
   loggedOut: Boolean!
 }
 
+type MediaFile {
+  createdAt: DateTime!
+  id: ID!
+  key: String!
+  post: Post!
+  postId: Int!
+  updatedAt: DateTime!
+  url: String!
+}
+
+input MediaFileCreateManyPostInput {
+  createdAt: DateTime
+  id: Int
+  key: String!
+  updatedAt: DateTime
+  url: String!
+}
+
+input MediaFileCreateManyPostInputEnvelope {
+  data: [MediaFileCreateManyPostInput!]!
+  skipDuplicates: Boolean
+}
+
+input MediaFileCreateNestedManyWithoutPostInput {
+  connect: [MediaFileWhereUniqueInput!]
+  connectOrCreate: [MediaFileCreateOrConnectWithoutPostInput!]
+  create: [MediaFileCreateWithoutPostInput!]
+  createMany: MediaFileCreateManyPostInputEnvelope
+}
+
+input MediaFileCreateOrConnectWithoutPostInput {
+  create: MediaFileCreateWithoutPostInput!
+  where: MediaFileWhereUniqueInput!
+}
+
+input MediaFileCreateWithoutPostInput {
+  createdAt: DateTime
+  key: String!
+  updatedAt: DateTime
+  url: String!
+}
+
+input MediaFileListRelationFilter {
+  every: MediaFileWhereInput
+  none: MediaFileWhereInput
+  some: MediaFileWhereInput
+}
+
+input MediaFileOrderByRelationAggregateInput {
+  _count: SortOrder
+}
+
+input MediaFileWhereInput {
+  AND: [MediaFileWhereInput!]
+  NOT: [MediaFileWhereInput!]
+  OR: [MediaFileWhereInput!]
+  createdAt: DateTimeFilter
+  id: IntFilter
+  key: StringFilter
+  post: PostRelationFilter
+  postId: IntFilter
+  updatedAt: DateTimeFilter
+  url: StringFilter
+}
+
+input MediaFileWhereUniqueInput {
+  AND: [MediaFileWhereInput!]
+  NOT: [MediaFileWhereInput!]
+  OR: [MediaFileWhereInput!]
+  createdAt: DateTimeFilter
+  id: Int
+  key: StringFilter
+  post: PostRelationFilter
+  postId: IntFilter
+  updatedAt: DateTimeFilter
+  url: StringFilter
+}
+
 type Mutation {
   createPost(createPostInput: PostCreateWithoutUserInput!): Post!
   followUser(targetUserIdInput: TargetUserIdInput!): FollowUser!
@@ -317,7 +395,7 @@ type Post {
   id: ID!
   isHideLikeAndCount: Boolean!
   isTurnOffComment: Boolean!
-  mediaUrls: [String!]
+  mediaFiles: [MediaFile!]
   postHashtags: [PostHashtagEntity!]
   title: String
   updatedAt: DateTime
@@ -330,7 +408,6 @@ input PostCreateManyUserInput {
   id: Int
   isHideLikeAndCount: Boolean
   isTurnOffComment: Boolean
-  mediaUrls: PostCreatemediaUrlsInput
   title: String
   updatedAt: DateTime
 }
@@ -356,14 +433,10 @@ input PostCreateWithoutUserInput {
   createdAt: DateTime
   isHideLikeAndCount: Boolean
   isTurnOffComment: Boolean
-  mediaUrls: PostCreatemediaUrlsInput
+  mediaFiles: MediaFileCreateNestedManyWithoutPostInput
   postHashtags: PostHashtagCreateNestedManyWithoutPostInput
   title: String
   updatedAt: DateTime
-}
-
-input PostCreatemediaUrlsInput {
-  set: [String!]!
 }
 
 type PostHashtag {
@@ -471,7 +544,7 @@ input PostOrderByWithRelationInput {
   id: SortOrder
   isHideLikeAndCount: SortOrder
   isTurnOffComment: SortOrder
-  mediaUrls: SortOrder
+  mediaFiles: MediaFileOrderByRelationAggregateInput
   postHashtags: PostHashtagOrderByRelationAggregateInput
   title: SortOrderInput
   updatedAt: SortOrder
@@ -489,7 +562,6 @@ enum PostScalarFieldEnum {
   id
   isHideLikeAndCount
   isTurnOffComment
-  mediaUrls
   title
   updatedAt
   userId
@@ -503,7 +575,7 @@ input PostWhereInput {
   id: IntFilter
   isHideLikeAndCount: BoolFilter
   isTurnOffComment: BoolFilter
-  mediaUrls: StringNullableListFilter
+  mediaFiles: MediaFileListRelationFilter
   postHashtags: PostHashtagListRelationFilter
   title: StringNullableFilter
   updatedAt: DateTimeFilter
@@ -519,7 +591,7 @@ input PostWhereUniqueInput {
   id: Int
   isHideLikeAndCount: BoolFilter
   isTurnOffComment: BoolFilter
-  mediaUrls: StringNullableListFilter
+  mediaFiles: MediaFileListRelationFilter
   postHashtags: PostHashtagListRelationFilter
   title: StringNullableFilter
   updatedAt: DateTimeFilter
@@ -596,14 +668,6 @@ input StringNullableFilter {
   not: NestedStringNullableFilter
   notIn: [String!]
   startsWith: String
-}
-
-input StringNullableListFilter {
-  equals: [String!]
-  has: String
-  hasEvery: [String!]
-  hasSome: [String!]
-  isEmpty: Boolean
 }
 
 input TargetUserIdInput {

--- a/client/next.config.js
+++ b/client/next.config.js
@@ -5,7 +5,13 @@ const nextConfig = {
     esmExternals: false // Uploadthing
   },
   images: {
-    domains: ['blog.hubspot.com', 'images.unsplash.com', 'plus.unsplash.com', 'uploadthing.com']
+    domains: [
+      'blog.hubspot.com',
+      'images.unsplash.com',
+      'plus.unsplash.com',
+      'uploadthing.com',
+      't3.ftcdn.net'
+    ]
   }
 }
 

--- a/client/src/components/organisms/Post/index.tsx
+++ b/client/src/components/organisms/Post/index.tsx
@@ -40,7 +40,7 @@ const Post: FC<PostProps> = (props): JSX.Element => {
     isFollowed,
     state: { setIsModalOpen }
   } = props
-  const { id, mediaUrls, title, user, postHashtags } = post
+  const { id, mediaFiles, title, user, postHashtags } = post
 
   const { handleFollow, handleUnfollow } = useFollow()
   const followMethod = handleFollow()
@@ -156,12 +156,12 @@ const Post: FC<PostProps> = (props): JSX.Element => {
                 )}
               >
                 <Carousel>
-                  {mediaUrls.map((asset, idx) => {
-                    if (asset.endsWith('.mp4')) {
+                  {mediaFiles?.map((asset, idx) => {
+                    if (asset.url.endsWith('.mp4')) {
                       return (
                         <video
                           key={idx}
-                          src={asset}
+                          src={asset.url}
                           autoPlay
                           muted
                           loop
@@ -174,12 +174,12 @@ const Post: FC<PostProps> = (props): JSX.Element => {
                       return (
                         <Image
                           key={idx}
-                          src={asset}
+                          src={asset.url}
                           width={500}
                           height={470}
                           placeholder="blur"
                           className="z-50"
-                          blurDataURL={asset}
+                          blurDataURL={asset.url}
                           alt=""
                         />
                       )

--- a/client/src/components/organisms/PostModal/index.tsx
+++ b/client/src/components/organisms/PostModal/index.tsx
@@ -133,10 +133,10 @@ const PostModal: FC<PostModalProps> = ({ isOpen, closeModal, postId }): JSX.Elem
             <div className="h-full w-ful flex justify-center items-center max-w-md overflow-hidden">
               <Carousel>
                 {
-                  userPost?.mediaUrls.map((asset, idx) => {
-                    if (asset.endsWith('.mp4')) {
+                  userPost?.mediaFiles?.map((asset, idx) => {
+                    if (asset.url.endsWith('.mp4')) {
                       return (
-                        <video key={idx} src={asset} autoPlay muted loop className="w-full">
+                        <video key={idx} src={asset.url} autoPlay muted loop className="w-full">
                           Your browser does not support the video tag.
                         </video>
                       )
@@ -144,11 +144,11 @@ const PostModal: FC<PostModalProps> = ({ isOpen, closeModal, postId }): JSX.Elem
                       return (
                         <Image
                           key={idx}
-                          src={asset}
+                          src={asset.url}
                           width={500}
                           height={470}
                           placeholder="blur"
-                          blurDataURL={asset}
+                          blurDataURL={asset.url}
                           className="z-50"
                           alt=""
                         />

--- a/client/src/graphql/mutations/post.ts
+++ b/client/src/graphql/mutations/post.ts
@@ -5,7 +5,10 @@ export const CREATE_POST_MUTATION = gql`
     createPost(createPostInput: $createPostInput) {
       id
       title
-      mediaUrls
+      mediaFiles {
+        key
+        url
+      }
       createdAt
       updatedAt
       user {

--- a/client/src/graphql/queries/postsQuery.ts
+++ b/client/src/graphql/queries/postsQuery.ts
@@ -7,7 +7,10 @@ export const GET_ALL_POST_QUERY = gql`
       title
       isHideLikeAndCount
       isTurnOffComment
-      mediaUrls
+      mediaFiles {
+        key
+        url
+      }
       updatedAt
       createdAt
       user {
@@ -30,7 +33,10 @@ export const GET_ONE_POST_QUERY = gql`
     findOnePost(where: $where) {
       id
       title
-      mediaUrls
+      mediaFiles {
+        key
+        url
+      }
       isHideLikeAndCount
       isTurnOffComment
       updatedAt
@@ -55,7 +61,10 @@ export const GET_ALL_POST_BY_USERNAME_QUERY = gql`
   query FindAllPostByUsername($where: PostWhereInput, $orderBy: [PostOrderByWithRelationInput!]) {
     findAllPostByUsername(where: $where, orderBy: $orderBy) {
       id
-      mediaUrls
+      mediaFiles {
+        key
+        url
+      }
       createdAt
     }
   }

--- a/client/src/pages/[@username]/index.tsx
+++ b/client/src/pages/[@username]/index.tsx
@@ -87,7 +87,7 @@ const Username: NextPage = (): JSX.Element => {
             >
               <div className="group-hover:brightness-75 transition ease-in-out duration-75">
                 <img
-                  src={post?.mediaUrls[0]}
+                  src={post?.mediaFiles[0].url}
                   className="w-full h-52 object-cover bg-black"
                   alt=""
                 />

--- a/client/src/utils/interface/Post.ts
+++ b/client/src/utils/interface/Post.ts
@@ -1,7 +1,9 @@
+import { MediaFiles } from './../types/input'
+
 export interface IPost {
   id: string
   title: string
-  mediaUrls: string[]
+  mediaFiles: MediaFiles[]
   createdAt: string
   updatedAt: string
   isHideLikeAndCount: boolean

--- a/client/src/utils/types/input.ts
+++ b/client/src/utils/types/input.ts
@@ -1,7 +1,9 @@
 export type PostRequestInput = {
   title: string
-  mediaUrls: {
-    set: string[]
+  mediaFiles: {
+    createMany: {
+      data: MediaFiles[]
+    }
   }
   isHideLikeAndCount: boolean
   isTurnOffComment: boolean
@@ -23,4 +25,9 @@ export type PostRequestInput = {
 
 export type TargetUserIdInput = {
   id: number
+}
+
+export type MediaFiles = {
+  key: string
+  url: string
 }

--- a/client/src/utils/yup-schema/index.ts
+++ b/client/src/utils/yup-schema/index.ts
@@ -22,7 +22,12 @@ export type SignUpFormValues = yup.InferType<typeof SignUpSchema>
 export type SignInFormValues = yup.InferType<typeof SignInSchema>
 
 export const UserPostSchema = yup.object().shape({
-  mediaUrls: yup.array().of(yup.string().url().required('Media URL is required')),
+  mediaFiles: yup.array().of(
+    yup.object().shape({
+      key: yup.string().required('Media key is required'),
+      url: yup.string().url().required('Media URL is required')
+    })
+  ),
   captions: yup.string().max(200),
   location: yup.string()
 })


### PR DESCRIPTION
## Issue Link

- https://www.notion.so/MM-46-FE-Modified-Posts-MediaUrls-to-add-Key-and-Url-object-f27ab331a837490882ad85ea95f65c78?pvs=4

## Definition of Done

- [x] Modified Posts column to change the mediaUrls into Media Files with key and Url object
- [x] Modified affecting existing queries and backend and  frontend
- [x] Fixed Upload media with url and key value fair 

## Notes

- N/A

## Pre-condition

### Docker Setup

- docker-compose up --build

### Local Setup

- cd client && npm install && npm run dev
- cd api && npm install && npm run dev
- goto the homepage and the properties of mediaUrls are change

## Expected Output

- It should now have the mediaFiles in the Posts column and not mediaUrls with key and value 
- Modified existing queries and functionality

## Screenshots/Recordings
[key and url.webm](https://github.com/Osomware/meme-me/assets/108642414/0653830d-8601-41d4-b959-0bffaf49eecf)

![image](https://github.com/Osomware/meme-me/assets/108642414/1f07656b-382a-4008-aeb8-ced6ae577dcf)
