### PR TITLE
MM-[47] - [FE] Implement Infinite Scroll Posts

### DIFF
--- a/api/src/post/post.resolver.ts
+++ b/api/src/post/post.resolver.ts
@@ -1,4 +1,4 @@
-import { Resolver, Query, Mutation, Args } from '@nestjs/graphql'
+import { Resolver, Query, Mutation, Args, Int } from '@nestjs/graphql'
 
 import { PostService } from './post.service'
 import { Post } from './entities/post.entity'
@@ -32,5 +32,10 @@ export class PostResolver {
   @Query(() => [Post], { name: 'findAllPostByUsername' })
   findAllByUsername(@Args() args: FindManyPostArgs): Promise<Post[]> {
     return this.postService.findAllByUsername(args)
+  }
+
+  @Query(() => Int, { name: 'countAllPost' })
+  countllPost(): Promise<number> {
+    return this.postService.countAllPost()
   }
 }

--- a/api/src/post/post.service.ts
+++ b/api/src/post/post.service.ts
@@ -72,4 +72,8 @@ export class PostService {
       }
     })
   }
+
+  async countAllPost(): Promise<number> {
+    return await this.prisma.post.count()
+  }
 }

--- a/api/src/schema.gql
+++ b/api/src/schema.gql
@@ -601,6 +601,7 @@ input PostWhereUniqueInput {
 
 type Query {
   checkUserFollowed(targetUserIdInput: TargetUserIdInput!): Boolean!
+  countAllPost: Int!
   findAllPost(cursor: PostWhereUniqueInput, distinct: [PostScalarFieldEnum!], orderBy: [PostOrderByWithRelationInput!], skip: Int, take: Int, where: PostWhereInput): [Post!]!
   findAllPostByUsername(cursor: PostWhereUniqueInput, distinct: [PostScalarFieldEnum!], orderBy: [PostOrderByWithRelationInput!], skip: Int, take: Int, where: PostWhereInput): [Post!]!
   findOnePost(cursor: PostWhereUniqueInput, distinct: [PostScalarFieldEnum!], orderBy: [PostOrderByWithRelationInput!], skip: Int, take: Int, where: PostWhereInput): Post!

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -36,6 +36,7 @@
         "react-feather": "^2.0.10",
         "react-hook-form": "^7.45.1",
         "react-hot-toast": "^2.4.1",
+        "react-intersection-observer": "^9.5.2",
         "react-nice-avatar": "^1.4.1",
         "react-responsive-carousel": "^3.2.23",
         "react-responsive-modal": "^6.4.2",
@@ -4390,6 +4391,14 @@
       "peerDependencies": {
         "react": ">=16",
         "react-dom": ">=16"
+      }
+    },
+    "node_modules/react-intersection-observer": {
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.5.2.tgz",
+      "integrity": "sha512-EmoV66/yvksJcGa1rdW0nDNc4I1RifDWkT50gXSFnPLYQ4xUptuDD4V7k+Rj1OgVAlww628KLGcxPXFlOkkU/Q==",
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-is": {

--- a/client/package.json
+++ b/client/package.json
@@ -41,6 +41,7 @@
     "react-feather": "^2.0.10",
     "react-hook-form": "^7.45.1",
     "react-hot-toast": "^2.4.1",
+    "react-intersection-observer": "^9.5.2",
     "react-nice-avatar": "^1.4.1",
     "react-responsive-carousel": "^3.2.23",
     "react-responsive-modal": "^6.4.2",

--- a/client/src/graphql/queries/postsQuery.ts
+++ b/client/src/graphql/queries/postsQuery.ts
@@ -1,8 +1,8 @@
 import { gql } from 'graphql-request'
 
 export const GET_ALL_POST_QUERY = gql`
-  query GetAllUserPost($orderBy: [PostOrderByWithRelationInput!]) {
-    findAllPost(orderBy: $orderBy) {
+  query GetAllUserPost($orderBy: [PostOrderByWithRelationInput!], $skip: Int, $take: Int) {
+    findAllPost(orderBy: $orderBy, skip: $skip, take: $take) {
       id
       title
       isHideLikeAndCount
@@ -67,5 +67,11 @@ export const GET_ALL_POST_BY_USERNAME_QUERY = gql`
       }
       createdAt
     }
+  }
+`
+
+export const COUNT_ALL_POST_QUERY = gql`
+  query CountAllPosts {
+    countAllPost
   }
 `


### PR DESCRIPTION
## Issue Link

- https://www.notion.so/MM-47-FE-Implement-Infinite-Scroll-Posts-f27ab331a837490882ad85ea95f65c78?pvs=4

## Definition of Done

- [x] Refactor useQuery to useInfiniteQuery
- [x] Add skip and take to fetch other post
- [x] Install `react-intersection-observer` package to perform fetch post  

## Notes

- N/A

## Pre-condition

### Docker Setup

- docker-compose up --build

### Local Setup

- cd client && npm install && npm run dev
- cd api && npm install && npm run dev
- goto the homepage and scroll down

## Expected Output

- It should now have an infinite scroll feature in the home page and it will fetch 5 post every request

## Screenshots/Recordings
[infinite scroll.webm](https://github.com/Osomware/meme-me/assets/108642414/56ed7450-ff94-4016-8407-d68598bbd7e2)

