### PR TITLE
MM-[48] - [BE] Implement Like/Unlike Post Functionality

### DIFF
--- a/api/@generated/like/aggregate-like.output.ts
+++ b/api/@generated/like/aggregate-like.output.ts
@@ -1,0 +1,26 @@
+import { Field } from '@nestjs/graphql';
+import { ObjectType } from '@nestjs/graphql';
+import { LikeCountAggregate } from './like-count-aggregate.output';
+import { LikeAvgAggregate } from './like-avg-aggregate.output';
+import { LikeSumAggregate } from './like-sum-aggregate.output';
+import { LikeMinAggregate } from './like-min-aggregate.output';
+import { LikeMaxAggregate } from './like-max-aggregate.output';
+
+@ObjectType()
+export class AggregateLike {
+
+    @Field(() => LikeCountAggregate, {nullable:true})
+    _count?: LikeCountAggregate;
+
+    @Field(() => LikeAvgAggregate, {nullable:true})
+    _avg?: LikeAvgAggregate;
+
+    @Field(() => LikeSumAggregate, {nullable:true})
+    _sum?: LikeSumAggregate;
+
+    @Field(() => LikeMinAggregate, {nullable:true})
+    _min?: LikeMinAggregate;
+
+    @Field(() => LikeMaxAggregate, {nullable:true})
+    _max?: LikeMaxAggregate;
+}

--- a/api/@generated/like/create-many-like.args.ts
+++ b/api/@generated/like/create-many-like.args.ts
@@ -1,0 +1,15 @@
+import { Field } from '@nestjs/graphql';
+import { ArgsType } from '@nestjs/graphql';
+import { LikeCreateManyInput } from './like-create-many.input';
+import { Type } from 'class-transformer';
+
+@ArgsType()
+export class CreateManyLikeArgs {
+
+    @Field(() => [LikeCreateManyInput], {nullable:false})
+    @Type(() => LikeCreateManyInput)
+    data!: Array<LikeCreateManyInput>;
+
+    @Field(() => Boolean, {nullable:true})
+    skipDuplicates?: boolean;
+}

--- a/api/@generated/like/create-one-like.args.ts
+++ b/api/@generated/like/create-one-like.args.ts
@@ -1,0 +1,12 @@
+import { Field } from '@nestjs/graphql';
+import { ArgsType } from '@nestjs/graphql';
+import { LikeCreateInput } from './like-create.input';
+import { Type } from 'class-transformer';
+
+@ArgsType()
+export class CreateOneLikeArgs {
+
+    @Field(() => LikeCreateInput, {nullable:false})
+    @Type(() => LikeCreateInput)
+    data!: LikeCreateInput;
+}

--- a/api/@generated/like/delete-many-like.args.ts
+++ b/api/@generated/like/delete-many-like.args.ts
@@ -1,0 +1,12 @@
+import { Field } from '@nestjs/graphql';
+import { ArgsType } from '@nestjs/graphql';
+import { LikeWhereInput } from './like-where.input';
+import { Type } from 'class-transformer';
+
+@ArgsType()
+export class DeleteManyLikeArgs {
+
+    @Field(() => LikeWhereInput, {nullable:true})
+    @Type(() => LikeWhereInput)
+    where?: LikeWhereInput;
+}

--- a/api/@generated/like/delete-one-like.args.ts
+++ b/api/@generated/like/delete-one-like.args.ts
@@ -1,0 +1,13 @@
+import { Field } from '@nestjs/graphql';
+import { ArgsType } from '@nestjs/graphql';
+import { Prisma } from '@prisma/client';
+import { LikeWhereUniqueInput } from './like-where-unique.input';
+import { Type } from 'class-transformer';
+
+@ArgsType()
+export class DeleteOneLikeArgs {
+
+    @Field(() => LikeWhereUniqueInput, {nullable:false})
+    @Type(() => LikeWhereUniqueInput)
+    where!: Prisma.AtLeast<LikeWhereUniqueInput, 'id' | 'userId_postId'>;
+}

--- a/api/@generated/like/find-first-like-or-throw.args.ts
+++ b/api/@generated/like/find-first-like-or-throw.args.ts
@@ -1,0 +1,32 @@
+import { Field } from '@nestjs/graphql';
+import { ArgsType } from '@nestjs/graphql';
+import { LikeWhereInput } from './like-where.input';
+import { Type } from 'class-transformer';
+import { LikeOrderByWithRelationInput } from './like-order-by-with-relation.input';
+import { Prisma } from '@prisma/client';
+import { LikeWhereUniqueInput } from './like-where-unique.input';
+import { Int } from '@nestjs/graphql';
+import { LikeScalarFieldEnum } from './like-scalar-field.enum';
+
+@ArgsType()
+export class FindFirstLikeOrThrowArgs {
+
+    @Field(() => LikeWhereInput, {nullable:true})
+    @Type(() => LikeWhereInput)
+    where?: LikeWhereInput;
+
+    @Field(() => [LikeOrderByWithRelationInput], {nullable:true})
+    orderBy?: Array<LikeOrderByWithRelationInput>;
+
+    @Field(() => LikeWhereUniqueInput, {nullable:true})
+    cursor?: Prisma.AtLeast<LikeWhereUniqueInput, 'id' | 'userId_postId'>;
+
+    @Field(() => Int, {nullable:true})
+    take?: number;
+
+    @Field(() => Int, {nullable:true})
+    skip?: number;
+
+    @Field(() => [LikeScalarFieldEnum], {nullable:true})
+    distinct?: Array<keyof typeof LikeScalarFieldEnum>;
+}

--- a/api/@generated/like/find-first-like.args.ts
+++ b/api/@generated/like/find-first-like.args.ts
@@ -1,0 +1,32 @@
+import { Field } from '@nestjs/graphql';
+import { ArgsType } from '@nestjs/graphql';
+import { LikeWhereInput } from './like-where.input';
+import { Type } from 'class-transformer';
+import { LikeOrderByWithRelationInput } from './like-order-by-with-relation.input';
+import { Prisma } from '@prisma/client';
+import { LikeWhereUniqueInput } from './like-where-unique.input';
+import { Int } from '@nestjs/graphql';
+import { LikeScalarFieldEnum } from './like-scalar-field.enum';
+
+@ArgsType()
+export class FindFirstLikeArgs {
+
+    @Field(() => LikeWhereInput, {nullable:true})
+    @Type(() => LikeWhereInput)
+    where?: LikeWhereInput;
+
+    @Field(() => [LikeOrderByWithRelationInput], {nullable:true})
+    orderBy?: Array<LikeOrderByWithRelationInput>;
+
+    @Field(() => LikeWhereUniqueInput, {nullable:true})
+    cursor?: Prisma.AtLeast<LikeWhereUniqueInput, 'id' | 'userId_postId'>;
+
+    @Field(() => Int, {nullable:true})
+    take?: number;
+
+    @Field(() => Int, {nullable:true})
+    skip?: number;
+
+    @Field(() => [LikeScalarFieldEnum], {nullable:true})
+    distinct?: Array<keyof typeof LikeScalarFieldEnum>;
+}

--- a/api/@generated/like/find-many-like.args.ts
+++ b/api/@generated/like/find-many-like.args.ts
@@ -1,0 +1,32 @@
+import { Field } from '@nestjs/graphql';
+import { ArgsType } from '@nestjs/graphql';
+import { LikeWhereInput } from './like-where.input';
+import { Type } from 'class-transformer';
+import { LikeOrderByWithRelationInput } from './like-order-by-with-relation.input';
+import { Prisma } from '@prisma/client';
+import { LikeWhereUniqueInput } from './like-where-unique.input';
+import { Int } from '@nestjs/graphql';
+import { LikeScalarFieldEnum } from './like-scalar-field.enum';
+
+@ArgsType()
+export class FindManyLikeArgs {
+
+    @Field(() => LikeWhereInput, {nullable:true})
+    @Type(() => LikeWhereInput)
+    where?: LikeWhereInput;
+
+    @Field(() => [LikeOrderByWithRelationInput], {nullable:true})
+    orderBy?: Array<LikeOrderByWithRelationInput>;
+
+    @Field(() => LikeWhereUniqueInput, {nullable:true})
+    cursor?: Prisma.AtLeast<LikeWhereUniqueInput, 'id' | 'userId_postId'>;
+
+    @Field(() => Int, {nullable:true})
+    take?: number;
+
+    @Field(() => Int, {nullable:true})
+    skip?: number;
+
+    @Field(() => [LikeScalarFieldEnum], {nullable:true})
+    distinct?: Array<keyof typeof LikeScalarFieldEnum>;
+}

--- a/api/@generated/like/find-unique-like-or-throw.args.ts
+++ b/api/@generated/like/find-unique-like-or-throw.args.ts
@@ -1,0 +1,13 @@
+import { Field } from '@nestjs/graphql';
+import { ArgsType } from '@nestjs/graphql';
+import { Prisma } from '@prisma/client';
+import { LikeWhereUniqueInput } from './like-where-unique.input';
+import { Type } from 'class-transformer';
+
+@ArgsType()
+export class FindUniqueLikeOrThrowArgs {
+
+    @Field(() => LikeWhereUniqueInput, {nullable:false})
+    @Type(() => LikeWhereUniqueInput)
+    where!: Prisma.AtLeast<LikeWhereUniqueInput, 'id' | 'userId_postId'>;
+}

--- a/api/@generated/like/find-unique-like.args.ts
+++ b/api/@generated/like/find-unique-like.args.ts
@@ -1,0 +1,13 @@
+import { Field } from '@nestjs/graphql';
+import { ArgsType } from '@nestjs/graphql';
+import { Prisma } from '@prisma/client';
+import { LikeWhereUniqueInput } from './like-where-unique.input';
+import { Type } from 'class-transformer';
+
+@ArgsType()
+export class FindUniqueLikeArgs {
+
+    @Field(() => LikeWhereUniqueInput, {nullable:false})
+    @Type(() => LikeWhereUniqueInput)
+    where!: Prisma.AtLeast<LikeWhereUniqueInput, 'id' | 'userId_postId'>;
+}

--- a/api/@generated/like/like-aggregate.args.ts
+++ b/api/@generated/like/like-aggregate.args.ts
@@ -1,0 +1,48 @@
+import { Field } from '@nestjs/graphql';
+import { ArgsType } from '@nestjs/graphql';
+import { LikeWhereInput } from './like-where.input';
+import { Type } from 'class-transformer';
+import { LikeOrderByWithRelationInput } from './like-order-by-with-relation.input';
+import { Prisma } from '@prisma/client';
+import { LikeWhereUniqueInput } from './like-where-unique.input';
+import { Int } from '@nestjs/graphql';
+import { LikeCountAggregateInput } from './like-count-aggregate.input';
+import { LikeAvgAggregateInput } from './like-avg-aggregate.input';
+import { LikeSumAggregateInput } from './like-sum-aggregate.input';
+import { LikeMinAggregateInput } from './like-min-aggregate.input';
+import { LikeMaxAggregateInput } from './like-max-aggregate.input';
+
+@ArgsType()
+export class LikeAggregateArgs {
+
+    @Field(() => LikeWhereInput, {nullable:true})
+    @Type(() => LikeWhereInput)
+    where?: LikeWhereInput;
+
+    @Field(() => [LikeOrderByWithRelationInput], {nullable:true})
+    orderBy?: Array<LikeOrderByWithRelationInput>;
+
+    @Field(() => LikeWhereUniqueInput, {nullable:true})
+    cursor?: Prisma.AtLeast<LikeWhereUniqueInput, 'id' | 'userId_postId'>;
+
+    @Field(() => Int, {nullable:true})
+    take?: number;
+
+    @Field(() => Int, {nullable:true})
+    skip?: number;
+
+    @Field(() => LikeCountAggregateInput, {nullable:true})
+    _count?: LikeCountAggregateInput;
+
+    @Field(() => LikeAvgAggregateInput, {nullable:true})
+    _avg?: LikeAvgAggregateInput;
+
+    @Field(() => LikeSumAggregateInput, {nullable:true})
+    _sum?: LikeSumAggregateInput;
+
+    @Field(() => LikeMinAggregateInput, {nullable:true})
+    _min?: LikeMinAggregateInput;
+
+    @Field(() => LikeMaxAggregateInput, {nullable:true})
+    _max?: LikeMaxAggregateInput;
+}

--- a/api/@generated/like/like-avg-aggregate.input.ts
+++ b/api/@generated/like/like-avg-aggregate.input.ts
@@ -1,0 +1,15 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+
+@InputType()
+export class LikeAvgAggregateInput {
+
+    @Field(() => Boolean, {nullable:true})
+    id?: true;
+
+    @Field(() => Boolean, {nullable:true})
+    userId?: true;
+
+    @Field(() => Boolean, {nullable:true})
+    postId?: true;
+}

--- a/api/@generated/like/like-avg-aggregate.output.ts
+++ b/api/@generated/like/like-avg-aggregate.output.ts
@@ -1,0 +1,16 @@
+import { Field } from '@nestjs/graphql';
+import { ObjectType } from '@nestjs/graphql';
+import { Float } from '@nestjs/graphql';
+
+@ObjectType()
+export class LikeAvgAggregate {
+
+    @Field(() => Float, {nullable:true})
+    id?: number;
+
+    @Field(() => Float, {nullable:true})
+    userId?: number;
+
+    @Field(() => Float, {nullable:true})
+    postId?: number;
+}

--- a/api/@generated/like/like-avg-order-by-aggregate.input.ts
+++ b/api/@generated/like/like-avg-order-by-aggregate.input.ts
@@ -1,0 +1,16 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { SortOrder } from '../prisma/sort-order.enum';
+
+@InputType()
+export class LikeAvgOrderByAggregateInput {
+
+    @Field(() => SortOrder, {nullable:true})
+    id?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    userId?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    postId?: keyof typeof SortOrder;
+}

--- a/api/@generated/like/like-count-aggregate.input.ts
+++ b/api/@generated/like/like-count-aggregate.input.ts
@@ -1,0 +1,24 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+
+@InputType()
+export class LikeCountAggregateInput {
+
+    @Field(() => Boolean, {nullable:true})
+    id?: true;
+
+    @Field(() => Boolean, {nullable:true})
+    userId?: true;
+
+    @Field(() => Boolean, {nullable:true})
+    postId?: true;
+
+    @Field(() => Boolean, {nullable:true})
+    createdAt?: true;
+
+    @Field(() => Boolean, {nullable:true})
+    updatedAt?: true;
+
+    @Field(() => Boolean, {nullable:true})
+    _all?: true;
+}

--- a/api/@generated/like/like-count-aggregate.output.ts
+++ b/api/@generated/like/like-count-aggregate.output.ts
@@ -1,0 +1,25 @@
+import { Field } from '@nestjs/graphql';
+import { ObjectType } from '@nestjs/graphql';
+import { Int } from '@nestjs/graphql';
+
+@ObjectType()
+export class LikeCountAggregate {
+
+    @Field(() => Int, {nullable:false})
+    id!: number;
+
+    @Field(() => Int, {nullable:false})
+    userId!: number;
+
+    @Field(() => Int, {nullable:false})
+    postId!: number;
+
+    @Field(() => Int, {nullable:false})
+    createdAt!: number;
+
+    @Field(() => Int, {nullable:false})
+    updatedAt!: number;
+
+    @Field(() => Int, {nullable:false})
+    _all!: number;
+}

--- a/api/@generated/like/like-count-order-by-aggregate.input.ts
+++ b/api/@generated/like/like-count-order-by-aggregate.input.ts
@@ -1,0 +1,22 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { SortOrder } from '../prisma/sort-order.enum';
+
+@InputType()
+export class LikeCountOrderByAggregateInput {
+
+    @Field(() => SortOrder, {nullable:true})
+    id?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    userId?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    postId?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    createdAt?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    updatedAt?: keyof typeof SortOrder;
+}

--- a/api/@generated/like/like-create-many-post-input-envelope.input.ts
+++ b/api/@generated/like/like-create-many-post-input-envelope.input.ts
@@ -1,0 +1,15 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { LikeCreateManyPostInput } from './like-create-many-post.input';
+import { Type } from 'class-transformer';
+
+@InputType()
+export class LikeCreateManyPostInputEnvelope {
+
+    @Field(() => [LikeCreateManyPostInput], {nullable:false})
+    @Type(() => LikeCreateManyPostInput)
+    data!: Array<LikeCreateManyPostInput>;
+
+    @Field(() => Boolean, {nullable:true})
+    skipDuplicates?: boolean;
+}

--- a/api/@generated/like/like-create-many-post.input.ts
+++ b/api/@generated/like/like-create-many-post.input.ts
@@ -1,0 +1,19 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { Int } from '@nestjs/graphql';
+
+@InputType()
+export class LikeCreateManyPostInput {
+
+    @Field(() => Int, {nullable:true})
+    id?: number;
+
+    @Field(() => Int, {nullable:false})
+    userId!: number;
+
+    @Field(() => Date, {nullable:true})
+    createdAt?: Date | string;
+
+    @Field(() => Date, {nullable:true})
+    updatedAt?: Date | string;
+}

--- a/api/@generated/like/like-create-many-user-input-envelope.input.ts
+++ b/api/@generated/like/like-create-many-user-input-envelope.input.ts
@@ -1,0 +1,15 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { LikeCreateManyUserInput } from './like-create-many-user.input';
+import { Type } from 'class-transformer';
+
+@InputType()
+export class LikeCreateManyUserInputEnvelope {
+
+    @Field(() => [LikeCreateManyUserInput], {nullable:false})
+    @Type(() => LikeCreateManyUserInput)
+    data!: Array<LikeCreateManyUserInput>;
+
+    @Field(() => Boolean, {nullable:true})
+    skipDuplicates?: boolean;
+}

--- a/api/@generated/like/like-create-many-user.input.ts
+++ b/api/@generated/like/like-create-many-user.input.ts
@@ -1,0 +1,19 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { Int } from '@nestjs/graphql';
+
+@InputType()
+export class LikeCreateManyUserInput {
+
+    @Field(() => Int, {nullable:true})
+    id?: number;
+
+    @Field(() => Int, {nullable:false})
+    postId!: number;
+
+    @Field(() => Date, {nullable:true})
+    createdAt?: Date | string;
+
+    @Field(() => Date, {nullable:true})
+    updatedAt?: Date | string;
+}

--- a/api/@generated/like/like-create-many.input.ts
+++ b/api/@generated/like/like-create-many.input.ts
@@ -1,0 +1,22 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { Int } from '@nestjs/graphql';
+
+@InputType()
+export class LikeCreateManyInput {
+
+    @Field(() => Int, {nullable:true})
+    id?: number;
+
+    @Field(() => Int, {nullable:false})
+    userId!: number;
+
+    @Field(() => Int, {nullable:false})
+    postId!: number;
+
+    @Field(() => Date, {nullable:true})
+    createdAt?: Date | string;
+
+    @Field(() => Date, {nullable:true})
+    updatedAt?: Date | string;
+}

--- a/api/@generated/like/like-create-nested-many-without-post.input.ts
+++ b/api/@generated/like/like-create-nested-many-without-post.input.ts
@@ -1,0 +1,28 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { LikeCreateWithoutPostInput } from './like-create-without-post.input';
+import { Type } from 'class-transformer';
+import { LikeCreateOrConnectWithoutPostInput } from './like-create-or-connect-without-post.input';
+import { LikeCreateManyPostInputEnvelope } from './like-create-many-post-input-envelope.input';
+import { Prisma } from '@prisma/client';
+import { LikeWhereUniqueInput } from './like-where-unique.input';
+
+@InputType()
+export class LikeCreateNestedManyWithoutPostInput {
+
+    @Field(() => [LikeCreateWithoutPostInput], {nullable:true})
+    @Type(() => LikeCreateWithoutPostInput)
+    create?: Array<LikeCreateWithoutPostInput>;
+
+    @Field(() => [LikeCreateOrConnectWithoutPostInput], {nullable:true})
+    @Type(() => LikeCreateOrConnectWithoutPostInput)
+    connectOrCreate?: Array<LikeCreateOrConnectWithoutPostInput>;
+
+    @Field(() => LikeCreateManyPostInputEnvelope, {nullable:true})
+    @Type(() => LikeCreateManyPostInputEnvelope)
+    createMany?: LikeCreateManyPostInputEnvelope;
+
+    @Field(() => [LikeWhereUniqueInput], {nullable:true})
+    @Type(() => LikeWhereUniqueInput)
+    connect?: Array<Prisma.AtLeast<LikeWhereUniqueInput, 'id' | 'userId_postId'>>;
+}

--- a/api/@generated/like/like-create-nested-many-without-user.input.ts
+++ b/api/@generated/like/like-create-nested-many-without-user.input.ts
@@ -1,0 +1,28 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { LikeCreateWithoutUserInput } from './like-create-without-user.input';
+import { Type } from 'class-transformer';
+import { LikeCreateOrConnectWithoutUserInput } from './like-create-or-connect-without-user.input';
+import { LikeCreateManyUserInputEnvelope } from './like-create-many-user-input-envelope.input';
+import { Prisma } from '@prisma/client';
+import { LikeWhereUniqueInput } from './like-where-unique.input';
+
+@InputType()
+export class LikeCreateNestedManyWithoutUserInput {
+
+    @Field(() => [LikeCreateWithoutUserInput], {nullable:true})
+    @Type(() => LikeCreateWithoutUserInput)
+    create?: Array<LikeCreateWithoutUserInput>;
+
+    @Field(() => [LikeCreateOrConnectWithoutUserInput], {nullable:true})
+    @Type(() => LikeCreateOrConnectWithoutUserInput)
+    connectOrCreate?: Array<LikeCreateOrConnectWithoutUserInput>;
+
+    @Field(() => LikeCreateManyUserInputEnvelope, {nullable:true})
+    @Type(() => LikeCreateManyUserInputEnvelope)
+    createMany?: LikeCreateManyUserInputEnvelope;
+
+    @Field(() => [LikeWhereUniqueInput], {nullable:true})
+    @Type(() => LikeWhereUniqueInput)
+    connect?: Array<Prisma.AtLeast<LikeWhereUniqueInput, 'id' | 'userId_postId'>>;
+}

--- a/api/@generated/like/like-create-or-connect-without-post.input.ts
+++ b/api/@generated/like/like-create-or-connect-without-post.input.ts
@@ -1,0 +1,18 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { Prisma } from '@prisma/client';
+import { LikeWhereUniqueInput } from './like-where-unique.input';
+import { Type } from 'class-transformer';
+import { LikeCreateWithoutPostInput } from './like-create-without-post.input';
+
+@InputType()
+export class LikeCreateOrConnectWithoutPostInput {
+
+    @Field(() => LikeWhereUniqueInput, {nullable:false})
+    @Type(() => LikeWhereUniqueInput)
+    where!: Prisma.AtLeast<LikeWhereUniqueInput, 'id' | 'userId_postId'>;
+
+    @Field(() => LikeCreateWithoutPostInput, {nullable:false})
+    @Type(() => LikeCreateWithoutPostInput)
+    create!: LikeCreateWithoutPostInput;
+}

--- a/api/@generated/like/like-create-or-connect-without-user.input.ts
+++ b/api/@generated/like/like-create-or-connect-without-user.input.ts
@@ -1,0 +1,18 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { Prisma } from '@prisma/client';
+import { LikeWhereUniqueInput } from './like-where-unique.input';
+import { Type } from 'class-transformer';
+import { LikeCreateWithoutUserInput } from './like-create-without-user.input';
+
+@InputType()
+export class LikeCreateOrConnectWithoutUserInput {
+
+    @Field(() => LikeWhereUniqueInput, {nullable:false})
+    @Type(() => LikeWhereUniqueInput)
+    where!: Prisma.AtLeast<LikeWhereUniqueInput, 'id' | 'userId_postId'>;
+
+    @Field(() => LikeCreateWithoutUserInput, {nullable:false})
+    @Type(() => LikeCreateWithoutUserInput)
+    create!: LikeCreateWithoutUserInput;
+}

--- a/api/@generated/like/like-create-without-post.input.ts
+++ b/api/@generated/like/like-create-without-post.input.ts
@@ -1,0 +1,16 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { UserCreateNestedOneWithoutLikesInput } from '../user/user-create-nested-one-without-likes.input';
+
+@InputType()
+export class LikeCreateWithoutPostInput {
+
+    @Field(() => Date, {nullable:true})
+    createdAt?: Date | string;
+
+    @Field(() => Date, {nullable:true})
+    updatedAt?: Date | string;
+
+    @Field(() => UserCreateNestedOneWithoutLikesInput, {nullable:false})
+    user!: UserCreateNestedOneWithoutLikesInput;
+}

--- a/api/@generated/like/like-create-without-user.input.ts
+++ b/api/@generated/like/like-create-without-user.input.ts
@@ -1,0 +1,16 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { PostCreateNestedOneWithoutLikesInput } from '../post/post-create-nested-one-without-likes.input';
+
+@InputType()
+export class LikeCreateWithoutUserInput {
+
+    @Field(() => Date, {nullable:true})
+    createdAt?: Date | string;
+
+    @Field(() => Date, {nullable:true})
+    updatedAt?: Date | string;
+
+    @Field(() => PostCreateNestedOneWithoutLikesInput, {nullable:false})
+    post!: PostCreateNestedOneWithoutLikesInput;
+}

--- a/api/@generated/like/like-create.input.ts
+++ b/api/@generated/like/like-create.input.ts
@@ -1,0 +1,20 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { UserCreateNestedOneWithoutLikesInput } from '../user/user-create-nested-one-without-likes.input';
+import { PostCreateNestedOneWithoutLikesInput } from '../post/post-create-nested-one-without-likes.input';
+
+@InputType()
+export class LikeCreateInput {
+
+    @Field(() => Date, {nullable:true})
+    createdAt?: Date | string;
+
+    @Field(() => Date, {nullable:true})
+    updatedAt?: Date | string;
+
+    @Field(() => UserCreateNestedOneWithoutLikesInput, {nullable:false})
+    user!: UserCreateNestedOneWithoutLikesInput;
+
+    @Field(() => PostCreateNestedOneWithoutLikesInput, {nullable:false})
+    post!: PostCreateNestedOneWithoutLikesInput;
+}

--- a/api/@generated/like/like-group-by.args.ts
+++ b/api/@generated/like/like-group-by.args.ts
@@ -1,0 +1,51 @@
+import { Field } from '@nestjs/graphql';
+import { ArgsType } from '@nestjs/graphql';
+import { LikeWhereInput } from './like-where.input';
+import { Type } from 'class-transformer';
+import { LikeOrderByWithAggregationInput } from './like-order-by-with-aggregation.input';
+import { LikeScalarFieldEnum } from './like-scalar-field.enum';
+import { LikeScalarWhereWithAggregatesInput } from './like-scalar-where-with-aggregates.input';
+import { Int } from '@nestjs/graphql';
+import { LikeCountAggregateInput } from './like-count-aggregate.input';
+import { LikeAvgAggregateInput } from './like-avg-aggregate.input';
+import { LikeSumAggregateInput } from './like-sum-aggregate.input';
+import { LikeMinAggregateInput } from './like-min-aggregate.input';
+import { LikeMaxAggregateInput } from './like-max-aggregate.input';
+
+@ArgsType()
+export class LikeGroupByArgs {
+
+    @Field(() => LikeWhereInput, {nullable:true})
+    @Type(() => LikeWhereInput)
+    where?: LikeWhereInput;
+
+    @Field(() => [LikeOrderByWithAggregationInput], {nullable:true})
+    orderBy?: Array<LikeOrderByWithAggregationInput>;
+
+    @Field(() => [LikeScalarFieldEnum], {nullable:false})
+    by!: Array<keyof typeof LikeScalarFieldEnum>;
+
+    @Field(() => LikeScalarWhereWithAggregatesInput, {nullable:true})
+    having?: LikeScalarWhereWithAggregatesInput;
+
+    @Field(() => Int, {nullable:true})
+    take?: number;
+
+    @Field(() => Int, {nullable:true})
+    skip?: number;
+
+    @Field(() => LikeCountAggregateInput, {nullable:true})
+    _count?: LikeCountAggregateInput;
+
+    @Field(() => LikeAvgAggregateInput, {nullable:true})
+    _avg?: LikeAvgAggregateInput;
+
+    @Field(() => LikeSumAggregateInput, {nullable:true})
+    _sum?: LikeSumAggregateInput;
+
+    @Field(() => LikeMinAggregateInput, {nullable:true})
+    _min?: LikeMinAggregateInput;
+
+    @Field(() => LikeMaxAggregateInput, {nullable:true})
+    _max?: LikeMaxAggregateInput;
+}

--- a/api/@generated/like/like-group-by.output.ts
+++ b/api/@generated/like/like-group-by.output.ts
@@ -1,0 +1,42 @@
+import { Field } from '@nestjs/graphql';
+import { ObjectType } from '@nestjs/graphql';
+import { Int } from '@nestjs/graphql';
+import { LikeCountAggregate } from './like-count-aggregate.output';
+import { LikeAvgAggregate } from './like-avg-aggregate.output';
+import { LikeSumAggregate } from './like-sum-aggregate.output';
+import { LikeMinAggregate } from './like-min-aggregate.output';
+import { LikeMaxAggregate } from './like-max-aggregate.output';
+
+@ObjectType()
+export class LikeGroupBy {
+
+    @Field(() => Int, {nullable:false})
+    id!: number;
+
+    @Field(() => Int, {nullable:false})
+    userId!: number;
+
+    @Field(() => Int, {nullable:false})
+    postId!: number;
+
+    @Field(() => Date, {nullable:false})
+    createdAt!: Date | string;
+
+    @Field(() => Date, {nullable:false})
+    updatedAt!: Date | string;
+
+    @Field(() => LikeCountAggregate, {nullable:true})
+    _count?: LikeCountAggregate;
+
+    @Field(() => LikeAvgAggregate, {nullable:true})
+    _avg?: LikeAvgAggregate;
+
+    @Field(() => LikeSumAggregate, {nullable:true})
+    _sum?: LikeSumAggregate;
+
+    @Field(() => LikeMinAggregate, {nullable:true})
+    _min?: LikeMinAggregate;
+
+    @Field(() => LikeMaxAggregate, {nullable:true})
+    _max?: LikeMaxAggregate;
+}

--- a/api/@generated/like/like-list-relation-filter.input.ts
+++ b/api/@generated/like/like-list-relation-filter.input.ts
@@ -1,0 +1,16 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { LikeWhereInput } from './like-where.input';
+
+@InputType()
+export class LikeListRelationFilter {
+
+    @Field(() => LikeWhereInput, {nullable:true})
+    every?: LikeWhereInput;
+
+    @Field(() => LikeWhereInput, {nullable:true})
+    some?: LikeWhereInput;
+
+    @Field(() => LikeWhereInput, {nullable:true})
+    none?: LikeWhereInput;
+}

--- a/api/@generated/like/like-max-aggregate.input.ts
+++ b/api/@generated/like/like-max-aggregate.input.ts
@@ -1,0 +1,21 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+
+@InputType()
+export class LikeMaxAggregateInput {
+
+    @Field(() => Boolean, {nullable:true})
+    id?: true;
+
+    @Field(() => Boolean, {nullable:true})
+    userId?: true;
+
+    @Field(() => Boolean, {nullable:true})
+    postId?: true;
+
+    @Field(() => Boolean, {nullable:true})
+    createdAt?: true;
+
+    @Field(() => Boolean, {nullable:true})
+    updatedAt?: true;
+}

--- a/api/@generated/like/like-max-aggregate.output.ts
+++ b/api/@generated/like/like-max-aggregate.output.ts
@@ -1,0 +1,22 @@
+import { Field } from '@nestjs/graphql';
+import { ObjectType } from '@nestjs/graphql';
+import { Int } from '@nestjs/graphql';
+
+@ObjectType()
+export class LikeMaxAggregate {
+
+    @Field(() => Int, {nullable:true})
+    id?: number;
+
+    @Field(() => Int, {nullable:true})
+    userId?: number;
+
+    @Field(() => Int, {nullable:true})
+    postId?: number;
+
+    @Field(() => Date, {nullable:true})
+    createdAt?: Date | string;
+
+    @Field(() => Date, {nullable:true})
+    updatedAt?: Date | string;
+}

--- a/api/@generated/like/like-max-order-by-aggregate.input.ts
+++ b/api/@generated/like/like-max-order-by-aggregate.input.ts
@@ -1,0 +1,22 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { SortOrder } from '../prisma/sort-order.enum';
+
+@InputType()
+export class LikeMaxOrderByAggregateInput {
+
+    @Field(() => SortOrder, {nullable:true})
+    id?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    userId?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    postId?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    createdAt?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    updatedAt?: keyof typeof SortOrder;
+}

--- a/api/@generated/like/like-min-aggregate.input.ts
+++ b/api/@generated/like/like-min-aggregate.input.ts
@@ -1,0 +1,21 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+
+@InputType()
+export class LikeMinAggregateInput {
+
+    @Field(() => Boolean, {nullable:true})
+    id?: true;
+
+    @Field(() => Boolean, {nullable:true})
+    userId?: true;
+
+    @Field(() => Boolean, {nullable:true})
+    postId?: true;
+
+    @Field(() => Boolean, {nullable:true})
+    createdAt?: true;
+
+    @Field(() => Boolean, {nullable:true})
+    updatedAt?: true;
+}

--- a/api/@generated/like/like-min-aggregate.output.ts
+++ b/api/@generated/like/like-min-aggregate.output.ts
@@ -1,0 +1,22 @@
+import { Field } from '@nestjs/graphql';
+import { ObjectType } from '@nestjs/graphql';
+import { Int } from '@nestjs/graphql';
+
+@ObjectType()
+export class LikeMinAggregate {
+
+    @Field(() => Int, {nullable:true})
+    id?: number;
+
+    @Field(() => Int, {nullable:true})
+    userId?: number;
+
+    @Field(() => Int, {nullable:true})
+    postId?: number;
+
+    @Field(() => Date, {nullable:true})
+    createdAt?: Date | string;
+
+    @Field(() => Date, {nullable:true})
+    updatedAt?: Date | string;
+}

--- a/api/@generated/like/like-min-order-by-aggregate.input.ts
+++ b/api/@generated/like/like-min-order-by-aggregate.input.ts
@@ -1,0 +1,22 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { SortOrder } from '../prisma/sort-order.enum';
+
+@InputType()
+export class LikeMinOrderByAggregateInput {
+
+    @Field(() => SortOrder, {nullable:true})
+    id?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    userId?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    postId?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    createdAt?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    updatedAt?: keyof typeof SortOrder;
+}

--- a/api/@generated/like/like-order-by-relation-aggregate.input.ts
+++ b/api/@generated/like/like-order-by-relation-aggregate.input.ts
@@ -1,0 +1,10 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { SortOrder } from '../prisma/sort-order.enum';
+
+@InputType()
+export class LikeOrderByRelationAggregateInput {
+
+    @Field(() => SortOrder, {nullable:true})
+    _count?: keyof typeof SortOrder;
+}

--- a/api/@generated/like/like-order-by-with-aggregation.input.ts
+++ b/api/@generated/like/like-order-by-with-aggregation.input.ts
@@ -1,0 +1,42 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { SortOrder } from '../prisma/sort-order.enum';
+import { LikeCountOrderByAggregateInput } from './like-count-order-by-aggregate.input';
+import { LikeAvgOrderByAggregateInput } from './like-avg-order-by-aggregate.input';
+import { LikeMaxOrderByAggregateInput } from './like-max-order-by-aggregate.input';
+import { LikeMinOrderByAggregateInput } from './like-min-order-by-aggregate.input';
+import { LikeSumOrderByAggregateInput } from './like-sum-order-by-aggregate.input';
+
+@InputType()
+export class LikeOrderByWithAggregationInput {
+
+    @Field(() => SortOrder, {nullable:true})
+    id?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    userId?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    postId?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    createdAt?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    updatedAt?: keyof typeof SortOrder;
+
+    @Field(() => LikeCountOrderByAggregateInput, {nullable:true})
+    _count?: LikeCountOrderByAggregateInput;
+
+    @Field(() => LikeAvgOrderByAggregateInput, {nullable:true})
+    _avg?: LikeAvgOrderByAggregateInput;
+
+    @Field(() => LikeMaxOrderByAggregateInput, {nullable:true})
+    _max?: LikeMaxOrderByAggregateInput;
+
+    @Field(() => LikeMinOrderByAggregateInput, {nullable:true})
+    _min?: LikeMinOrderByAggregateInput;
+
+    @Field(() => LikeSumOrderByAggregateInput, {nullable:true})
+    _sum?: LikeSumOrderByAggregateInput;
+}

--- a/api/@generated/like/like-order-by-with-relation.input.ts
+++ b/api/@generated/like/like-order-by-with-relation.input.ts
@@ -1,0 +1,30 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { SortOrder } from '../prisma/sort-order.enum';
+import { UserOrderByWithRelationInput } from '../user/user-order-by-with-relation.input';
+import { PostOrderByWithRelationInput } from '../post/post-order-by-with-relation.input';
+
+@InputType()
+export class LikeOrderByWithRelationInput {
+
+    @Field(() => SortOrder, {nullable:true})
+    id?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    userId?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    postId?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    createdAt?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    updatedAt?: keyof typeof SortOrder;
+
+    @Field(() => UserOrderByWithRelationInput, {nullable:true})
+    user?: UserOrderByWithRelationInput;
+
+    @Field(() => PostOrderByWithRelationInput, {nullable:true})
+    post?: PostOrderByWithRelationInput;
+}

--- a/api/@generated/like/like-scalar-field.enum.ts
+++ b/api/@generated/like/like-scalar-field.enum.ts
@@ -1,0 +1,12 @@
+import { registerEnumType } from '@nestjs/graphql';
+
+export enum LikeScalarFieldEnum {
+    id = "id",
+    userId = "userId",
+    postId = "postId",
+    createdAt = "createdAt",
+    updatedAt = "updatedAt"
+}
+
+
+registerEnumType(LikeScalarFieldEnum, { name: 'LikeScalarFieldEnum', description: undefined })

--- a/api/@generated/like/like-scalar-where-with-aggregates.input.ts
+++ b/api/@generated/like/like-scalar-where-with-aggregates.input.ts
@@ -1,0 +1,32 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { IntWithAggregatesFilter } from '../prisma/int-with-aggregates-filter.input';
+import { DateTimeWithAggregatesFilter } from '../prisma/date-time-with-aggregates-filter.input';
+
+@InputType()
+export class LikeScalarWhereWithAggregatesInput {
+
+    @Field(() => [LikeScalarWhereWithAggregatesInput], {nullable:true})
+    AND?: Array<LikeScalarWhereWithAggregatesInput>;
+
+    @Field(() => [LikeScalarWhereWithAggregatesInput], {nullable:true})
+    OR?: Array<LikeScalarWhereWithAggregatesInput>;
+
+    @Field(() => [LikeScalarWhereWithAggregatesInput], {nullable:true})
+    NOT?: Array<LikeScalarWhereWithAggregatesInput>;
+
+    @Field(() => IntWithAggregatesFilter, {nullable:true})
+    id?: IntWithAggregatesFilter;
+
+    @Field(() => IntWithAggregatesFilter, {nullable:true})
+    userId?: IntWithAggregatesFilter;
+
+    @Field(() => IntWithAggregatesFilter, {nullable:true})
+    postId?: IntWithAggregatesFilter;
+
+    @Field(() => DateTimeWithAggregatesFilter, {nullable:true})
+    createdAt?: DateTimeWithAggregatesFilter;
+
+    @Field(() => DateTimeWithAggregatesFilter, {nullable:true})
+    updatedAt?: DateTimeWithAggregatesFilter;
+}

--- a/api/@generated/like/like-scalar-where.input.ts
+++ b/api/@generated/like/like-scalar-where.input.ts
@@ -1,0 +1,32 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { IntFilter } from '../prisma/int-filter.input';
+import { DateTimeFilter } from '../prisma/date-time-filter.input';
+
+@InputType()
+export class LikeScalarWhereInput {
+
+    @Field(() => [LikeScalarWhereInput], {nullable:true})
+    AND?: Array<LikeScalarWhereInput>;
+
+    @Field(() => [LikeScalarWhereInput], {nullable:true})
+    OR?: Array<LikeScalarWhereInput>;
+
+    @Field(() => [LikeScalarWhereInput], {nullable:true})
+    NOT?: Array<LikeScalarWhereInput>;
+
+    @Field(() => IntFilter, {nullable:true})
+    id?: IntFilter;
+
+    @Field(() => IntFilter, {nullable:true})
+    userId?: IntFilter;
+
+    @Field(() => IntFilter, {nullable:true})
+    postId?: IntFilter;
+
+    @Field(() => DateTimeFilter, {nullable:true})
+    createdAt?: DateTimeFilter;
+
+    @Field(() => DateTimeFilter, {nullable:true})
+    updatedAt?: DateTimeFilter;
+}

--- a/api/@generated/like/like-sum-aggregate.input.ts
+++ b/api/@generated/like/like-sum-aggregate.input.ts
@@ -1,0 +1,15 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+
+@InputType()
+export class LikeSumAggregateInput {
+
+    @Field(() => Boolean, {nullable:true})
+    id?: true;
+
+    @Field(() => Boolean, {nullable:true})
+    userId?: true;
+
+    @Field(() => Boolean, {nullable:true})
+    postId?: true;
+}

--- a/api/@generated/like/like-sum-aggregate.output.ts
+++ b/api/@generated/like/like-sum-aggregate.output.ts
@@ -1,0 +1,16 @@
+import { Field } from '@nestjs/graphql';
+import { ObjectType } from '@nestjs/graphql';
+import { Int } from '@nestjs/graphql';
+
+@ObjectType()
+export class LikeSumAggregate {
+
+    @Field(() => Int, {nullable:true})
+    id?: number;
+
+    @Field(() => Int, {nullable:true})
+    userId?: number;
+
+    @Field(() => Int, {nullable:true})
+    postId?: number;
+}

--- a/api/@generated/like/like-sum-order-by-aggregate.input.ts
+++ b/api/@generated/like/like-sum-order-by-aggregate.input.ts
@@ -1,0 +1,16 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { SortOrder } from '../prisma/sort-order.enum';
+
+@InputType()
+export class LikeSumOrderByAggregateInput {
+
+    @Field(() => SortOrder, {nullable:true})
+    id?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    userId?: keyof typeof SortOrder;
+
+    @Field(() => SortOrder, {nullable:true})
+    postId?: keyof typeof SortOrder;
+}

--- a/api/@generated/like/like-unchecked-create-nested-many-without-post.input.ts
+++ b/api/@generated/like/like-unchecked-create-nested-many-without-post.input.ts
@@ -1,0 +1,28 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { LikeCreateWithoutPostInput } from './like-create-without-post.input';
+import { Type } from 'class-transformer';
+import { LikeCreateOrConnectWithoutPostInput } from './like-create-or-connect-without-post.input';
+import { LikeCreateManyPostInputEnvelope } from './like-create-many-post-input-envelope.input';
+import { Prisma } from '@prisma/client';
+import { LikeWhereUniqueInput } from './like-where-unique.input';
+
+@InputType()
+export class LikeUncheckedCreateNestedManyWithoutPostInput {
+
+    @Field(() => [LikeCreateWithoutPostInput], {nullable:true})
+    @Type(() => LikeCreateWithoutPostInput)
+    create?: Array<LikeCreateWithoutPostInput>;
+
+    @Field(() => [LikeCreateOrConnectWithoutPostInput], {nullable:true})
+    @Type(() => LikeCreateOrConnectWithoutPostInput)
+    connectOrCreate?: Array<LikeCreateOrConnectWithoutPostInput>;
+
+    @Field(() => LikeCreateManyPostInputEnvelope, {nullable:true})
+    @Type(() => LikeCreateManyPostInputEnvelope)
+    createMany?: LikeCreateManyPostInputEnvelope;
+
+    @Field(() => [LikeWhereUniqueInput], {nullable:true})
+    @Type(() => LikeWhereUniqueInput)
+    connect?: Array<Prisma.AtLeast<LikeWhereUniqueInput, 'id' | 'userId_postId'>>;
+}

--- a/api/@generated/like/like-unchecked-create-nested-many-without-user.input.ts
+++ b/api/@generated/like/like-unchecked-create-nested-many-without-user.input.ts
@@ -1,0 +1,28 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { LikeCreateWithoutUserInput } from './like-create-without-user.input';
+import { Type } from 'class-transformer';
+import { LikeCreateOrConnectWithoutUserInput } from './like-create-or-connect-without-user.input';
+import { LikeCreateManyUserInputEnvelope } from './like-create-many-user-input-envelope.input';
+import { Prisma } from '@prisma/client';
+import { LikeWhereUniqueInput } from './like-where-unique.input';
+
+@InputType()
+export class LikeUncheckedCreateNestedManyWithoutUserInput {
+
+    @Field(() => [LikeCreateWithoutUserInput], {nullable:true})
+    @Type(() => LikeCreateWithoutUserInput)
+    create?: Array<LikeCreateWithoutUserInput>;
+
+    @Field(() => [LikeCreateOrConnectWithoutUserInput], {nullable:true})
+    @Type(() => LikeCreateOrConnectWithoutUserInput)
+    connectOrCreate?: Array<LikeCreateOrConnectWithoutUserInput>;
+
+    @Field(() => LikeCreateManyUserInputEnvelope, {nullable:true})
+    @Type(() => LikeCreateManyUserInputEnvelope)
+    createMany?: LikeCreateManyUserInputEnvelope;
+
+    @Field(() => [LikeWhereUniqueInput], {nullable:true})
+    @Type(() => LikeWhereUniqueInput)
+    connect?: Array<Prisma.AtLeast<LikeWhereUniqueInput, 'id' | 'userId_postId'>>;
+}

--- a/api/@generated/like/like-unchecked-create-without-post.input.ts
+++ b/api/@generated/like/like-unchecked-create-without-post.input.ts
@@ -1,0 +1,19 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { Int } from '@nestjs/graphql';
+
+@InputType()
+export class LikeUncheckedCreateWithoutPostInput {
+
+    @Field(() => Int, {nullable:true})
+    id?: number;
+
+    @Field(() => Int, {nullable:false})
+    userId!: number;
+
+    @Field(() => Date, {nullable:true})
+    createdAt?: Date | string;
+
+    @Field(() => Date, {nullable:true})
+    updatedAt?: Date | string;
+}

--- a/api/@generated/like/like-unchecked-create-without-user.input.ts
+++ b/api/@generated/like/like-unchecked-create-without-user.input.ts
@@ -1,0 +1,19 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { Int } from '@nestjs/graphql';
+
+@InputType()
+export class LikeUncheckedCreateWithoutUserInput {
+
+    @Field(() => Int, {nullable:true})
+    id?: number;
+
+    @Field(() => Int, {nullable:false})
+    postId!: number;
+
+    @Field(() => Date, {nullable:true})
+    createdAt?: Date | string;
+
+    @Field(() => Date, {nullable:true})
+    updatedAt?: Date | string;
+}

--- a/api/@generated/like/like-unchecked-create.input.ts
+++ b/api/@generated/like/like-unchecked-create.input.ts
@@ -1,0 +1,22 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { Int } from '@nestjs/graphql';
+
+@InputType()
+export class LikeUncheckedCreateInput {
+
+    @Field(() => Int, {nullable:true})
+    id?: number;
+
+    @Field(() => Int, {nullable:false})
+    userId!: number;
+
+    @Field(() => Int, {nullable:false})
+    postId!: number;
+
+    @Field(() => Date, {nullable:true})
+    createdAt?: Date | string;
+
+    @Field(() => Date, {nullable:true})
+    updatedAt?: Date | string;
+}

--- a/api/@generated/like/like-unchecked-update-many-without-post-nested.input.ts
+++ b/api/@generated/like/like-unchecked-update-many-without-post-nested.input.ts
@@ -1,0 +1,60 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { LikeCreateWithoutPostInput } from './like-create-without-post.input';
+import { Type } from 'class-transformer';
+import { LikeCreateOrConnectWithoutPostInput } from './like-create-or-connect-without-post.input';
+import { LikeUpsertWithWhereUniqueWithoutPostInput } from './like-upsert-with-where-unique-without-post.input';
+import { LikeCreateManyPostInputEnvelope } from './like-create-many-post-input-envelope.input';
+import { Prisma } from '@prisma/client';
+import { LikeWhereUniqueInput } from './like-where-unique.input';
+import { LikeUpdateWithWhereUniqueWithoutPostInput } from './like-update-with-where-unique-without-post.input';
+import { LikeUpdateManyWithWhereWithoutPostInput } from './like-update-many-with-where-without-post.input';
+import { LikeScalarWhereInput } from './like-scalar-where.input';
+
+@InputType()
+export class LikeUncheckedUpdateManyWithoutPostNestedInput {
+
+    @Field(() => [LikeCreateWithoutPostInput], {nullable:true})
+    @Type(() => LikeCreateWithoutPostInput)
+    create?: Array<LikeCreateWithoutPostInput>;
+
+    @Field(() => [LikeCreateOrConnectWithoutPostInput], {nullable:true})
+    @Type(() => LikeCreateOrConnectWithoutPostInput)
+    connectOrCreate?: Array<LikeCreateOrConnectWithoutPostInput>;
+
+    @Field(() => [LikeUpsertWithWhereUniqueWithoutPostInput], {nullable:true})
+    @Type(() => LikeUpsertWithWhereUniqueWithoutPostInput)
+    upsert?: Array<LikeUpsertWithWhereUniqueWithoutPostInput>;
+
+    @Field(() => LikeCreateManyPostInputEnvelope, {nullable:true})
+    @Type(() => LikeCreateManyPostInputEnvelope)
+    createMany?: LikeCreateManyPostInputEnvelope;
+
+    @Field(() => [LikeWhereUniqueInput], {nullable:true})
+    @Type(() => LikeWhereUniqueInput)
+    set?: Array<Prisma.AtLeast<LikeWhereUniqueInput, 'id' | 'userId_postId'>>;
+
+    @Field(() => [LikeWhereUniqueInput], {nullable:true})
+    @Type(() => LikeWhereUniqueInput)
+    disconnect?: Array<Prisma.AtLeast<LikeWhereUniqueInput, 'id' | 'userId_postId'>>;
+
+    @Field(() => [LikeWhereUniqueInput], {nullable:true})
+    @Type(() => LikeWhereUniqueInput)
+    delete?: Array<Prisma.AtLeast<LikeWhereUniqueInput, 'id' | 'userId_postId'>>;
+
+    @Field(() => [LikeWhereUniqueInput], {nullable:true})
+    @Type(() => LikeWhereUniqueInput)
+    connect?: Array<Prisma.AtLeast<LikeWhereUniqueInput, 'id' | 'userId_postId'>>;
+
+    @Field(() => [LikeUpdateWithWhereUniqueWithoutPostInput], {nullable:true})
+    @Type(() => LikeUpdateWithWhereUniqueWithoutPostInput)
+    update?: Array<LikeUpdateWithWhereUniqueWithoutPostInput>;
+
+    @Field(() => [LikeUpdateManyWithWhereWithoutPostInput], {nullable:true})
+    @Type(() => LikeUpdateManyWithWhereWithoutPostInput)
+    updateMany?: Array<LikeUpdateManyWithWhereWithoutPostInput>;
+
+    @Field(() => [LikeScalarWhereInput], {nullable:true})
+    @Type(() => LikeScalarWhereInput)
+    deleteMany?: Array<LikeScalarWhereInput>;
+}

--- a/api/@generated/like/like-unchecked-update-many-without-post.input.ts
+++ b/api/@generated/like/like-unchecked-update-many-without-post.input.ts
@@ -1,0 +1,20 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { IntFieldUpdateOperationsInput } from '../prisma/int-field-update-operations.input';
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
+
+@InputType()
+export class LikeUncheckedUpdateManyWithoutPostInput {
+
+    @Field(() => IntFieldUpdateOperationsInput, {nullable:true})
+    id?: IntFieldUpdateOperationsInput;
+
+    @Field(() => IntFieldUpdateOperationsInput, {nullable:true})
+    userId?: IntFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    createdAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    updatedAt?: DateTimeFieldUpdateOperationsInput;
+}

--- a/api/@generated/like/like-unchecked-update-many-without-user-nested.input.ts
+++ b/api/@generated/like/like-unchecked-update-many-without-user-nested.input.ts
@@ -1,0 +1,60 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { LikeCreateWithoutUserInput } from './like-create-without-user.input';
+import { Type } from 'class-transformer';
+import { LikeCreateOrConnectWithoutUserInput } from './like-create-or-connect-without-user.input';
+import { LikeUpsertWithWhereUniqueWithoutUserInput } from './like-upsert-with-where-unique-without-user.input';
+import { LikeCreateManyUserInputEnvelope } from './like-create-many-user-input-envelope.input';
+import { Prisma } from '@prisma/client';
+import { LikeWhereUniqueInput } from './like-where-unique.input';
+import { LikeUpdateWithWhereUniqueWithoutUserInput } from './like-update-with-where-unique-without-user.input';
+import { LikeUpdateManyWithWhereWithoutUserInput } from './like-update-many-with-where-without-user.input';
+import { LikeScalarWhereInput } from './like-scalar-where.input';
+
+@InputType()
+export class LikeUncheckedUpdateManyWithoutUserNestedInput {
+
+    @Field(() => [LikeCreateWithoutUserInput], {nullable:true})
+    @Type(() => LikeCreateWithoutUserInput)
+    create?: Array<LikeCreateWithoutUserInput>;
+
+    @Field(() => [LikeCreateOrConnectWithoutUserInput], {nullable:true})
+    @Type(() => LikeCreateOrConnectWithoutUserInput)
+    connectOrCreate?: Array<LikeCreateOrConnectWithoutUserInput>;
+
+    @Field(() => [LikeUpsertWithWhereUniqueWithoutUserInput], {nullable:true})
+    @Type(() => LikeUpsertWithWhereUniqueWithoutUserInput)
+    upsert?: Array<LikeUpsertWithWhereUniqueWithoutUserInput>;
+
+    @Field(() => LikeCreateManyUserInputEnvelope, {nullable:true})
+    @Type(() => LikeCreateManyUserInputEnvelope)
+    createMany?: LikeCreateManyUserInputEnvelope;
+
+    @Field(() => [LikeWhereUniqueInput], {nullable:true})
+    @Type(() => LikeWhereUniqueInput)
+    set?: Array<Prisma.AtLeast<LikeWhereUniqueInput, 'id' | 'userId_postId'>>;
+
+    @Field(() => [LikeWhereUniqueInput], {nullable:true})
+    @Type(() => LikeWhereUniqueInput)
+    disconnect?: Array<Prisma.AtLeast<LikeWhereUniqueInput, 'id' | 'userId_postId'>>;
+
+    @Field(() => [LikeWhereUniqueInput], {nullable:true})
+    @Type(() => LikeWhereUniqueInput)
+    delete?: Array<Prisma.AtLeast<LikeWhereUniqueInput, 'id' | 'userId_postId'>>;
+
+    @Field(() => [LikeWhereUniqueInput], {nullable:true})
+    @Type(() => LikeWhereUniqueInput)
+    connect?: Array<Prisma.AtLeast<LikeWhereUniqueInput, 'id' | 'userId_postId'>>;
+
+    @Field(() => [LikeUpdateWithWhereUniqueWithoutUserInput], {nullable:true})
+    @Type(() => LikeUpdateWithWhereUniqueWithoutUserInput)
+    update?: Array<LikeUpdateWithWhereUniqueWithoutUserInput>;
+
+    @Field(() => [LikeUpdateManyWithWhereWithoutUserInput], {nullable:true})
+    @Type(() => LikeUpdateManyWithWhereWithoutUserInput)
+    updateMany?: Array<LikeUpdateManyWithWhereWithoutUserInput>;
+
+    @Field(() => [LikeScalarWhereInput], {nullable:true})
+    @Type(() => LikeScalarWhereInput)
+    deleteMany?: Array<LikeScalarWhereInput>;
+}

--- a/api/@generated/like/like-unchecked-update-many-without-user.input.ts
+++ b/api/@generated/like/like-unchecked-update-many-without-user.input.ts
@@ -1,0 +1,20 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { IntFieldUpdateOperationsInput } from '../prisma/int-field-update-operations.input';
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
+
+@InputType()
+export class LikeUncheckedUpdateManyWithoutUserInput {
+
+    @Field(() => IntFieldUpdateOperationsInput, {nullable:true})
+    id?: IntFieldUpdateOperationsInput;
+
+    @Field(() => IntFieldUpdateOperationsInput, {nullable:true})
+    postId?: IntFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    createdAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    updatedAt?: DateTimeFieldUpdateOperationsInput;
+}

--- a/api/@generated/like/like-unchecked-update-many.input.ts
+++ b/api/@generated/like/like-unchecked-update-many.input.ts
@@ -1,0 +1,23 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { IntFieldUpdateOperationsInput } from '../prisma/int-field-update-operations.input';
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
+
+@InputType()
+export class LikeUncheckedUpdateManyInput {
+
+    @Field(() => IntFieldUpdateOperationsInput, {nullable:true})
+    id?: IntFieldUpdateOperationsInput;
+
+    @Field(() => IntFieldUpdateOperationsInput, {nullable:true})
+    userId?: IntFieldUpdateOperationsInput;
+
+    @Field(() => IntFieldUpdateOperationsInput, {nullable:true})
+    postId?: IntFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    createdAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    updatedAt?: DateTimeFieldUpdateOperationsInput;
+}

--- a/api/@generated/like/like-unchecked-update-without-post.input.ts
+++ b/api/@generated/like/like-unchecked-update-without-post.input.ts
@@ -1,0 +1,20 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { IntFieldUpdateOperationsInput } from '../prisma/int-field-update-operations.input';
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
+
+@InputType()
+export class LikeUncheckedUpdateWithoutPostInput {
+
+    @Field(() => IntFieldUpdateOperationsInput, {nullable:true})
+    id?: IntFieldUpdateOperationsInput;
+
+    @Field(() => IntFieldUpdateOperationsInput, {nullable:true})
+    userId?: IntFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    createdAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    updatedAt?: DateTimeFieldUpdateOperationsInput;
+}

--- a/api/@generated/like/like-unchecked-update-without-user.input.ts
+++ b/api/@generated/like/like-unchecked-update-without-user.input.ts
@@ -1,0 +1,20 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { IntFieldUpdateOperationsInput } from '../prisma/int-field-update-operations.input';
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
+
+@InputType()
+export class LikeUncheckedUpdateWithoutUserInput {
+
+    @Field(() => IntFieldUpdateOperationsInput, {nullable:true})
+    id?: IntFieldUpdateOperationsInput;
+
+    @Field(() => IntFieldUpdateOperationsInput, {nullable:true})
+    postId?: IntFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    createdAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    updatedAt?: DateTimeFieldUpdateOperationsInput;
+}

--- a/api/@generated/like/like-unchecked-update.input.ts
+++ b/api/@generated/like/like-unchecked-update.input.ts
@@ -1,0 +1,23 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { IntFieldUpdateOperationsInput } from '../prisma/int-field-update-operations.input';
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
+
+@InputType()
+export class LikeUncheckedUpdateInput {
+
+    @Field(() => IntFieldUpdateOperationsInput, {nullable:true})
+    id?: IntFieldUpdateOperationsInput;
+
+    @Field(() => IntFieldUpdateOperationsInput, {nullable:true})
+    userId?: IntFieldUpdateOperationsInput;
+
+    @Field(() => IntFieldUpdateOperationsInput, {nullable:true})
+    postId?: IntFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    createdAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    updatedAt?: DateTimeFieldUpdateOperationsInput;
+}

--- a/api/@generated/like/like-update-many-mutation.input.ts
+++ b/api/@generated/like/like-update-many-mutation.input.ts
@@ -1,0 +1,13 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
+
+@InputType()
+export class LikeUpdateManyMutationInput {
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    createdAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    updatedAt?: DateTimeFieldUpdateOperationsInput;
+}

--- a/api/@generated/like/like-update-many-with-where-without-post.input.ts
+++ b/api/@generated/like/like-update-many-with-where-without-post.input.ts
@@ -1,0 +1,17 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { LikeScalarWhereInput } from './like-scalar-where.input';
+import { Type } from 'class-transformer';
+import { LikeUpdateManyMutationInput } from './like-update-many-mutation.input';
+
+@InputType()
+export class LikeUpdateManyWithWhereWithoutPostInput {
+
+    @Field(() => LikeScalarWhereInput, {nullable:false})
+    @Type(() => LikeScalarWhereInput)
+    where!: LikeScalarWhereInput;
+
+    @Field(() => LikeUpdateManyMutationInput, {nullable:false})
+    @Type(() => LikeUpdateManyMutationInput)
+    data!: LikeUpdateManyMutationInput;
+}

--- a/api/@generated/like/like-update-many-with-where-without-user.input.ts
+++ b/api/@generated/like/like-update-many-with-where-without-user.input.ts
@@ -1,0 +1,17 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { LikeScalarWhereInput } from './like-scalar-where.input';
+import { Type } from 'class-transformer';
+import { LikeUpdateManyMutationInput } from './like-update-many-mutation.input';
+
+@InputType()
+export class LikeUpdateManyWithWhereWithoutUserInput {
+
+    @Field(() => LikeScalarWhereInput, {nullable:false})
+    @Type(() => LikeScalarWhereInput)
+    where!: LikeScalarWhereInput;
+
+    @Field(() => LikeUpdateManyMutationInput, {nullable:false})
+    @Type(() => LikeUpdateManyMutationInput)
+    data!: LikeUpdateManyMutationInput;
+}

--- a/api/@generated/like/like-update-many-without-post-nested.input.ts
+++ b/api/@generated/like/like-update-many-without-post-nested.input.ts
@@ -1,0 +1,60 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { LikeCreateWithoutPostInput } from './like-create-without-post.input';
+import { Type } from 'class-transformer';
+import { LikeCreateOrConnectWithoutPostInput } from './like-create-or-connect-without-post.input';
+import { LikeUpsertWithWhereUniqueWithoutPostInput } from './like-upsert-with-where-unique-without-post.input';
+import { LikeCreateManyPostInputEnvelope } from './like-create-many-post-input-envelope.input';
+import { Prisma } from '@prisma/client';
+import { LikeWhereUniqueInput } from './like-where-unique.input';
+import { LikeUpdateWithWhereUniqueWithoutPostInput } from './like-update-with-where-unique-without-post.input';
+import { LikeUpdateManyWithWhereWithoutPostInput } from './like-update-many-with-where-without-post.input';
+import { LikeScalarWhereInput } from './like-scalar-where.input';
+
+@InputType()
+export class LikeUpdateManyWithoutPostNestedInput {
+
+    @Field(() => [LikeCreateWithoutPostInput], {nullable:true})
+    @Type(() => LikeCreateWithoutPostInput)
+    create?: Array<LikeCreateWithoutPostInput>;
+
+    @Field(() => [LikeCreateOrConnectWithoutPostInput], {nullable:true})
+    @Type(() => LikeCreateOrConnectWithoutPostInput)
+    connectOrCreate?: Array<LikeCreateOrConnectWithoutPostInput>;
+
+    @Field(() => [LikeUpsertWithWhereUniqueWithoutPostInput], {nullable:true})
+    @Type(() => LikeUpsertWithWhereUniqueWithoutPostInput)
+    upsert?: Array<LikeUpsertWithWhereUniqueWithoutPostInput>;
+
+    @Field(() => LikeCreateManyPostInputEnvelope, {nullable:true})
+    @Type(() => LikeCreateManyPostInputEnvelope)
+    createMany?: LikeCreateManyPostInputEnvelope;
+
+    @Field(() => [LikeWhereUniqueInput], {nullable:true})
+    @Type(() => LikeWhereUniqueInput)
+    set?: Array<Prisma.AtLeast<LikeWhereUniqueInput, 'id' | 'userId_postId'>>;
+
+    @Field(() => [LikeWhereUniqueInput], {nullable:true})
+    @Type(() => LikeWhereUniqueInput)
+    disconnect?: Array<Prisma.AtLeast<LikeWhereUniqueInput, 'id' | 'userId_postId'>>;
+
+    @Field(() => [LikeWhereUniqueInput], {nullable:true})
+    @Type(() => LikeWhereUniqueInput)
+    delete?: Array<Prisma.AtLeast<LikeWhereUniqueInput, 'id' | 'userId_postId'>>;
+
+    @Field(() => [LikeWhereUniqueInput], {nullable:true})
+    @Type(() => LikeWhereUniqueInput)
+    connect?: Array<Prisma.AtLeast<LikeWhereUniqueInput, 'id' | 'userId_postId'>>;
+
+    @Field(() => [LikeUpdateWithWhereUniqueWithoutPostInput], {nullable:true})
+    @Type(() => LikeUpdateWithWhereUniqueWithoutPostInput)
+    update?: Array<LikeUpdateWithWhereUniqueWithoutPostInput>;
+
+    @Field(() => [LikeUpdateManyWithWhereWithoutPostInput], {nullable:true})
+    @Type(() => LikeUpdateManyWithWhereWithoutPostInput)
+    updateMany?: Array<LikeUpdateManyWithWhereWithoutPostInput>;
+
+    @Field(() => [LikeScalarWhereInput], {nullable:true})
+    @Type(() => LikeScalarWhereInput)
+    deleteMany?: Array<LikeScalarWhereInput>;
+}

--- a/api/@generated/like/like-update-many-without-user-nested.input.ts
+++ b/api/@generated/like/like-update-many-without-user-nested.input.ts
@@ -1,0 +1,60 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { LikeCreateWithoutUserInput } from './like-create-without-user.input';
+import { Type } from 'class-transformer';
+import { LikeCreateOrConnectWithoutUserInput } from './like-create-or-connect-without-user.input';
+import { LikeUpsertWithWhereUniqueWithoutUserInput } from './like-upsert-with-where-unique-without-user.input';
+import { LikeCreateManyUserInputEnvelope } from './like-create-many-user-input-envelope.input';
+import { Prisma } from '@prisma/client';
+import { LikeWhereUniqueInput } from './like-where-unique.input';
+import { LikeUpdateWithWhereUniqueWithoutUserInput } from './like-update-with-where-unique-without-user.input';
+import { LikeUpdateManyWithWhereWithoutUserInput } from './like-update-many-with-where-without-user.input';
+import { LikeScalarWhereInput } from './like-scalar-where.input';
+
+@InputType()
+export class LikeUpdateManyWithoutUserNestedInput {
+
+    @Field(() => [LikeCreateWithoutUserInput], {nullable:true})
+    @Type(() => LikeCreateWithoutUserInput)
+    create?: Array<LikeCreateWithoutUserInput>;
+
+    @Field(() => [LikeCreateOrConnectWithoutUserInput], {nullable:true})
+    @Type(() => LikeCreateOrConnectWithoutUserInput)
+    connectOrCreate?: Array<LikeCreateOrConnectWithoutUserInput>;
+
+    @Field(() => [LikeUpsertWithWhereUniqueWithoutUserInput], {nullable:true})
+    @Type(() => LikeUpsertWithWhereUniqueWithoutUserInput)
+    upsert?: Array<LikeUpsertWithWhereUniqueWithoutUserInput>;
+
+    @Field(() => LikeCreateManyUserInputEnvelope, {nullable:true})
+    @Type(() => LikeCreateManyUserInputEnvelope)
+    createMany?: LikeCreateManyUserInputEnvelope;
+
+    @Field(() => [LikeWhereUniqueInput], {nullable:true})
+    @Type(() => LikeWhereUniqueInput)
+    set?: Array<Prisma.AtLeast<LikeWhereUniqueInput, 'id' | 'userId_postId'>>;
+
+    @Field(() => [LikeWhereUniqueInput], {nullable:true})
+    @Type(() => LikeWhereUniqueInput)
+    disconnect?: Array<Prisma.AtLeast<LikeWhereUniqueInput, 'id' | 'userId_postId'>>;
+
+    @Field(() => [LikeWhereUniqueInput], {nullable:true})
+    @Type(() => LikeWhereUniqueInput)
+    delete?: Array<Prisma.AtLeast<LikeWhereUniqueInput, 'id' | 'userId_postId'>>;
+
+    @Field(() => [LikeWhereUniqueInput], {nullable:true})
+    @Type(() => LikeWhereUniqueInput)
+    connect?: Array<Prisma.AtLeast<LikeWhereUniqueInput, 'id' | 'userId_postId'>>;
+
+    @Field(() => [LikeUpdateWithWhereUniqueWithoutUserInput], {nullable:true})
+    @Type(() => LikeUpdateWithWhereUniqueWithoutUserInput)
+    update?: Array<LikeUpdateWithWhereUniqueWithoutUserInput>;
+
+    @Field(() => [LikeUpdateManyWithWhereWithoutUserInput], {nullable:true})
+    @Type(() => LikeUpdateManyWithWhereWithoutUserInput)
+    updateMany?: Array<LikeUpdateManyWithWhereWithoutUserInput>;
+
+    @Field(() => [LikeScalarWhereInput], {nullable:true})
+    @Type(() => LikeScalarWhereInput)
+    deleteMany?: Array<LikeScalarWhereInput>;
+}

--- a/api/@generated/like/like-update-with-where-unique-without-post.input.ts
+++ b/api/@generated/like/like-update-with-where-unique-without-post.input.ts
@@ -1,0 +1,18 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { Prisma } from '@prisma/client';
+import { LikeWhereUniqueInput } from './like-where-unique.input';
+import { Type } from 'class-transformer';
+import { LikeUpdateWithoutPostInput } from './like-update-without-post.input';
+
+@InputType()
+export class LikeUpdateWithWhereUniqueWithoutPostInput {
+
+    @Field(() => LikeWhereUniqueInput, {nullable:false})
+    @Type(() => LikeWhereUniqueInput)
+    where!: Prisma.AtLeast<LikeWhereUniqueInput, 'id' | 'userId_postId'>;
+
+    @Field(() => LikeUpdateWithoutPostInput, {nullable:false})
+    @Type(() => LikeUpdateWithoutPostInput)
+    data!: LikeUpdateWithoutPostInput;
+}

--- a/api/@generated/like/like-update-with-where-unique-without-user.input.ts
+++ b/api/@generated/like/like-update-with-where-unique-without-user.input.ts
@@ -1,0 +1,18 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { Prisma } from '@prisma/client';
+import { LikeWhereUniqueInput } from './like-where-unique.input';
+import { Type } from 'class-transformer';
+import { LikeUpdateWithoutUserInput } from './like-update-without-user.input';
+
+@InputType()
+export class LikeUpdateWithWhereUniqueWithoutUserInput {
+
+    @Field(() => LikeWhereUniqueInput, {nullable:false})
+    @Type(() => LikeWhereUniqueInput)
+    where!: Prisma.AtLeast<LikeWhereUniqueInput, 'id' | 'userId_postId'>;
+
+    @Field(() => LikeUpdateWithoutUserInput, {nullable:false})
+    @Type(() => LikeUpdateWithoutUserInput)
+    data!: LikeUpdateWithoutUserInput;
+}

--- a/api/@generated/like/like-update-without-post.input.ts
+++ b/api/@generated/like/like-update-without-post.input.ts
@@ -1,0 +1,17 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
+import { UserUpdateOneRequiredWithoutLikesNestedInput } from '../user/user-update-one-required-without-likes-nested.input';
+
+@InputType()
+export class LikeUpdateWithoutPostInput {
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    createdAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    updatedAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => UserUpdateOneRequiredWithoutLikesNestedInput, {nullable:true})
+    user?: UserUpdateOneRequiredWithoutLikesNestedInput;
+}

--- a/api/@generated/like/like-update-without-user.input.ts
+++ b/api/@generated/like/like-update-without-user.input.ts
@@ -1,0 +1,17 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
+import { PostUpdateOneRequiredWithoutLikesNestedInput } from '../post/post-update-one-required-without-likes-nested.input';
+
+@InputType()
+export class LikeUpdateWithoutUserInput {
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    createdAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    updatedAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => PostUpdateOneRequiredWithoutLikesNestedInput, {nullable:true})
+    post?: PostUpdateOneRequiredWithoutLikesNestedInput;
+}

--- a/api/@generated/like/like-update.input.ts
+++ b/api/@generated/like/like-update.input.ts
@@ -1,0 +1,21 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
+import { UserUpdateOneRequiredWithoutLikesNestedInput } from '../user/user-update-one-required-without-likes-nested.input';
+import { PostUpdateOneRequiredWithoutLikesNestedInput } from '../post/post-update-one-required-without-likes-nested.input';
+
+@InputType()
+export class LikeUpdateInput {
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    createdAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    updatedAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => UserUpdateOneRequiredWithoutLikesNestedInput, {nullable:true})
+    user?: UserUpdateOneRequiredWithoutLikesNestedInput;
+
+    @Field(() => PostUpdateOneRequiredWithoutLikesNestedInput, {nullable:true})
+    post?: PostUpdateOneRequiredWithoutLikesNestedInput;
+}

--- a/api/@generated/like/like-upsert-with-where-unique-without-post.input.ts
+++ b/api/@generated/like/like-upsert-with-where-unique-without-post.input.ts
@@ -1,0 +1,23 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { Prisma } from '@prisma/client';
+import { LikeWhereUniqueInput } from './like-where-unique.input';
+import { Type } from 'class-transformer';
+import { LikeUpdateWithoutPostInput } from './like-update-without-post.input';
+import { LikeCreateWithoutPostInput } from './like-create-without-post.input';
+
+@InputType()
+export class LikeUpsertWithWhereUniqueWithoutPostInput {
+
+    @Field(() => LikeWhereUniqueInput, {nullable:false})
+    @Type(() => LikeWhereUniqueInput)
+    where!: Prisma.AtLeast<LikeWhereUniqueInput, 'id' | 'userId_postId'>;
+
+    @Field(() => LikeUpdateWithoutPostInput, {nullable:false})
+    @Type(() => LikeUpdateWithoutPostInput)
+    update!: LikeUpdateWithoutPostInput;
+
+    @Field(() => LikeCreateWithoutPostInput, {nullable:false})
+    @Type(() => LikeCreateWithoutPostInput)
+    create!: LikeCreateWithoutPostInput;
+}

--- a/api/@generated/like/like-upsert-with-where-unique-without-user.input.ts
+++ b/api/@generated/like/like-upsert-with-where-unique-without-user.input.ts
@@ -1,0 +1,23 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { Prisma } from '@prisma/client';
+import { LikeWhereUniqueInput } from './like-where-unique.input';
+import { Type } from 'class-transformer';
+import { LikeUpdateWithoutUserInput } from './like-update-without-user.input';
+import { LikeCreateWithoutUserInput } from './like-create-without-user.input';
+
+@InputType()
+export class LikeUpsertWithWhereUniqueWithoutUserInput {
+
+    @Field(() => LikeWhereUniqueInput, {nullable:false})
+    @Type(() => LikeWhereUniqueInput)
+    where!: Prisma.AtLeast<LikeWhereUniqueInput, 'id' | 'userId_postId'>;
+
+    @Field(() => LikeUpdateWithoutUserInput, {nullable:false})
+    @Type(() => LikeUpdateWithoutUserInput)
+    update!: LikeUpdateWithoutUserInput;
+
+    @Field(() => LikeCreateWithoutUserInput, {nullable:false})
+    @Type(() => LikeCreateWithoutUserInput)
+    create!: LikeCreateWithoutUserInput;
+}

--- a/api/@generated/like/like-user-id-post-id-compound-unique.input.ts
+++ b/api/@generated/like/like-user-id-post-id-compound-unique.input.ts
@@ -1,0 +1,13 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { Int } from '@nestjs/graphql';
+
+@InputType()
+export class LikeUserIdPostIdCompoundUniqueInput {
+
+    @Field(() => Int, {nullable:false})
+    userId!: number;
+
+    @Field(() => Int, {nullable:false})
+    postId!: number;
+}

--- a/api/@generated/like/like-where-unique.input.ts
+++ b/api/@generated/like/like-where-unique.input.ts
@@ -1,0 +1,46 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { Int } from '@nestjs/graphql';
+import { LikeUserIdPostIdCompoundUniqueInput } from './like-user-id-post-id-compound-unique.input';
+import { LikeWhereInput } from './like-where.input';
+import { IntFilter } from '../prisma/int-filter.input';
+import { DateTimeFilter } from '../prisma/date-time-filter.input';
+import { UserRelationFilter } from '../user/user-relation-filter.input';
+import { PostRelationFilter } from '../post/post-relation-filter.input';
+
+@InputType()
+export class LikeWhereUniqueInput {
+
+    @Field(() => Int, {nullable:true})
+    id?: number;
+
+    @Field(() => LikeUserIdPostIdCompoundUniqueInput, {nullable:true})
+    userId_postId?: LikeUserIdPostIdCompoundUniqueInput;
+
+    @Field(() => [LikeWhereInput], {nullable:true})
+    AND?: Array<LikeWhereInput>;
+
+    @Field(() => [LikeWhereInput], {nullable:true})
+    OR?: Array<LikeWhereInput>;
+
+    @Field(() => [LikeWhereInput], {nullable:true})
+    NOT?: Array<LikeWhereInput>;
+
+    @Field(() => IntFilter, {nullable:true})
+    userId?: IntFilter;
+
+    @Field(() => IntFilter, {nullable:true})
+    postId?: IntFilter;
+
+    @Field(() => DateTimeFilter, {nullable:true})
+    createdAt?: DateTimeFilter;
+
+    @Field(() => DateTimeFilter, {nullable:true})
+    updatedAt?: DateTimeFilter;
+
+    @Field(() => UserRelationFilter, {nullable:true})
+    user?: UserRelationFilter;
+
+    @Field(() => PostRelationFilter, {nullable:true})
+    post?: PostRelationFilter;
+}

--- a/api/@generated/like/like-where.input.ts
+++ b/api/@generated/like/like-where.input.ts
@@ -1,0 +1,40 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { IntFilter } from '../prisma/int-filter.input';
+import { DateTimeFilter } from '../prisma/date-time-filter.input';
+import { UserRelationFilter } from '../user/user-relation-filter.input';
+import { PostRelationFilter } from '../post/post-relation-filter.input';
+
+@InputType()
+export class LikeWhereInput {
+
+    @Field(() => [LikeWhereInput], {nullable:true})
+    AND?: Array<LikeWhereInput>;
+
+    @Field(() => [LikeWhereInput], {nullable:true})
+    OR?: Array<LikeWhereInput>;
+
+    @Field(() => [LikeWhereInput], {nullable:true})
+    NOT?: Array<LikeWhereInput>;
+
+    @Field(() => IntFilter, {nullable:true})
+    id?: IntFilter;
+
+    @Field(() => IntFilter, {nullable:true})
+    userId?: IntFilter;
+
+    @Field(() => IntFilter, {nullable:true})
+    postId?: IntFilter;
+
+    @Field(() => DateTimeFilter, {nullable:true})
+    createdAt?: DateTimeFilter;
+
+    @Field(() => DateTimeFilter, {nullable:true})
+    updatedAt?: DateTimeFilter;
+
+    @Field(() => UserRelationFilter, {nullable:true})
+    user?: UserRelationFilter;
+
+    @Field(() => PostRelationFilter, {nullable:true})
+    post?: PostRelationFilter;
+}

--- a/api/@generated/like/like.model.ts
+++ b/api/@generated/like/like.model.ts
@@ -1,0 +1,31 @@
+import { Field } from '@nestjs/graphql';
+import { ObjectType } from '@nestjs/graphql';
+import { ID } from '@nestjs/graphql';
+import { Int } from '@nestjs/graphql';
+import { User } from '../user/user.model';
+import { Post } from '../post/post.model';
+
+@ObjectType()
+export class Like {
+
+    @Field(() => ID, {nullable:false})
+    id!: number;
+
+    @Field(() => Int, {nullable:false})
+    userId!: number;
+
+    @Field(() => Int, {nullable:false})
+    postId!: number;
+
+    @Field(() => Date, {nullable:false})
+    createdAt!: Date;
+
+    @Field(() => Date, {nullable:false})
+    updatedAt!: Date;
+
+    @Field(() => User, {nullable:false})
+    user?: User;
+
+    @Field(() => Post, {nullable:false})
+    post?: Post;
+}

--- a/api/@generated/like/update-many-like.args.ts
+++ b/api/@generated/like/update-many-like.args.ts
@@ -1,0 +1,17 @@
+import { Field } from '@nestjs/graphql';
+import { ArgsType } from '@nestjs/graphql';
+import { LikeUpdateManyMutationInput } from './like-update-many-mutation.input';
+import { Type } from 'class-transformer';
+import { LikeWhereInput } from './like-where.input';
+
+@ArgsType()
+export class UpdateManyLikeArgs {
+
+    @Field(() => LikeUpdateManyMutationInput, {nullable:false})
+    @Type(() => LikeUpdateManyMutationInput)
+    data!: LikeUpdateManyMutationInput;
+
+    @Field(() => LikeWhereInput, {nullable:true})
+    @Type(() => LikeWhereInput)
+    where?: LikeWhereInput;
+}

--- a/api/@generated/like/update-one-like.args.ts
+++ b/api/@generated/like/update-one-like.args.ts
@@ -1,0 +1,18 @@
+import { Field } from '@nestjs/graphql';
+import { ArgsType } from '@nestjs/graphql';
+import { LikeUpdateInput } from './like-update.input';
+import { Type } from 'class-transformer';
+import { Prisma } from '@prisma/client';
+import { LikeWhereUniqueInput } from './like-where-unique.input';
+
+@ArgsType()
+export class UpdateOneLikeArgs {
+
+    @Field(() => LikeUpdateInput, {nullable:false})
+    @Type(() => LikeUpdateInput)
+    data!: LikeUpdateInput;
+
+    @Field(() => LikeWhereUniqueInput, {nullable:false})
+    @Type(() => LikeWhereUniqueInput)
+    where!: Prisma.AtLeast<LikeWhereUniqueInput, 'id' | 'userId_postId'>;
+}

--- a/api/@generated/like/upsert-one-like.args.ts
+++ b/api/@generated/like/upsert-one-like.args.ts
@@ -1,0 +1,23 @@
+import { Field } from '@nestjs/graphql';
+import { ArgsType } from '@nestjs/graphql';
+import { Prisma } from '@prisma/client';
+import { LikeWhereUniqueInput } from './like-where-unique.input';
+import { Type } from 'class-transformer';
+import { LikeCreateInput } from './like-create.input';
+import { LikeUpdateInput } from './like-update.input';
+
+@ArgsType()
+export class UpsertOneLikeArgs {
+
+    @Field(() => LikeWhereUniqueInput, {nullable:false})
+    @Type(() => LikeWhereUniqueInput)
+    where!: Prisma.AtLeast<LikeWhereUniqueInput, 'id' | 'userId_postId'>;
+
+    @Field(() => LikeCreateInput, {nullable:false})
+    @Type(() => LikeCreateInput)
+    create!: LikeCreateInput;
+
+    @Field(() => LikeUpdateInput, {nullable:false})
+    @Type(() => LikeUpdateInput)
+    update!: LikeUpdateInput;
+}

--- a/api/@generated/post/post-count.output.ts
+++ b/api/@generated/post/post-count.output.ts
@@ -10,4 +10,7 @@ export class PostCount {
 
     @Field(() => Int, {nullable:false})
     postHashtags?: number;
+
+    @Field(() => Int, {nullable:false})
+    likes?: number;
 }

--- a/api/@generated/post/post-create-nested-one-without-likes.input.ts
+++ b/api/@generated/post/post-create-nested-one-without-likes.input.ts
@@ -1,0 +1,23 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { PostCreateWithoutLikesInput } from './post-create-without-likes.input';
+import { Type } from 'class-transformer';
+import { PostCreateOrConnectWithoutLikesInput } from './post-create-or-connect-without-likes.input';
+import { Prisma } from '@prisma/client';
+import { PostWhereUniqueInput } from './post-where-unique.input';
+
+@InputType()
+export class PostCreateNestedOneWithoutLikesInput {
+
+    @Field(() => PostCreateWithoutLikesInput, {nullable:true})
+    @Type(() => PostCreateWithoutLikesInput)
+    create?: PostCreateWithoutLikesInput;
+
+    @Field(() => PostCreateOrConnectWithoutLikesInput, {nullable:true})
+    @Type(() => PostCreateOrConnectWithoutLikesInput)
+    connectOrCreate?: PostCreateOrConnectWithoutLikesInput;
+
+    @Field(() => PostWhereUniqueInput, {nullable:true})
+    @Type(() => PostWhereUniqueInput)
+    connect?: Prisma.AtLeast<PostWhereUniqueInput, 'id'>;
+}

--- a/api/@generated/post/post-create-or-connect-without-likes.input.ts
+++ b/api/@generated/post/post-create-or-connect-without-likes.input.ts
@@ -1,0 +1,18 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { Prisma } from '@prisma/client';
+import { PostWhereUniqueInput } from './post-where-unique.input';
+import { Type } from 'class-transformer';
+import { PostCreateWithoutLikesInput } from './post-create-without-likes.input';
+
+@InputType()
+export class PostCreateOrConnectWithoutLikesInput {
+
+    @Field(() => PostWhereUniqueInput, {nullable:false})
+    @Type(() => PostWhereUniqueInput)
+    where!: Prisma.AtLeast<PostWhereUniqueInput, 'id'>;
+
+    @Field(() => PostCreateWithoutLikesInput, {nullable:false})
+    @Type(() => PostCreateWithoutLikesInput)
+    create!: PostCreateWithoutLikesInput;
+}

--- a/api/@generated/post/post-create-without-likes.input.ts
+++ b/api/@generated/post/post-create-without-likes.input.ts
@@ -1,0 +1,33 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { MediaFileCreateNestedManyWithoutPostInput } from '../media-file/media-file-create-nested-many-without-post.input';
+import { UserCreateNestedOneWithoutPostsInput } from '../user/user-create-nested-one-without-posts.input';
+import { PostHashtagCreateNestedManyWithoutPostInput } from '../post-hashtag/post-hashtag-create-nested-many-without-post.input';
+
+@InputType()
+export class PostCreateWithoutLikesInput {
+
+    @Field(() => String, {nullable:true})
+    title?: string;
+
+    @Field(() => Boolean, {nullable:true})
+    isHideLikeAndCount?: boolean;
+
+    @Field(() => Boolean, {nullable:true})
+    isTurnOffComment?: boolean;
+
+    @Field(() => Date, {nullable:true})
+    createdAt?: Date | string;
+
+    @Field(() => Date, {nullable:true})
+    updatedAt?: Date | string;
+
+    @Field(() => MediaFileCreateNestedManyWithoutPostInput, {nullable:true})
+    mediaFiles?: MediaFileCreateNestedManyWithoutPostInput;
+
+    @Field(() => UserCreateNestedOneWithoutPostsInput, {nullable:false})
+    user!: UserCreateNestedOneWithoutPostsInput;
+
+    @Field(() => PostHashtagCreateNestedManyWithoutPostInput, {nullable:true})
+    postHashtags?: PostHashtagCreateNestedManyWithoutPostInput;
+}

--- a/api/@generated/post/post-create-without-media-files.input.ts
+++ b/api/@generated/post/post-create-without-media-files.input.ts
@@ -2,6 +2,7 @@ import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
 import { UserCreateNestedOneWithoutPostsInput } from '../user/user-create-nested-one-without-posts.input';
 import { PostHashtagCreateNestedManyWithoutPostInput } from '../post-hashtag/post-hashtag-create-nested-many-without-post.input';
+import { LikeCreateNestedManyWithoutPostInput } from '../like/like-create-nested-many-without-post.input';
 
 @InputType()
 export class PostCreateWithoutMediaFilesInput {
@@ -26,4 +27,7 @@ export class PostCreateWithoutMediaFilesInput {
 
     @Field(() => PostHashtagCreateNestedManyWithoutPostInput, {nullable:true})
     postHashtags?: PostHashtagCreateNestedManyWithoutPostInput;
+
+    @Field(() => LikeCreateNestedManyWithoutPostInput, {nullable:true})
+    likes?: LikeCreateNestedManyWithoutPostInput;
 }

--- a/api/@generated/post/post-create-without-post-hashtags.input.ts
+++ b/api/@generated/post/post-create-without-post-hashtags.input.ts
@@ -2,6 +2,7 @@ import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
 import { MediaFileCreateNestedManyWithoutPostInput } from '../media-file/media-file-create-nested-many-without-post.input';
 import { UserCreateNestedOneWithoutPostsInput } from '../user/user-create-nested-one-without-posts.input';
+import { LikeCreateNestedManyWithoutPostInput } from '../like/like-create-nested-many-without-post.input';
 
 @InputType()
 export class PostCreateWithoutPostHashtagsInput {
@@ -26,4 +27,7 @@ export class PostCreateWithoutPostHashtagsInput {
 
     @Field(() => UserCreateNestedOneWithoutPostsInput, {nullable:false})
     user!: UserCreateNestedOneWithoutPostsInput;
+
+    @Field(() => LikeCreateNestedManyWithoutPostInput, {nullable:true})
+    likes?: LikeCreateNestedManyWithoutPostInput;
 }

--- a/api/@generated/post/post-create-without-user.input.ts
+++ b/api/@generated/post/post-create-without-user.input.ts
@@ -2,6 +2,7 @@ import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
 import { MediaFileCreateNestedManyWithoutPostInput } from '../media-file/media-file-create-nested-many-without-post.input';
 import { PostHashtagCreateNestedManyWithoutPostInput } from '../post-hashtag/post-hashtag-create-nested-many-without-post.input';
+import { LikeCreateNestedManyWithoutPostInput } from '../like/like-create-nested-many-without-post.input';
 
 @InputType()
 export class PostCreateWithoutUserInput {
@@ -26,4 +27,7 @@ export class PostCreateWithoutUserInput {
 
     @Field(() => PostHashtagCreateNestedManyWithoutPostInput, {nullable:true})
     postHashtags?: PostHashtagCreateNestedManyWithoutPostInput;
+
+    @Field(() => LikeCreateNestedManyWithoutPostInput, {nullable:true})
+    likes?: LikeCreateNestedManyWithoutPostInput;
 }

--- a/api/@generated/post/post-create.input.ts
+++ b/api/@generated/post/post-create.input.ts
@@ -3,6 +3,7 @@ import { InputType } from '@nestjs/graphql';
 import { MediaFileCreateNestedManyWithoutPostInput } from '../media-file/media-file-create-nested-many-without-post.input';
 import { UserCreateNestedOneWithoutPostsInput } from '../user/user-create-nested-one-without-posts.input';
 import { PostHashtagCreateNestedManyWithoutPostInput } from '../post-hashtag/post-hashtag-create-nested-many-without-post.input';
+import { LikeCreateNestedManyWithoutPostInput } from '../like/like-create-nested-many-without-post.input';
 
 @InputType()
 export class PostCreateInput {
@@ -30,4 +31,7 @@ export class PostCreateInput {
 
     @Field(() => PostHashtagCreateNestedManyWithoutPostInput, {nullable:true})
     postHashtags?: PostHashtagCreateNestedManyWithoutPostInput;
+
+    @Field(() => LikeCreateNestedManyWithoutPostInput, {nullable:true})
+    likes?: LikeCreateNestedManyWithoutPostInput;
 }

--- a/api/@generated/post/post-order-by-with-relation.input.ts
+++ b/api/@generated/post/post-order-by-with-relation.input.ts
@@ -5,6 +5,7 @@ import { SortOrderInput } from '../prisma/sort-order.input';
 import { MediaFileOrderByRelationAggregateInput } from '../media-file/media-file-order-by-relation-aggregate.input';
 import { UserOrderByWithRelationInput } from '../user/user-order-by-with-relation.input';
 import { PostHashtagOrderByRelationAggregateInput } from '../post-hashtag/post-hashtag-order-by-relation-aggregate.input';
+import { LikeOrderByRelationAggregateInput } from '../like/like-order-by-relation-aggregate.input';
 
 @InputType()
 export class PostOrderByWithRelationInput {
@@ -38,4 +39,7 @@ export class PostOrderByWithRelationInput {
 
     @Field(() => PostHashtagOrderByRelationAggregateInput, {nullable:true})
     postHashtags?: PostHashtagOrderByRelationAggregateInput;
+
+    @Field(() => LikeOrderByRelationAggregateInput, {nullable:true})
+    likes?: LikeOrderByRelationAggregateInput;
 }

--- a/api/@generated/post/post-unchecked-create-without-likes.input.ts
+++ b/api/@generated/post/post-unchecked-create-without-likes.input.ts
@@ -1,0 +1,36 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { Int } from '@nestjs/graphql';
+import { MediaFileUncheckedCreateNestedManyWithoutPostInput } from '../media-file/media-file-unchecked-create-nested-many-without-post.input';
+import { PostHashtagUncheckedCreateNestedManyWithoutPostInput } from '../post-hashtag/post-hashtag-unchecked-create-nested-many-without-post.input';
+
+@InputType()
+export class PostUncheckedCreateWithoutLikesInput {
+
+    @Field(() => Int, {nullable:true})
+    id?: number;
+
+    @Field(() => String, {nullable:true})
+    title?: string;
+
+    @Field(() => Int, {nullable:false})
+    userId!: number;
+
+    @Field(() => Boolean, {nullable:true})
+    isHideLikeAndCount?: boolean;
+
+    @Field(() => Boolean, {nullable:true})
+    isTurnOffComment?: boolean;
+
+    @Field(() => Date, {nullable:true})
+    createdAt?: Date | string;
+
+    @Field(() => Date, {nullable:true})
+    updatedAt?: Date | string;
+
+    @Field(() => MediaFileUncheckedCreateNestedManyWithoutPostInput, {nullable:true})
+    mediaFiles?: MediaFileUncheckedCreateNestedManyWithoutPostInput;
+
+    @Field(() => PostHashtagUncheckedCreateNestedManyWithoutPostInput, {nullable:true})
+    postHashtags?: PostHashtagUncheckedCreateNestedManyWithoutPostInput;
+}

--- a/api/@generated/post/post-unchecked-create-without-media-files.input.ts
+++ b/api/@generated/post/post-unchecked-create-without-media-files.input.ts
@@ -2,6 +2,7 @@ import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
 import { Int } from '@nestjs/graphql';
 import { PostHashtagUncheckedCreateNestedManyWithoutPostInput } from '../post-hashtag/post-hashtag-unchecked-create-nested-many-without-post.input';
+import { LikeUncheckedCreateNestedManyWithoutPostInput } from '../like/like-unchecked-create-nested-many-without-post.input';
 
 @InputType()
 export class PostUncheckedCreateWithoutMediaFilesInput {
@@ -29,4 +30,7 @@ export class PostUncheckedCreateWithoutMediaFilesInput {
 
     @Field(() => PostHashtagUncheckedCreateNestedManyWithoutPostInput, {nullable:true})
     postHashtags?: PostHashtagUncheckedCreateNestedManyWithoutPostInput;
+
+    @Field(() => LikeUncheckedCreateNestedManyWithoutPostInput, {nullable:true})
+    likes?: LikeUncheckedCreateNestedManyWithoutPostInput;
 }

--- a/api/@generated/post/post-unchecked-create-without-post-hashtags.input.ts
+++ b/api/@generated/post/post-unchecked-create-without-post-hashtags.input.ts
@@ -2,6 +2,7 @@ import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
 import { Int } from '@nestjs/graphql';
 import { MediaFileUncheckedCreateNestedManyWithoutPostInput } from '../media-file/media-file-unchecked-create-nested-many-without-post.input';
+import { LikeUncheckedCreateNestedManyWithoutPostInput } from '../like/like-unchecked-create-nested-many-without-post.input';
 
 @InputType()
 export class PostUncheckedCreateWithoutPostHashtagsInput {
@@ -29,4 +30,7 @@ export class PostUncheckedCreateWithoutPostHashtagsInput {
 
     @Field(() => MediaFileUncheckedCreateNestedManyWithoutPostInput, {nullable:true})
     mediaFiles?: MediaFileUncheckedCreateNestedManyWithoutPostInput;
+
+    @Field(() => LikeUncheckedCreateNestedManyWithoutPostInput, {nullable:true})
+    likes?: LikeUncheckedCreateNestedManyWithoutPostInput;
 }

--- a/api/@generated/post/post-unchecked-create-without-user.input.ts
+++ b/api/@generated/post/post-unchecked-create-without-user.input.ts
@@ -3,6 +3,7 @@ import { InputType } from '@nestjs/graphql';
 import { Int } from '@nestjs/graphql';
 import { MediaFileUncheckedCreateNestedManyWithoutPostInput } from '../media-file/media-file-unchecked-create-nested-many-without-post.input';
 import { PostHashtagUncheckedCreateNestedManyWithoutPostInput } from '../post-hashtag/post-hashtag-unchecked-create-nested-many-without-post.input';
+import { LikeUncheckedCreateNestedManyWithoutPostInput } from '../like/like-unchecked-create-nested-many-without-post.input';
 
 @InputType()
 export class PostUncheckedCreateWithoutUserInput {
@@ -30,4 +31,7 @@ export class PostUncheckedCreateWithoutUserInput {
 
     @Field(() => PostHashtagUncheckedCreateNestedManyWithoutPostInput, {nullable:true})
     postHashtags?: PostHashtagUncheckedCreateNestedManyWithoutPostInput;
+
+    @Field(() => LikeUncheckedCreateNestedManyWithoutPostInput, {nullable:true})
+    likes?: LikeUncheckedCreateNestedManyWithoutPostInput;
 }

--- a/api/@generated/post/post-unchecked-create.input.ts
+++ b/api/@generated/post/post-unchecked-create.input.ts
@@ -3,6 +3,7 @@ import { InputType } from '@nestjs/graphql';
 import { Int } from '@nestjs/graphql';
 import { MediaFileUncheckedCreateNestedManyWithoutPostInput } from '../media-file/media-file-unchecked-create-nested-many-without-post.input';
 import { PostHashtagUncheckedCreateNestedManyWithoutPostInput } from '../post-hashtag/post-hashtag-unchecked-create-nested-many-without-post.input';
+import { LikeUncheckedCreateNestedManyWithoutPostInput } from '../like/like-unchecked-create-nested-many-without-post.input';
 
 @InputType()
 export class PostUncheckedCreateInput {
@@ -33,4 +34,7 @@ export class PostUncheckedCreateInput {
 
     @Field(() => PostHashtagUncheckedCreateNestedManyWithoutPostInput, {nullable:true})
     postHashtags?: PostHashtagUncheckedCreateNestedManyWithoutPostInput;
+
+    @Field(() => LikeUncheckedCreateNestedManyWithoutPostInput, {nullable:true})
+    likes?: LikeUncheckedCreateNestedManyWithoutPostInput;
 }

--- a/api/@generated/post/post-unchecked-update-without-likes.input.ts
+++ b/api/@generated/post/post-unchecked-update-without-likes.input.ts
@@ -1,0 +1,39 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { IntFieldUpdateOperationsInput } from '../prisma/int-field-update-operations.input';
+import { NullableStringFieldUpdateOperationsInput } from '../prisma/nullable-string-field-update-operations.input';
+import { BoolFieldUpdateOperationsInput } from '../prisma/bool-field-update-operations.input';
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
+import { MediaFileUncheckedUpdateManyWithoutPostNestedInput } from '../media-file/media-file-unchecked-update-many-without-post-nested.input';
+import { PostHashtagUncheckedUpdateManyWithoutPostNestedInput } from '../post-hashtag/post-hashtag-unchecked-update-many-without-post-nested.input';
+
+@InputType()
+export class PostUncheckedUpdateWithoutLikesInput {
+
+    @Field(() => IntFieldUpdateOperationsInput, {nullable:true})
+    id?: IntFieldUpdateOperationsInput;
+
+    @Field(() => NullableStringFieldUpdateOperationsInput, {nullable:true})
+    title?: NullableStringFieldUpdateOperationsInput;
+
+    @Field(() => IntFieldUpdateOperationsInput, {nullable:true})
+    userId?: IntFieldUpdateOperationsInput;
+
+    @Field(() => BoolFieldUpdateOperationsInput, {nullable:true})
+    isHideLikeAndCount?: BoolFieldUpdateOperationsInput;
+
+    @Field(() => BoolFieldUpdateOperationsInput, {nullable:true})
+    isTurnOffComment?: BoolFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    createdAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    updatedAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => MediaFileUncheckedUpdateManyWithoutPostNestedInput, {nullable:true})
+    mediaFiles?: MediaFileUncheckedUpdateManyWithoutPostNestedInput;
+
+    @Field(() => PostHashtagUncheckedUpdateManyWithoutPostNestedInput, {nullable:true})
+    postHashtags?: PostHashtagUncheckedUpdateManyWithoutPostNestedInput;
+}

--- a/api/@generated/post/post-unchecked-update-without-media-files.input.ts
+++ b/api/@generated/post/post-unchecked-update-without-media-files.input.ts
@@ -5,6 +5,7 @@ import { NullableStringFieldUpdateOperationsInput } from '../prisma/nullable-str
 import { BoolFieldUpdateOperationsInput } from '../prisma/bool-field-update-operations.input';
 import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
 import { PostHashtagUncheckedUpdateManyWithoutPostNestedInput } from '../post-hashtag/post-hashtag-unchecked-update-many-without-post-nested.input';
+import { LikeUncheckedUpdateManyWithoutPostNestedInput } from '../like/like-unchecked-update-many-without-post-nested.input';
 
 @InputType()
 export class PostUncheckedUpdateWithoutMediaFilesInput {
@@ -32,4 +33,7 @@ export class PostUncheckedUpdateWithoutMediaFilesInput {
 
     @Field(() => PostHashtagUncheckedUpdateManyWithoutPostNestedInput, {nullable:true})
     postHashtags?: PostHashtagUncheckedUpdateManyWithoutPostNestedInput;
+
+    @Field(() => LikeUncheckedUpdateManyWithoutPostNestedInput, {nullable:true})
+    likes?: LikeUncheckedUpdateManyWithoutPostNestedInput;
 }

--- a/api/@generated/post/post-unchecked-update-without-post-hashtags.input.ts
+++ b/api/@generated/post/post-unchecked-update-without-post-hashtags.input.ts
@@ -5,6 +5,7 @@ import { NullableStringFieldUpdateOperationsInput } from '../prisma/nullable-str
 import { BoolFieldUpdateOperationsInput } from '../prisma/bool-field-update-operations.input';
 import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
 import { MediaFileUncheckedUpdateManyWithoutPostNestedInput } from '../media-file/media-file-unchecked-update-many-without-post-nested.input';
+import { LikeUncheckedUpdateManyWithoutPostNestedInput } from '../like/like-unchecked-update-many-without-post-nested.input';
 
 @InputType()
 export class PostUncheckedUpdateWithoutPostHashtagsInput {
@@ -32,4 +33,7 @@ export class PostUncheckedUpdateWithoutPostHashtagsInput {
 
     @Field(() => MediaFileUncheckedUpdateManyWithoutPostNestedInput, {nullable:true})
     mediaFiles?: MediaFileUncheckedUpdateManyWithoutPostNestedInput;
+
+    @Field(() => LikeUncheckedUpdateManyWithoutPostNestedInput, {nullable:true})
+    likes?: LikeUncheckedUpdateManyWithoutPostNestedInput;
 }

--- a/api/@generated/post/post-unchecked-update-without-user.input.ts
+++ b/api/@generated/post/post-unchecked-update-without-user.input.ts
@@ -6,6 +6,7 @@ import { BoolFieldUpdateOperationsInput } from '../prisma/bool-field-update-oper
 import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
 import { MediaFileUncheckedUpdateManyWithoutPostNestedInput } from '../media-file/media-file-unchecked-update-many-without-post-nested.input';
 import { PostHashtagUncheckedUpdateManyWithoutPostNestedInput } from '../post-hashtag/post-hashtag-unchecked-update-many-without-post-nested.input';
+import { LikeUncheckedUpdateManyWithoutPostNestedInput } from '../like/like-unchecked-update-many-without-post-nested.input';
 
 @InputType()
 export class PostUncheckedUpdateWithoutUserInput {
@@ -33,4 +34,7 @@ export class PostUncheckedUpdateWithoutUserInput {
 
     @Field(() => PostHashtagUncheckedUpdateManyWithoutPostNestedInput, {nullable:true})
     postHashtags?: PostHashtagUncheckedUpdateManyWithoutPostNestedInput;
+
+    @Field(() => LikeUncheckedUpdateManyWithoutPostNestedInput, {nullable:true})
+    likes?: LikeUncheckedUpdateManyWithoutPostNestedInput;
 }

--- a/api/@generated/post/post-unchecked-update.input.ts
+++ b/api/@generated/post/post-unchecked-update.input.ts
@@ -6,6 +6,7 @@ import { BoolFieldUpdateOperationsInput } from '../prisma/bool-field-update-oper
 import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
 import { MediaFileUncheckedUpdateManyWithoutPostNestedInput } from '../media-file/media-file-unchecked-update-many-without-post-nested.input';
 import { PostHashtagUncheckedUpdateManyWithoutPostNestedInput } from '../post-hashtag/post-hashtag-unchecked-update-many-without-post-nested.input';
+import { LikeUncheckedUpdateManyWithoutPostNestedInput } from '../like/like-unchecked-update-many-without-post-nested.input';
 
 @InputType()
 export class PostUncheckedUpdateInput {
@@ -36,4 +37,7 @@ export class PostUncheckedUpdateInput {
 
     @Field(() => PostHashtagUncheckedUpdateManyWithoutPostNestedInput, {nullable:true})
     postHashtags?: PostHashtagUncheckedUpdateManyWithoutPostNestedInput;
+
+    @Field(() => LikeUncheckedUpdateManyWithoutPostNestedInput, {nullable:true})
+    likes?: LikeUncheckedUpdateManyWithoutPostNestedInput;
 }

--- a/api/@generated/post/post-update-one-required-without-likes-nested.input.ts
+++ b/api/@generated/post/post-update-one-required-without-likes-nested.input.ts
@@ -1,0 +1,33 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { PostCreateWithoutLikesInput } from './post-create-without-likes.input';
+import { Type } from 'class-transformer';
+import { PostCreateOrConnectWithoutLikesInput } from './post-create-or-connect-without-likes.input';
+import { PostUpsertWithoutLikesInput } from './post-upsert-without-likes.input';
+import { Prisma } from '@prisma/client';
+import { PostWhereUniqueInput } from './post-where-unique.input';
+import { PostUpdateToOneWithWhereWithoutLikesInput } from './post-update-to-one-with-where-without-likes.input';
+
+@InputType()
+export class PostUpdateOneRequiredWithoutLikesNestedInput {
+
+    @Field(() => PostCreateWithoutLikesInput, {nullable:true})
+    @Type(() => PostCreateWithoutLikesInput)
+    create?: PostCreateWithoutLikesInput;
+
+    @Field(() => PostCreateOrConnectWithoutLikesInput, {nullable:true})
+    @Type(() => PostCreateOrConnectWithoutLikesInput)
+    connectOrCreate?: PostCreateOrConnectWithoutLikesInput;
+
+    @Field(() => PostUpsertWithoutLikesInput, {nullable:true})
+    @Type(() => PostUpsertWithoutLikesInput)
+    upsert?: PostUpsertWithoutLikesInput;
+
+    @Field(() => PostWhereUniqueInput, {nullable:true})
+    @Type(() => PostWhereUniqueInput)
+    connect?: Prisma.AtLeast<PostWhereUniqueInput, 'id'>;
+
+    @Field(() => PostUpdateToOneWithWhereWithoutLikesInput, {nullable:true})
+    @Type(() => PostUpdateToOneWithWhereWithoutLikesInput)
+    update?: PostUpdateToOneWithWhereWithoutLikesInput;
+}

--- a/api/@generated/post/post-update-to-one-with-where-without-likes.input.ts
+++ b/api/@generated/post/post-update-to-one-with-where-without-likes.input.ts
@@ -1,0 +1,17 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { PostWhereInput } from './post-where.input';
+import { Type } from 'class-transformer';
+import { PostUpdateWithoutLikesInput } from './post-update-without-likes.input';
+
+@InputType()
+export class PostUpdateToOneWithWhereWithoutLikesInput {
+
+    @Field(() => PostWhereInput, {nullable:true})
+    @Type(() => PostWhereInput)
+    where?: PostWhereInput;
+
+    @Field(() => PostUpdateWithoutLikesInput, {nullable:false})
+    @Type(() => PostUpdateWithoutLikesInput)
+    data!: PostUpdateWithoutLikesInput;
+}

--- a/api/@generated/post/post-update-without-likes.input.ts
+++ b/api/@generated/post/post-update-without-likes.input.ts
@@ -1,0 +1,36 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { NullableStringFieldUpdateOperationsInput } from '../prisma/nullable-string-field-update-operations.input';
+import { BoolFieldUpdateOperationsInput } from '../prisma/bool-field-update-operations.input';
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
+import { MediaFileUpdateManyWithoutPostNestedInput } from '../media-file/media-file-update-many-without-post-nested.input';
+import { UserUpdateOneRequiredWithoutPostsNestedInput } from '../user/user-update-one-required-without-posts-nested.input';
+import { PostHashtagUpdateManyWithoutPostNestedInput } from '../post-hashtag/post-hashtag-update-many-without-post-nested.input';
+
+@InputType()
+export class PostUpdateWithoutLikesInput {
+
+    @Field(() => NullableStringFieldUpdateOperationsInput, {nullable:true})
+    title?: NullableStringFieldUpdateOperationsInput;
+
+    @Field(() => BoolFieldUpdateOperationsInput, {nullable:true})
+    isHideLikeAndCount?: BoolFieldUpdateOperationsInput;
+
+    @Field(() => BoolFieldUpdateOperationsInput, {nullable:true})
+    isTurnOffComment?: BoolFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    createdAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    updatedAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => MediaFileUpdateManyWithoutPostNestedInput, {nullable:true})
+    mediaFiles?: MediaFileUpdateManyWithoutPostNestedInput;
+
+    @Field(() => UserUpdateOneRequiredWithoutPostsNestedInput, {nullable:true})
+    user?: UserUpdateOneRequiredWithoutPostsNestedInput;
+
+    @Field(() => PostHashtagUpdateManyWithoutPostNestedInput, {nullable:true})
+    postHashtags?: PostHashtagUpdateManyWithoutPostNestedInput;
+}

--- a/api/@generated/post/post-update-without-media-files.input.ts
+++ b/api/@generated/post/post-update-without-media-files.input.ts
@@ -5,6 +5,7 @@ import { BoolFieldUpdateOperationsInput } from '../prisma/bool-field-update-oper
 import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
 import { UserUpdateOneRequiredWithoutPostsNestedInput } from '../user/user-update-one-required-without-posts-nested.input';
 import { PostHashtagUpdateManyWithoutPostNestedInput } from '../post-hashtag/post-hashtag-update-many-without-post-nested.input';
+import { LikeUpdateManyWithoutPostNestedInput } from '../like/like-update-many-without-post-nested.input';
 
 @InputType()
 export class PostUpdateWithoutMediaFilesInput {
@@ -29,4 +30,7 @@ export class PostUpdateWithoutMediaFilesInput {
 
     @Field(() => PostHashtagUpdateManyWithoutPostNestedInput, {nullable:true})
     postHashtags?: PostHashtagUpdateManyWithoutPostNestedInput;
+
+    @Field(() => LikeUpdateManyWithoutPostNestedInput, {nullable:true})
+    likes?: LikeUpdateManyWithoutPostNestedInput;
 }

--- a/api/@generated/post/post-update-without-post-hashtags.input.ts
+++ b/api/@generated/post/post-update-without-post-hashtags.input.ts
@@ -5,6 +5,7 @@ import { BoolFieldUpdateOperationsInput } from '../prisma/bool-field-update-oper
 import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
 import { MediaFileUpdateManyWithoutPostNestedInput } from '../media-file/media-file-update-many-without-post-nested.input';
 import { UserUpdateOneRequiredWithoutPostsNestedInput } from '../user/user-update-one-required-without-posts-nested.input';
+import { LikeUpdateManyWithoutPostNestedInput } from '../like/like-update-many-without-post-nested.input';
 
 @InputType()
 export class PostUpdateWithoutPostHashtagsInput {
@@ -29,4 +30,7 @@ export class PostUpdateWithoutPostHashtagsInput {
 
     @Field(() => UserUpdateOneRequiredWithoutPostsNestedInput, {nullable:true})
     user?: UserUpdateOneRequiredWithoutPostsNestedInput;
+
+    @Field(() => LikeUpdateManyWithoutPostNestedInput, {nullable:true})
+    likes?: LikeUpdateManyWithoutPostNestedInput;
 }

--- a/api/@generated/post/post-update-without-user.input.ts
+++ b/api/@generated/post/post-update-without-user.input.ts
@@ -5,6 +5,7 @@ import { BoolFieldUpdateOperationsInput } from '../prisma/bool-field-update-oper
 import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
 import { MediaFileUpdateManyWithoutPostNestedInput } from '../media-file/media-file-update-many-without-post-nested.input';
 import { PostHashtagUpdateManyWithoutPostNestedInput } from '../post-hashtag/post-hashtag-update-many-without-post-nested.input';
+import { LikeUpdateManyWithoutPostNestedInput } from '../like/like-update-many-without-post-nested.input';
 
 @InputType()
 export class PostUpdateWithoutUserInput {
@@ -29,4 +30,7 @@ export class PostUpdateWithoutUserInput {
 
     @Field(() => PostHashtagUpdateManyWithoutPostNestedInput, {nullable:true})
     postHashtags?: PostHashtagUpdateManyWithoutPostNestedInput;
+
+    @Field(() => LikeUpdateManyWithoutPostNestedInput, {nullable:true})
+    likes?: LikeUpdateManyWithoutPostNestedInput;
 }

--- a/api/@generated/post/post-update.input.ts
+++ b/api/@generated/post/post-update.input.ts
@@ -6,6 +6,7 @@ import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-up
 import { MediaFileUpdateManyWithoutPostNestedInput } from '../media-file/media-file-update-many-without-post-nested.input';
 import { UserUpdateOneRequiredWithoutPostsNestedInput } from '../user/user-update-one-required-without-posts-nested.input';
 import { PostHashtagUpdateManyWithoutPostNestedInput } from '../post-hashtag/post-hashtag-update-many-without-post-nested.input';
+import { LikeUpdateManyWithoutPostNestedInput } from '../like/like-update-many-without-post-nested.input';
 
 @InputType()
 export class PostUpdateInput {
@@ -33,4 +34,7 @@ export class PostUpdateInput {
 
     @Field(() => PostHashtagUpdateManyWithoutPostNestedInput, {nullable:true})
     postHashtags?: PostHashtagUpdateManyWithoutPostNestedInput;
+
+    @Field(() => LikeUpdateManyWithoutPostNestedInput, {nullable:true})
+    likes?: LikeUpdateManyWithoutPostNestedInput;
 }

--- a/api/@generated/post/post-upsert-without-likes.input.ts
+++ b/api/@generated/post/post-upsert-without-likes.input.ts
@@ -1,0 +1,22 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { PostUpdateWithoutLikesInput } from './post-update-without-likes.input';
+import { Type } from 'class-transformer';
+import { PostCreateWithoutLikesInput } from './post-create-without-likes.input';
+import { PostWhereInput } from './post-where.input';
+
+@InputType()
+export class PostUpsertWithoutLikesInput {
+
+    @Field(() => PostUpdateWithoutLikesInput, {nullable:false})
+    @Type(() => PostUpdateWithoutLikesInput)
+    update!: PostUpdateWithoutLikesInput;
+
+    @Field(() => PostCreateWithoutLikesInput, {nullable:false})
+    @Type(() => PostCreateWithoutLikesInput)
+    create!: PostCreateWithoutLikesInput;
+
+    @Field(() => PostWhereInput, {nullable:true})
+    @Type(() => PostWhereInput)
+    where?: PostWhereInput;
+}

--- a/api/@generated/post/post-where-unique.input.ts
+++ b/api/@generated/post/post-where-unique.input.ts
@@ -9,6 +9,7 @@ import { DateTimeFilter } from '../prisma/date-time-filter.input';
 import { MediaFileListRelationFilter } from '../media-file/media-file-list-relation-filter.input';
 import { UserRelationFilter } from '../user/user-relation-filter.input';
 import { PostHashtagListRelationFilter } from '../post-hashtag/post-hashtag-list-relation-filter.input';
+import { LikeListRelationFilter } from '../like/like-list-relation-filter.input';
 
 @InputType()
 export class PostWhereUniqueInput {
@@ -51,4 +52,7 @@ export class PostWhereUniqueInput {
 
     @Field(() => PostHashtagListRelationFilter, {nullable:true})
     postHashtags?: PostHashtagListRelationFilter;
+
+    @Field(() => LikeListRelationFilter, {nullable:true})
+    likes?: LikeListRelationFilter;
 }

--- a/api/@generated/post/post-where.input.ts
+++ b/api/@generated/post/post-where.input.ts
@@ -7,6 +7,7 @@ import { DateTimeFilter } from '../prisma/date-time-filter.input';
 import { MediaFileListRelationFilter } from '../media-file/media-file-list-relation-filter.input';
 import { UserRelationFilter } from '../user/user-relation-filter.input';
 import { PostHashtagListRelationFilter } from '../post-hashtag/post-hashtag-list-relation-filter.input';
+import { LikeListRelationFilter } from '../like/like-list-relation-filter.input';
 
 @InputType()
 export class PostWhereInput {
@@ -49,4 +50,7 @@ export class PostWhereInput {
 
     @Field(() => PostHashtagListRelationFilter, {nullable:true})
     postHashtags?: PostHashtagListRelationFilter;
+
+    @Field(() => LikeListRelationFilter, {nullable:true})
+    likes?: LikeListRelationFilter;
 }

--- a/api/@generated/post/post.model.ts
+++ b/api/@generated/post/post.model.ts
@@ -5,6 +5,7 @@ import { Int } from '@nestjs/graphql';
 import { MediaFile } from '../media-file/media-file.model';
 import { User } from '../user/user.model';
 import { PostHashtag } from '../post-hashtag/post-hashtag.model';
+import { Like } from '../like/like.model';
 import { PostCount } from './post-count.output';
 
 @ObjectType()
@@ -39,6 +40,9 @@ export class Post {
 
     @Field(() => [PostHashtag], {nullable:true})
     postHashtags?: Array<PostHashtag>;
+
+    @Field(() => [Like], {nullable:true})
+    likes?: Array<Like>;
 
     @Field(() => PostCount, {nullable:false})
     _count?: PostCount;

--- a/api/@generated/user/user-count.output.ts
+++ b/api/@generated/user/user-count.output.ts
@@ -9,6 +9,9 @@ export class UserCount {
     posts?: number;
 
     @Field(() => Int, {nullable:false})
+    likes?: number;
+
+    @Field(() => Int, {nullable:false})
     followers?: number;
 
     @Field(() => Int, {nullable:false})

--- a/api/@generated/user/user-create-nested-one-without-likes.input.ts
+++ b/api/@generated/user/user-create-nested-one-without-likes.input.ts
@@ -1,0 +1,23 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { UserCreateWithoutLikesInput } from './user-create-without-likes.input';
+import { Type } from 'class-transformer';
+import { UserCreateOrConnectWithoutLikesInput } from './user-create-or-connect-without-likes.input';
+import { Prisma } from '@prisma/client';
+import { UserWhereUniqueInput } from './user-where-unique.input';
+
+@InputType()
+export class UserCreateNestedOneWithoutLikesInput {
+
+    @Field(() => UserCreateWithoutLikesInput, {nullable:true})
+    @Type(() => UserCreateWithoutLikesInput)
+    create?: UserCreateWithoutLikesInput;
+
+    @Field(() => UserCreateOrConnectWithoutLikesInput, {nullable:true})
+    @Type(() => UserCreateOrConnectWithoutLikesInput)
+    connectOrCreate?: UserCreateOrConnectWithoutLikesInput;
+
+    @Field(() => UserWhereUniqueInput, {nullable:true})
+    @Type(() => UserWhereUniqueInput)
+    connect?: Prisma.AtLeast<UserWhereUniqueInput, 'id' | 'email' | 'username'>;
+}

--- a/api/@generated/user/user-create-or-connect-without-likes.input.ts
+++ b/api/@generated/user/user-create-or-connect-without-likes.input.ts
@@ -1,0 +1,18 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { Prisma } from '@prisma/client';
+import { UserWhereUniqueInput } from './user-where-unique.input';
+import { Type } from 'class-transformer';
+import { UserCreateWithoutLikesInput } from './user-create-without-likes.input';
+
+@InputType()
+export class UserCreateOrConnectWithoutLikesInput {
+
+    @Field(() => UserWhereUniqueInput, {nullable:false})
+    @Type(() => UserWhereUniqueInput)
+    where!: Prisma.AtLeast<UserWhereUniqueInput, 'id' | 'email' | 'username'>;
+
+    @Field(() => UserCreateWithoutLikesInput, {nullable:false})
+    @Type(() => UserCreateWithoutLikesInput)
+    create!: UserCreateWithoutLikesInput;
+}

--- a/api/@generated/user/user-create-without-followers.input.ts
+++ b/api/@generated/user/user-create-without-followers.input.ts
@@ -3,6 +3,7 @@ import { InputType } from '@nestjs/graphql';
 import * as Validator from 'class-validator';
 import { Role } from '../prisma/role.enum';
 import { PostCreateNestedManyWithoutUserInput } from '../post/post-create-nested-many-without-user.input';
+import { LikeCreateNestedManyWithoutUserInput } from '../like/like-create-nested-many-without-user.input';
 import { FollowCreateNestedManyWithoutFollowingInput } from '../follow/follow-create-nested-many-without-following.input';
 
 @InputType()
@@ -37,6 +38,9 @@ export class UserCreateWithoutFollowersInput {
 
     @Field(() => PostCreateNestedManyWithoutUserInput, {nullable:true})
     posts?: PostCreateNestedManyWithoutUserInput;
+
+    @Field(() => LikeCreateNestedManyWithoutUserInput, {nullable:true})
+    likes?: LikeCreateNestedManyWithoutUserInput;
 
     @Field(() => FollowCreateNestedManyWithoutFollowingInput, {nullable:true})
     following?: FollowCreateNestedManyWithoutFollowingInput;

--- a/api/@generated/user/user-create-without-following.input.ts
+++ b/api/@generated/user/user-create-without-following.input.ts
@@ -3,6 +3,7 @@ import { InputType } from '@nestjs/graphql';
 import * as Validator from 'class-validator';
 import { Role } from '../prisma/role.enum';
 import { PostCreateNestedManyWithoutUserInput } from '../post/post-create-nested-many-without-user.input';
+import { LikeCreateNestedManyWithoutUserInput } from '../like/like-create-nested-many-without-user.input';
 import { FollowCreateNestedManyWithoutFollowerInput } from '../follow/follow-create-nested-many-without-follower.input';
 
 @InputType()
@@ -37,6 +38,9 @@ export class UserCreateWithoutFollowingInput {
 
     @Field(() => PostCreateNestedManyWithoutUserInput, {nullable:true})
     posts?: PostCreateNestedManyWithoutUserInput;
+
+    @Field(() => LikeCreateNestedManyWithoutUserInput, {nullable:true})
+    likes?: LikeCreateNestedManyWithoutUserInput;
 
     @Field(() => FollowCreateNestedManyWithoutFollowerInput, {nullable:true})
     followers?: FollowCreateNestedManyWithoutFollowerInput;

--- a/api/@generated/user/user-create-without-likes.input.ts
+++ b/api/@generated/user/user-create-without-likes.input.ts
@@ -1,0 +1,47 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import * as Validator from 'class-validator';
+import { Role } from '../prisma/role.enum';
+import { PostCreateNestedManyWithoutUserInput } from '../post/post-create-nested-many-without-user.input';
+import { FollowCreateNestedManyWithoutFollowerInput } from '../follow/follow-create-nested-many-without-follower.input';
+import { FollowCreateNestedManyWithoutFollowingInput } from '../follow/follow-create-nested-many-without-following.input';
+
+@InputType()
+export class UserCreateWithoutLikesInput {
+
+    @Field(() => String, {nullable:false})
+    email!: string;
+
+    @Field(() => String, {nullable:false})
+    @Validator.MinLength(5)
+    username!: string;
+
+    @Field(() => String, {nullable:false})
+    @Validator.MinLength(3)
+    name!: string;
+
+    @Field(() => String, {nullable:false})
+    @Validator.MinLength(6)
+    password!: string;
+
+    @Field(() => String, {nullable:true})
+    refreshToken?: string;
+
+    @Field(() => Role, {nullable:true})
+    role?: keyof typeof Role;
+
+    @Field(() => Date, {nullable:true})
+    createdAt?: Date | string;
+
+    @Field(() => Date, {nullable:true})
+    updatedAt?: Date | string;
+
+    @Field(() => PostCreateNestedManyWithoutUserInput, {nullable:true})
+    posts?: PostCreateNestedManyWithoutUserInput;
+
+    @Field(() => FollowCreateNestedManyWithoutFollowerInput, {nullable:true})
+    followers?: FollowCreateNestedManyWithoutFollowerInput;
+
+    @Field(() => FollowCreateNestedManyWithoutFollowingInput, {nullable:true})
+    following?: FollowCreateNestedManyWithoutFollowingInput;
+}

--- a/api/@generated/user/user-create-without-posts.input.ts
+++ b/api/@generated/user/user-create-without-posts.input.ts
@@ -2,6 +2,7 @@ import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
 import * as Validator from 'class-validator';
 import { Role } from '../prisma/role.enum';
+import { LikeCreateNestedManyWithoutUserInput } from '../like/like-create-nested-many-without-user.input';
 import { FollowCreateNestedManyWithoutFollowerInput } from '../follow/follow-create-nested-many-without-follower.input';
 import { FollowCreateNestedManyWithoutFollowingInput } from '../follow/follow-create-nested-many-without-following.input';
 
@@ -34,6 +35,9 @@ export class UserCreateWithoutPostsInput {
 
     @Field(() => Date, {nullable:true})
     updatedAt?: Date | string;
+
+    @Field(() => LikeCreateNestedManyWithoutUserInput, {nullable:true})
+    likes?: LikeCreateNestedManyWithoutUserInput;
 
     @Field(() => FollowCreateNestedManyWithoutFollowerInput, {nullable:true})
     followers?: FollowCreateNestedManyWithoutFollowerInput;

--- a/api/@generated/user/user-create.input.ts
+++ b/api/@generated/user/user-create.input.ts
@@ -3,6 +3,7 @@ import { InputType } from '@nestjs/graphql';
 import * as Validator from 'class-validator';
 import { Role } from '../prisma/role.enum';
 import { PostCreateNestedManyWithoutUserInput } from '../post/post-create-nested-many-without-user.input';
+import { LikeCreateNestedManyWithoutUserInput } from '../like/like-create-nested-many-without-user.input';
 import { FollowCreateNestedManyWithoutFollowerInput } from '../follow/follow-create-nested-many-without-follower.input';
 import { FollowCreateNestedManyWithoutFollowingInput } from '../follow/follow-create-nested-many-without-following.input';
 
@@ -38,6 +39,9 @@ export class UserCreateInput {
 
     @Field(() => PostCreateNestedManyWithoutUserInput, {nullable:true})
     posts?: PostCreateNestedManyWithoutUserInput;
+
+    @Field(() => LikeCreateNestedManyWithoutUserInput, {nullable:true})
+    likes?: LikeCreateNestedManyWithoutUserInput;
 
     @Field(() => FollowCreateNestedManyWithoutFollowerInput, {nullable:true})
     followers?: FollowCreateNestedManyWithoutFollowerInput;

--- a/api/@generated/user/user-order-by-with-relation.input.ts
+++ b/api/@generated/user/user-order-by-with-relation.input.ts
@@ -3,6 +3,7 @@ import { InputType } from '@nestjs/graphql';
 import { SortOrder } from '../prisma/sort-order.enum';
 import { SortOrderInput } from '../prisma/sort-order.input';
 import { PostOrderByRelationAggregateInput } from '../post/post-order-by-relation-aggregate.input';
+import { LikeOrderByRelationAggregateInput } from '../like/like-order-by-relation-aggregate.input';
 import { FollowOrderByRelationAggregateInput } from '../follow/follow-order-by-relation-aggregate.input';
 
 @InputType()
@@ -37,6 +38,9 @@ export class UserOrderByWithRelationInput {
 
     @Field(() => PostOrderByRelationAggregateInput, {nullable:true})
     posts?: PostOrderByRelationAggregateInput;
+
+    @Field(() => LikeOrderByRelationAggregateInput, {nullable:true})
+    likes?: LikeOrderByRelationAggregateInput;
 
     @Field(() => FollowOrderByRelationAggregateInput, {nullable:true})
     followers?: FollowOrderByRelationAggregateInput;

--- a/api/@generated/user/user-unchecked-create-without-followers.input.ts
+++ b/api/@generated/user/user-unchecked-create-without-followers.input.ts
@@ -4,6 +4,7 @@ import { Int } from '@nestjs/graphql';
 import * as Validator from 'class-validator';
 import { Role } from '../prisma/role.enum';
 import { PostUncheckedCreateNestedManyWithoutUserInput } from '../post/post-unchecked-create-nested-many-without-user.input';
+import { LikeUncheckedCreateNestedManyWithoutUserInput } from '../like/like-unchecked-create-nested-many-without-user.input';
 import { FollowUncheckedCreateNestedManyWithoutFollowingInput } from '../follow/follow-unchecked-create-nested-many-without-following.input';
 
 @InputType()
@@ -41,6 +42,9 @@ export class UserUncheckedCreateWithoutFollowersInput {
 
     @Field(() => PostUncheckedCreateNestedManyWithoutUserInput, {nullable:true})
     posts?: PostUncheckedCreateNestedManyWithoutUserInput;
+
+    @Field(() => LikeUncheckedCreateNestedManyWithoutUserInput, {nullable:true})
+    likes?: LikeUncheckedCreateNestedManyWithoutUserInput;
 
     @Field(() => FollowUncheckedCreateNestedManyWithoutFollowingInput, {nullable:true})
     following?: FollowUncheckedCreateNestedManyWithoutFollowingInput;

--- a/api/@generated/user/user-unchecked-create-without-following.input.ts
+++ b/api/@generated/user/user-unchecked-create-without-following.input.ts
@@ -4,6 +4,7 @@ import { Int } from '@nestjs/graphql';
 import * as Validator from 'class-validator';
 import { Role } from '../prisma/role.enum';
 import { PostUncheckedCreateNestedManyWithoutUserInput } from '../post/post-unchecked-create-nested-many-without-user.input';
+import { LikeUncheckedCreateNestedManyWithoutUserInput } from '../like/like-unchecked-create-nested-many-without-user.input';
 import { FollowUncheckedCreateNestedManyWithoutFollowerInput } from '../follow/follow-unchecked-create-nested-many-without-follower.input';
 
 @InputType()
@@ -41,6 +42,9 @@ export class UserUncheckedCreateWithoutFollowingInput {
 
     @Field(() => PostUncheckedCreateNestedManyWithoutUserInput, {nullable:true})
     posts?: PostUncheckedCreateNestedManyWithoutUserInput;
+
+    @Field(() => LikeUncheckedCreateNestedManyWithoutUserInput, {nullable:true})
+    likes?: LikeUncheckedCreateNestedManyWithoutUserInput;
 
     @Field(() => FollowUncheckedCreateNestedManyWithoutFollowerInput, {nullable:true})
     followers?: FollowUncheckedCreateNestedManyWithoutFollowerInput;

--- a/api/@generated/user/user-unchecked-create-without-likes.input.ts
+++ b/api/@generated/user/user-unchecked-create-without-likes.input.ts
@@ -1,0 +1,51 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { Int } from '@nestjs/graphql';
+import * as Validator from 'class-validator';
+import { Role } from '../prisma/role.enum';
+import { PostUncheckedCreateNestedManyWithoutUserInput } from '../post/post-unchecked-create-nested-many-without-user.input';
+import { FollowUncheckedCreateNestedManyWithoutFollowerInput } from '../follow/follow-unchecked-create-nested-many-without-follower.input';
+import { FollowUncheckedCreateNestedManyWithoutFollowingInput } from '../follow/follow-unchecked-create-nested-many-without-following.input';
+
+@InputType()
+export class UserUncheckedCreateWithoutLikesInput {
+
+    @Field(() => Int, {nullable:true})
+    id?: number;
+
+    @Field(() => String, {nullable:false})
+    email!: string;
+
+    @Field(() => String, {nullable:false})
+    @Validator.MinLength(5)
+    username!: string;
+
+    @Field(() => String, {nullable:false})
+    @Validator.MinLength(3)
+    name!: string;
+
+    @Field(() => String, {nullable:false})
+    @Validator.MinLength(6)
+    password!: string;
+
+    @Field(() => String, {nullable:true})
+    refreshToken?: string;
+
+    @Field(() => Role, {nullable:true})
+    role?: keyof typeof Role;
+
+    @Field(() => Date, {nullable:true})
+    createdAt?: Date | string;
+
+    @Field(() => Date, {nullable:true})
+    updatedAt?: Date | string;
+
+    @Field(() => PostUncheckedCreateNestedManyWithoutUserInput, {nullable:true})
+    posts?: PostUncheckedCreateNestedManyWithoutUserInput;
+
+    @Field(() => FollowUncheckedCreateNestedManyWithoutFollowerInput, {nullable:true})
+    followers?: FollowUncheckedCreateNestedManyWithoutFollowerInput;
+
+    @Field(() => FollowUncheckedCreateNestedManyWithoutFollowingInput, {nullable:true})
+    following?: FollowUncheckedCreateNestedManyWithoutFollowingInput;
+}

--- a/api/@generated/user/user-unchecked-create-without-posts.input.ts
+++ b/api/@generated/user/user-unchecked-create-without-posts.input.ts
@@ -3,6 +3,7 @@ import { InputType } from '@nestjs/graphql';
 import { Int } from '@nestjs/graphql';
 import * as Validator from 'class-validator';
 import { Role } from '../prisma/role.enum';
+import { LikeUncheckedCreateNestedManyWithoutUserInput } from '../like/like-unchecked-create-nested-many-without-user.input';
 import { FollowUncheckedCreateNestedManyWithoutFollowerInput } from '../follow/follow-unchecked-create-nested-many-without-follower.input';
 import { FollowUncheckedCreateNestedManyWithoutFollowingInput } from '../follow/follow-unchecked-create-nested-many-without-following.input';
 
@@ -38,6 +39,9 @@ export class UserUncheckedCreateWithoutPostsInput {
 
     @Field(() => Date, {nullable:true})
     updatedAt?: Date | string;
+
+    @Field(() => LikeUncheckedCreateNestedManyWithoutUserInput, {nullable:true})
+    likes?: LikeUncheckedCreateNestedManyWithoutUserInput;
 
     @Field(() => FollowUncheckedCreateNestedManyWithoutFollowerInput, {nullable:true})
     followers?: FollowUncheckedCreateNestedManyWithoutFollowerInput;

--- a/api/@generated/user/user-unchecked-create.input.ts
+++ b/api/@generated/user/user-unchecked-create.input.ts
@@ -4,6 +4,7 @@ import { Int } from '@nestjs/graphql';
 import * as Validator from 'class-validator';
 import { Role } from '../prisma/role.enum';
 import { PostUncheckedCreateNestedManyWithoutUserInput } from '../post/post-unchecked-create-nested-many-without-user.input';
+import { LikeUncheckedCreateNestedManyWithoutUserInput } from '../like/like-unchecked-create-nested-many-without-user.input';
 import { FollowUncheckedCreateNestedManyWithoutFollowerInput } from '../follow/follow-unchecked-create-nested-many-without-follower.input';
 import { FollowUncheckedCreateNestedManyWithoutFollowingInput } from '../follow/follow-unchecked-create-nested-many-without-following.input';
 
@@ -42,6 +43,9 @@ export class UserUncheckedCreateInput {
 
     @Field(() => PostUncheckedCreateNestedManyWithoutUserInput, {nullable:true})
     posts?: PostUncheckedCreateNestedManyWithoutUserInput;
+
+    @Field(() => LikeUncheckedCreateNestedManyWithoutUserInput, {nullable:true})
+    likes?: LikeUncheckedCreateNestedManyWithoutUserInput;
 
     @Field(() => FollowUncheckedCreateNestedManyWithoutFollowerInput, {nullable:true})
     followers?: FollowUncheckedCreateNestedManyWithoutFollowerInput;

--- a/api/@generated/user/user-unchecked-update-without-followers.input.ts
+++ b/api/@generated/user/user-unchecked-update-without-followers.input.ts
@@ -6,6 +6,7 @@ import { NullableStringFieldUpdateOperationsInput } from '../prisma/nullable-str
 import { EnumRoleFieldUpdateOperationsInput } from '../prisma/enum-role-field-update-operations.input';
 import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
 import { PostUncheckedUpdateManyWithoutUserNestedInput } from '../post/post-unchecked-update-many-without-user-nested.input';
+import { LikeUncheckedUpdateManyWithoutUserNestedInput } from '../like/like-unchecked-update-many-without-user-nested.input';
 import { FollowUncheckedUpdateManyWithoutFollowingNestedInput } from '../follow/follow-unchecked-update-many-without-following-nested.input';
 
 @InputType()
@@ -40,6 +41,9 @@ export class UserUncheckedUpdateWithoutFollowersInput {
 
     @Field(() => PostUncheckedUpdateManyWithoutUserNestedInput, {nullable:true})
     posts?: PostUncheckedUpdateManyWithoutUserNestedInput;
+
+    @Field(() => LikeUncheckedUpdateManyWithoutUserNestedInput, {nullable:true})
+    likes?: LikeUncheckedUpdateManyWithoutUserNestedInput;
 
     @Field(() => FollowUncheckedUpdateManyWithoutFollowingNestedInput, {nullable:true})
     following?: FollowUncheckedUpdateManyWithoutFollowingNestedInput;

--- a/api/@generated/user/user-unchecked-update-without-following.input.ts
+++ b/api/@generated/user/user-unchecked-update-without-following.input.ts
@@ -6,6 +6,7 @@ import { NullableStringFieldUpdateOperationsInput } from '../prisma/nullable-str
 import { EnumRoleFieldUpdateOperationsInput } from '../prisma/enum-role-field-update-operations.input';
 import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
 import { PostUncheckedUpdateManyWithoutUserNestedInput } from '../post/post-unchecked-update-many-without-user-nested.input';
+import { LikeUncheckedUpdateManyWithoutUserNestedInput } from '../like/like-unchecked-update-many-without-user-nested.input';
 import { FollowUncheckedUpdateManyWithoutFollowerNestedInput } from '../follow/follow-unchecked-update-many-without-follower-nested.input';
 
 @InputType()
@@ -40,6 +41,9 @@ export class UserUncheckedUpdateWithoutFollowingInput {
 
     @Field(() => PostUncheckedUpdateManyWithoutUserNestedInput, {nullable:true})
     posts?: PostUncheckedUpdateManyWithoutUserNestedInput;
+
+    @Field(() => LikeUncheckedUpdateManyWithoutUserNestedInput, {nullable:true})
+    likes?: LikeUncheckedUpdateManyWithoutUserNestedInput;
 
     @Field(() => FollowUncheckedUpdateManyWithoutFollowerNestedInput, {nullable:true})
     followers?: FollowUncheckedUpdateManyWithoutFollowerNestedInput;

--- a/api/@generated/user/user-unchecked-update-without-likes.input.ts
+++ b/api/@generated/user/user-unchecked-update-without-likes.input.ts
@@ -1,0 +1,50 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { IntFieldUpdateOperationsInput } from '../prisma/int-field-update-operations.input';
+import { StringFieldUpdateOperationsInput } from '../prisma/string-field-update-operations.input';
+import { NullableStringFieldUpdateOperationsInput } from '../prisma/nullable-string-field-update-operations.input';
+import { EnumRoleFieldUpdateOperationsInput } from '../prisma/enum-role-field-update-operations.input';
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
+import { PostUncheckedUpdateManyWithoutUserNestedInput } from '../post/post-unchecked-update-many-without-user-nested.input';
+import { FollowUncheckedUpdateManyWithoutFollowerNestedInput } from '../follow/follow-unchecked-update-many-without-follower-nested.input';
+import { FollowUncheckedUpdateManyWithoutFollowingNestedInput } from '../follow/follow-unchecked-update-many-without-following-nested.input';
+
+@InputType()
+export class UserUncheckedUpdateWithoutLikesInput {
+
+    @Field(() => IntFieldUpdateOperationsInput, {nullable:true})
+    id?: IntFieldUpdateOperationsInput;
+
+    @Field(() => StringFieldUpdateOperationsInput, {nullable:true})
+    email?: StringFieldUpdateOperationsInput;
+
+    @Field(() => StringFieldUpdateOperationsInput, {nullable:true})
+    username?: StringFieldUpdateOperationsInput;
+
+    @Field(() => StringFieldUpdateOperationsInput, {nullable:true})
+    name?: StringFieldUpdateOperationsInput;
+
+    @Field(() => StringFieldUpdateOperationsInput, {nullable:true})
+    password?: StringFieldUpdateOperationsInput;
+
+    @Field(() => NullableStringFieldUpdateOperationsInput, {nullable:true})
+    refreshToken?: NullableStringFieldUpdateOperationsInput;
+
+    @Field(() => EnumRoleFieldUpdateOperationsInput, {nullable:true})
+    role?: EnumRoleFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    createdAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    updatedAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => PostUncheckedUpdateManyWithoutUserNestedInput, {nullable:true})
+    posts?: PostUncheckedUpdateManyWithoutUserNestedInput;
+
+    @Field(() => FollowUncheckedUpdateManyWithoutFollowerNestedInput, {nullable:true})
+    followers?: FollowUncheckedUpdateManyWithoutFollowerNestedInput;
+
+    @Field(() => FollowUncheckedUpdateManyWithoutFollowingNestedInput, {nullable:true})
+    following?: FollowUncheckedUpdateManyWithoutFollowingNestedInput;
+}

--- a/api/@generated/user/user-unchecked-update-without-posts.input.ts
+++ b/api/@generated/user/user-unchecked-update-without-posts.input.ts
@@ -5,6 +5,7 @@ import { StringFieldUpdateOperationsInput } from '../prisma/string-field-update-
 import { NullableStringFieldUpdateOperationsInput } from '../prisma/nullable-string-field-update-operations.input';
 import { EnumRoleFieldUpdateOperationsInput } from '../prisma/enum-role-field-update-operations.input';
 import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
+import { LikeUncheckedUpdateManyWithoutUserNestedInput } from '../like/like-unchecked-update-many-without-user-nested.input';
 import { FollowUncheckedUpdateManyWithoutFollowerNestedInput } from '../follow/follow-unchecked-update-many-without-follower-nested.input';
 import { FollowUncheckedUpdateManyWithoutFollowingNestedInput } from '../follow/follow-unchecked-update-many-without-following-nested.input';
 
@@ -37,6 +38,9 @@ export class UserUncheckedUpdateWithoutPostsInput {
 
     @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
     updatedAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => LikeUncheckedUpdateManyWithoutUserNestedInput, {nullable:true})
+    likes?: LikeUncheckedUpdateManyWithoutUserNestedInput;
 
     @Field(() => FollowUncheckedUpdateManyWithoutFollowerNestedInput, {nullable:true})
     followers?: FollowUncheckedUpdateManyWithoutFollowerNestedInput;

--- a/api/@generated/user/user-unchecked-update.input.ts
+++ b/api/@generated/user/user-unchecked-update.input.ts
@@ -6,6 +6,7 @@ import { NullableStringFieldUpdateOperationsInput } from '../prisma/nullable-str
 import { EnumRoleFieldUpdateOperationsInput } from '../prisma/enum-role-field-update-operations.input';
 import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
 import { PostUncheckedUpdateManyWithoutUserNestedInput } from '../post/post-unchecked-update-many-without-user-nested.input';
+import { LikeUncheckedUpdateManyWithoutUserNestedInput } from '../like/like-unchecked-update-many-without-user-nested.input';
 import { FollowUncheckedUpdateManyWithoutFollowerNestedInput } from '../follow/follow-unchecked-update-many-without-follower-nested.input';
 import { FollowUncheckedUpdateManyWithoutFollowingNestedInput } from '../follow/follow-unchecked-update-many-without-following-nested.input';
 
@@ -41,6 +42,9 @@ export class UserUncheckedUpdateInput {
 
     @Field(() => PostUncheckedUpdateManyWithoutUserNestedInput, {nullable:true})
     posts?: PostUncheckedUpdateManyWithoutUserNestedInput;
+
+    @Field(() => LikeUncheckedUpdateManyWithoutUserNestedInput, {nullable:true})
+    likes?: LikeUncheckedUpdateManyWithoutUserNestedInput;
 
     @Field(() => FollowUncheckedUpdateManyWithoutFollowerNestedInput, {nullable:true})
     followers?: FollowUncheckedUpdateManyWithoutFollowerNestedInput;

--- a/api/@generated/user/user-update-one-required-without-likes-nested.input.ts
+++ b/api/@generated/user/user-update-one-required-without-likes-nested.input.ts
@@ -1,0 +1,33 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { UserCreateWithoutLikesInput } from './user-create-without-likes.input';
+import { Type } from 'class-transformer';
+import { UserCreateOrConnectWithoutLikesInput } from './user-create-or-connect-without-likes.input';
+import { UserUpsertWithoutLikesInput } from './user-upsert-without-likes.input';
+import { Prisma } from '@prisma/client';
+import { UserWhereUniqueInput } from './user-where-unique.input';
+import { UserUpdateToOneWithWhereWithoutLikesInput } from './user-update-to-one-with-where-without-likes.input';
+
+@InputType()
+export class UserUpdateOneRequiredWithoutLikesNestedInput {
+
+    @Field(() => UserCreateWithoutLikesInput, {nullable:true})
+    @Type(() => UserCreateWithoutLikesInput)
+    create?: UserCreateWithoutLikesInput;
+
+    @Field(() => UserCreateOrConnectWithoutLikesInput, {nullable:true})
+    @Type(() => UserCreateOrConnectWithoutLikesInput)
+    connectOrCreate?: UserCreateOrConnectWithoutLikesInput;
+
+    @Field(() => UserUpsertWithoutLikesInput, {nullable:true})
+    @Type(() => UserUpsertWithoutLikesInput)
+    upsert?: UserUpsertWithoutLikesInput;
+
+    @Field(() => UserWhereUniqueInput, {nullable:true})
+    @Type(() => UserWhereUniqueInput)
+    connect?: Prisma.AtLeast<UserWhereUniqueInput, 'id' | 'email' | 'username'>;
+
+    @Field(() => UserUpdateToOneWithWhereWithoutLikesInput, {nullable:true})
+    @Type(() => UserUpdateToOneWithWhereWithoutLikesInput)
+    update?: UserUpdateToOneWithWhereWithoutLikesInput;
+}

--- a/api/@generated/user/user-update-to-one-with-where-without-likes.input.ts
+++ b/api/@generated/user/user-update-to-one-with-where-without-likes.input.ts
@@ -1,0 +1,17 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { UserWhereInput } from './user-where.input';
+import { Type } from 'class-transformer';
+import { UserUpdateWithoutLikesInput } from './user-update-without-likes.input';
+
+@InputType()
+export class UserUpdateToOneWithWhereWithoutLikesInput {
+
+    @Field(() => UserWhereInput, {nullable:true})
+    @Type(() => UserWhereInput)
+    where?: UserWhereInput;
+
+    @Field(() => UserUpdateWithoutLikesInput, {nullable:false})
+    @Type(() => UserUpdateWithoutLikesInput)
+    data!: UserUpdateWithoutLikesInput;
+}

--- a/api/@generated/user/user-update-without-followers.input.ts
+++ b/api/@generated/user/user-update-without-followers.input.ts
@@ -5,6 +5,7 @@ import { NullableStringFieldUpdateOperationsInput } from '../prisma/nullable-str
 import { EnumRoleFieldUpdateOperationsInput } from '../prisma/enum-role-field-update-operations.input';
 import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
 import { PostUpdateManyWithoutUserNestedInput } from '../post/post-update-many-without-user-nested.input';
+import { LikeUpdateManyWithoutUserNestedInput } from '../like/like-update-many-without-user-nested.input';
 import { FollowUpdateManyWithoutFollowingNestedInput } from '../follow/follow-update-many-without-following-nested.input';
 
 @InputType()
@@ -36,6 +37,9 @@ export class UserUpdateWithoutFollowersInput {
 
     @Field(() => PostUpdateManyWithoutUserNestedInput, {nullable:true})
     posts?: PostUpdateManyWithoutUserNestedInput;
+
+    @Field(() => LikeUpdateManyWithoutUserNestedInput, {nullable:true})
+    likes?: LikeUpdateManyWithoutUserNestedInput;
 
     @Field(() => FollowUpdateManyWithoutFollowingNestedInput, {nullable:true})
     following?: FollowUpdateManyWithoutFollowingNestedInput;

--- a/api/@generated/user/user-update-without-following.input.ts
+++ b/api/@generated/user/user-update-without-following.input.ts
@@ -5,6 +5,7 @@ import { NullableStringFieldUpdateOperationsInput } from '../prisma/nullable-str
 import { EnumRoleFieldUpdateOperationsInput } from '../prisma/enum-role-field-update-operations.input';
 import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
 import { PostUpdateManyWithoutUserNestedInput } from '../post/post-update-many-without-user-nested.input';
+import { LikeUpdateManyWithoutUserNestedInput } from '../like/like-update-many-without-user-nested.input';
 import { FollowUpdateManyWithoutFollowerNestedInput } from '../follow/follow-update-many-without-follower-nested.input';
 
 @InputType()
@@ -36,6 +37,9 @@ export class UserUpdateWithoutFollowingInput {
 
     @Field(() => PostUpdateManyWithoutUserNestedInput, {nullable:true})
     posts?: PostUpdateManyWithoutUserNestedInput;
+
+    @Field(() => LikeUpdateManyWithoutUserNestedInput, {nullable:true})
+    likes?: LikeUpdateManyWithoutUserNestedInput;
 
     @Field(() => FollowUpdateManyWithoutFollowerNestedInput, {nullable:true})
     followers?: FollowUpdateManyWithoutFollowerNestedInput;

--- a/api/@generated/user/user-update-without-likes.input.ts
+++ b/api/@generated/user/user-update-without-likes.input.ts
@@ -1,0 +1,46 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { StringFieldUpdateOperationsInput } from '../prisma/string-field-update-operations.input';
+import { NullableStringFieldUpdateOperationsInput } from '../prisma/nullable-string-field-update-operations.input';
+import { EnumRoleFieldUpdateOperationsInput } from '../prisma/enum-role-field-update-operations.input';
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
+import { PostUpdateManyWithoutUserNestedInput } from '../post/post-update-many-without-user-nested.input';
+import { FollowUpdateManyWithoutFollowerNestedInput } from '../follow/follow-update-many-without-follower-nested.input';
+import { FollowUpdateManyWithoutFollowingNestedInput } from '../follow/follow-update-many-without-following-nested.input';
+
+@InputType()
+export class UserUpdateWithoutLikesInput {
+
+    @Field(() => StringFieldUpdateOperationsInput, {nullable:true})
+    email?: StringFieldUpdateOperationsInput;
+
+    @Field(() => StringFieldUpdateOperationsInput, {nullable:true})
+    username?: StringFieldUpdateOperationsInput;
+
+    @Field(() => StringFieldUpdateOperationsInput, {nullable:true})
+    name?: StringFieldUpdateOperationsInput;
+
+    @Field(() => StringFieldUpdateOperationsInput, {nullable:true})
+    password?: StringFieldUpdateOperationsInput;
+
+    @Field(() => NullableStringFieldUpdateOperationsInput, {nullable:true})
+    refreshToken?: NullableStringFieldUpdateOperationsInput;
+
+    @Field(() => EnumRoleFieldUpdateOperationsInput, {nullable:true})
+    role?: EnumRoleFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    createdAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
+    updatedAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => PostUpdateManyWithoutUserNestedInput, {nullable:true})
+    posts?: PostUpdateManyWithoutUserNestedInput;
+
+    @Field(() => FollowUpdateManyWithoutFollowerNestedInput, {nullable:true})
+    followers?: FollowUpdateManyWithoutFollowerNestedInput;
+
+    @Field(() => FollowUpdateManyWithoutFollowingNestedInput, {nullable:true})
+    following?: FollowUpdateManyWithoutFollowingNestedInput;
+}

--- a/api/@generated/user/user-update-without-posts.input.ts
+++ b/api/@generated/user/user-update-without-posts.input.ts
@@ -4,6 +4,7 @@ import { StringFieldUpdateOperationsInput } from '../prisma/string-field-update-
 import { NullableStringFieldUpdateOperationsInput } from '../prisma/nullable-string-field-update-operations.input';
 import { EnumRoleFieldUpdateOperationsInput } from '../prisma/enum-role-field-update-operations.input';
 import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
+import { LikeUpdateManyWithoutUserNestedInput } from '../like/like-update-many-without-user-nested.input';
 import { FollowUpdateManyWithoutFollowerNestedInput } from '../follow/follow-update-many-without-follower-nested.input';
 import { FollowUpdateManyWithoutFollowingNestedInput } from '../follow/follow-update-many-without-following-nested.input';
 
@@ -33,6 +34,9 @@ export class UserUpdateWithoutPostsInput {
 
     @Field(() => DateTimeFieldUpdateOperationsInput, {nullable:true})
     updatedAt?: DateTimeFieldUpdateOperationsInput;
+
+    @Field(() => LikeUpdateManyWithoutUserNestedInput, {nullable:true})
+    likes?: LikeUpdateManyWithoutUserNestedInput;
 
     @Field(() => FollowUpdateManyWithoutFollowerNestedInput, {nullable:true})
     followers?: FollowUpdateManyWithoutFollowerNestedInput;

--- a/api/@generated/user/user-update.input.ts
+++ b/api/@generated/user/user-update.input.ts
@@ -5,6 +5,7 @@ import { NullableStringFieldUpdateOperationsInput } from '../prisma/nullable-str
 import { EnumRoleFieldUpdateOperationsInput } from '../prisma/enum-role-field-update-operations.input';
 import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
 import { PostUpdateManyWithoutUserNestedInput } from '../post/post-update-many-without-user-nested.input';
+import { LikeUpdateManyWithoutUserNestedInput } from '../like/like-update-many-without-user-nested.input';
 import { FollowUpdateManyWithoutFollowerNestedInput } from '../follow/follow-update-many-without-follower-nested.input';
 import { FollowUpdateManyWithoutFollowingNestedInput } from '../follow/follow-update-many-without-following-nested.input';
 
@@ -37,6 +38,9 @@ export class UserUpdateInput {
 
     @Field(() => PostUpdateManyWithoutUserNestedInput, {nullable:true})
     posts?: PostUpdateManyWithoutUserNestedInput;
+
+    @Field(() => LikeUpdateManyWithoutUserNestedInput, {nullable:true})
+    likes?: LikeUpdateManyWithoutUserNestedInput;
 
     @Field(() => FollowUpdateManyWithoutFollowerNestedInput, {nullable:true})
     followers?: FollowUpdateManyWithoutFollowerNestedInput;

--- a/api/@generated/user/user-upsert-without-likes.input.ts
+++ b/api/@generated/user/user-upsert-without-likes.input.ts
@@ -1,0 +1,22 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { UserUpdateWithoutLikesInput } from './user-update-without-likes.input';
+import { Type } from 'class-transformer';
+import { UserCreateWithoutLikesInput } from './user-create-without-likes.input';
+import { UserWhereInput } from './user-where.input';
+
+@InputType()
+export class UserUpsertWithoutLikesInput {
+
+    @Field(() => UserUpdateWithoutLikesInput, {nullable:false})
+    @Type(() => UserUpdateWithoutLikesInput)
+    update!: UserUpdateWithoutLikesInput;
+
+    @Field(() => UserCreateWithoutLikesInput, {nullable:false})
+    @Type(() => UserCreateWithoutLikesInput)
+    create!: UserCreateWithoutLikesInput;
+
+    @Field(() => UserWhereInput, {nullable:true})
+    @Type(() => UserWhereInput)
+    where?: UserWhereInput;
+}

--- a/api/@generated/user/user-where-unique.input.ts
+++ b/api/@generated/user/user-where-unique.input.ts
@@ -8,6 +8,7 @@ import { StringNullableFilter } from '../prisma/string-nullable-filter.input';
 import { EnumRoleFilter } from '../prisma/enum-role-filter.input';
 import { DateTimeFilter } from '../prisma/date-time-filter.input';
 import { PostListRelationFilter } from '../post/post-list-relation-filter.input';
+import { LikeListRelationFilter } from '../like/like-list-relation-filter.input';
 import { FollowListRelationFilter } from '../follow/follow-list-relation-filter.input';
 
 @InputType()
@@ -52,6 +53,9 @@ export class UserWhereUniqueInput {
 
     @Field(() => PostListRelationFilter, {nullable:true})
     posts?: PostListRelationFilter;
+
+    @Field(() => LikeListRelationFilter, {nullable:true})
+    likes?: LikeListRelationFilter;
 
     @Field(() => FollowListRelationFilter, {nullable:true})
     followers?: FollowListRelationFilter;

--- a/api/@generated/user/user-where.input.ts
+++ b/api/@generated/user/user-where.input.ts
@@ -6,6 +6,7 @@ import { StringNullableFilter } from '../prisma/string-nullable-filter.input';
 import { EnumRoleFilter } from '../prisma/enum-role-filter.input';
 import { DateTimeFilter } from '../prisma/date-time-filter.input';
 import { PostListRelationFilter } from '../post/post-list-relation-filter.input';
+import { LikeListRelationFilter } from '../like/like-list-relation-filter.input';
 import { FollowListRelationFilter } from '../follow/follow-list-relation-filter.input';
 
 @InputType()
@@ -49,6 +50,9 @@ export class UserWhereInput {
 
     @Field(() => PostListRelationFilter, {nullable:true})
     posts?: PostListRelationFilter;
+
+    @Field(() => LikeListRelationFilter, {nullable:true})
+    likes?: LikeListRelationFilter;
 
     @Field(() => FollowListRelationFilter, {nullable:true})
     followers?: FollowListRelationFilter;

--- a/api/@generated/user/user.model.ts
+++ b/api/@generated/user/user.model.ts
@@ -3,6 +3,7 @@ import { ObjectType } from '@nestjs/graphql';
 import { ID } from '@nestjs/graphql';
 import { Role } from '../prisma/role.enum';
 import { Post } from '../post/post.model';
+import { Like } from '../like/like.model';
 import { Follow } from '../follow/follow.model';
 import { UserCount } from './user-count.output';
 
@@ -38,6 +39,9 @@ export class User {
 
     @Field(() => [Post], {nullable:true})
     posts?: Array<Post>;
+
+    @Field(() => [Like], {nullable:true})
+    likes?: Array<Like>;
 
     @Field(() => [Follow], {nullable:true})
     followers?: Array<Follow>;

--- a/api/prisma/migrations/20230906051523_create_like_model/migration.sql
+++ b/api/prisma/migrations/20230906051523_create_like_model/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "Like" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "postId" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Like_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Like_userId_postId_key" ON "Like"("userId", "postId");
+
+-- AddForeignKey
+ALTER TABLE "Like" ADD CONSTRAINT "Like_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Like" ADD CONSTRAINT "Like_postId_fkey" FOREIGN KEY ("postId") REFERENCES "Post"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -18,19 +18,21 @@ generator nestgraphql {
 }
 
 model User {
-  id           Int      @id @default(autoincrement())
-  email        String   @unique
+  id           Int     @id @default(autoincrement())
+  email        String  @unique
   /// @Validator.MinLength(5)
-  username     String   @unique
+  username     String  @unique
   /// @Validator.MinLength(3)
   name         String
   /// @Validator.MinLength(6)
   password     String
   refreshToken String?
-  role         Role     @default(USER)
+  role         Role    @default(USER)
   posts        Post[]
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @default(now())
+  likes        Like[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now())
 
   followers Follow[] @relation("FollowerRelation")
   following Follow[] @relation("FollowingRelation")
@@ -61,8 +63,10 @@ model Post {
   isHideLikeAndCount Boolean       @default(false)
   isTurnOffComment   Boolean       @default(false)
   postHashtags       PostHashtag[]
-  createdAt          DateTime      @default(now())
-  updatedAt          DateTime      @default(now())
+  likes              Like[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now())
 }
 
 model MediaFile {
@@ -94,4 +98,16 @@ model Hashtag {
   postHashtags PostHashtag[]
   createdAt    DateTime      @default(now())
   updatedAt    DateTime      @default(now())
+}
+
+model Like {
+  id        Int      @id @default(autoincrement())
+  userId    Int
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  postId    Int
+  post      Post     @relation(fields: [postId], references: [id], onDelete: Cascade)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([userId, postId])
 }

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -10,6 +10,7 @@ import { AuthModule } from '~/auth/auth.module'
 import { UserModule } from '~/user/user.module'
 import { PostModule } from './post/post.module'
 import { PrismaService } from '~/prisma/prisma.service'
+import { LikePostModule } from './like-post/like-post.module'
 import { AccessTokenGuard } from '~/auth/guards/accessToken.guard'
 import { FollowUserModule } from './follow-user/follow-user.module'
 import { PostHashtagModule } from './post-hashtag/post-hashtag.module'
@@ -28,7 +29,8 @@ import { PostHashtagModule } from './post-hashtag/post-hashtag.module'
     UserModule,
     PostModule,
     FollowUserModule,
-    PostHashtagModule
+    PostHashtagModule,
+    LikePostModule
   ],
   controllers: [],
   providers: [PrismaService, { provide: APP_GUARD, useClass: AccessTokenGuard }]

--- a/api/src/like-post/dto/create-like-post.input.ts
+++ b/api/src/like-post/dto/create-like-post.input.ts
@@ -1,0 +1,7 @@
+import { InputType, Int, Field } from '@nestjs/graphql';
+
+@InputType()
+export class CreateLikePostInput {
+  @Field(() => Int, { description: 'Example field (placeholder)' })
+  exampleField: number;
+}

--- a/api/src/like-post/dto/update-like-post.input.ts
+++ b/api/src/like-post/dto/update-like-post.input.ts
@@ -1,0 +1,8 @@
+import { CreateLikePostInput } from './create-like-post.input';
+import { InputType, Field, Int, PartialType } from '@nestjs/graphql';
+
+@InputType()
+export class UpdateLikePostInput extends PartialType(CreateLikePostInput) {
+  @Field(() => Int)
+  id: number;
+}

--- a/api/src/like-post/entities/like-post.entity.ts
+++ b/api/src/like-post/entities/like-post.entity.ts
@@ -1,0 +1,31 @@
+import { ID } from '@nestjs/graphql'
+import { Int } from '@nestjs/graphql'
+import { Field } from '@nestjs/graphql'
+import { ObjectType } from '@nestjs/graphql'
+
+import { User } from '~/user/user.entity'
+import { Post } from '~/post/entities/post.entity'
+
+@ObjectType()
+export class LikePost {
+  @Field(() => ID, { nullable: false })
+  id!: number
+
+  @Field(() => Int, { nullable: false })
+  userId!: number
+
+  @Field(() => Int, { nullable: false })
+  postId!: number
+
+  @Field(() => Date, { nullable: false })
+  createdAt!: Date
+
+  @Field(() => Date, { nullable: false })
+  updatedAt!: Date
+
+  @Field(() => User, { nullable: false })
+  user?: User
+
+  @Field(() => Post, { nullable: false })
+  post?: Post
+}

--- a/api/src/like-post/entities/target-post.input.ts
+++ b/api/src/like-post/entities/target-post.input.ts
@@ -1,0 +1,7 @@
+import { InputType, Field, Int } from '@nestjs/graphql'
+
+@InputType()
+export class TargetPostInput {
+  @Field(() => Int)
+  id: number
+}

--- a/api/src/like-post/like-post.module.ts
+++ b/api/src/like-post/like-post.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common'
+
+import { LikePostService } from './like-post.service'
+import { LikePostResolver } from './like-post.resolver'
+import { PrismaService } from '~/prisma/prisma.service'
+
+@Module({
+  providers: [LikePostResolver, LikePostService, PrismaService]
+})
+export class LikePostModule {}

--- a/api/src/like-post/like-post.resolver.ts
+++ b/api/src/like-post/like-post.resolver.ts
@@ -1,0 +1,27 @@
+import { Resolver, Mutation, Args } from '@nestjs/graphql'
+
+import { LikePostService } from './like-post.service'
+import { LikePost } from './entities/like-post.entity'
+import { TargetPostInput } from './entities/target-post.input'
+import { CurrentUserId } from '~/auth/decorators/currentUserId.decotrator'
+
+@Resolver(() => LikePost)
+export class LikePostResolver {
+  constructor(private readonly likePostService: LikePostService) {}
+
+  @Mutation(() => LikePost, { name: 'likePost' })
+  likePost(
+    @Args('targetPostInput') targetPostInput: TargetPostInput,
+    @CurrentUserId() userId: number
+  ): Promise<LikePost> {
+    return this.likePostService.likePost(targetPostInput, userId)
+  }
+
+  @Mutation(() => LikePost, { name: 'unlikePost' })
+  unlikePost(
+    @Args('targetPostInput') targetPostInput: TargetPostInput,
+    @CurrentUserId() userId: number
+  ): Promise<LikePost> {
+    return this.likePostService.unlikePost(targetPostInput, userId)
+  }
+}

--- a/api/src/like-post/like-post.service.ts
+++ b/api/src/like-post/like-post.service.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@nestjs/common'
+
+import { LikePost } from './entities/like-post.entity'
+import { PrismaService } from '~/prisma/prisma.service'
+import { TargetPostInput } from './entities/target-post.input'
+
+@Injectable()
+export class LikePostService {
+  constructor(private prisma: PrismaService) {}
+
+  async likePost(targetPostInput: TargetPostInput, userId: number): Promise<LikePost> {
+    return await this.prisma.like.create({
+      data: {
+        post: {
+          connect: {
+            id: targetPostInput.id
+          }
+        },
+        user: {
+          connect: {
+            id: userId
+          }
+        }
+      }
+    })
+  }
+
+  async unlikePost(targetPostInput: TargetPostInput, userId: number): Promise<LikePost> {
+    return await this.prisma.like.delete({
+      where: {
+        userId_postId: {
+          postId: targetPostInput.id,
+          userId
+        }
+      },
+      include: {
+        post: true,
+        user: true
+      }
+    })
+  }
+}

--- a/api/src/schema.gql
+++ b/api/src/schema.gql
@@ -225,6 +225,118 @@ input IntFilter {
   notIn: [Int!]
 }
 
+input LikeCreateManyPostInput {
+  createdAt: DateTime
+  id: Int
+  updatedAt: DateTime
+  userId: Int!
+}
+
+input LikeCreateManyPostInputEnvelope {
+  data: [LikeCreateManyPostInput!]!
+  skipDuplicates: Boolean
+}
+
+input LikeCreateManyUserInput {
+  createdAt: DateTime
+  id: Int
+  postId: Int!
+  updatedAt: DateTime
+}
+
+input LikeCreateManyUserInputEnvelope {
+  data: [LikeCreateManyUserInput!]!
+  skipDuplicates: Boolean
+}
+
+input LikeCreateNestedManyWithoutPostInput {
+  connect: [LikeWhereUniqueInput!]
+  connectOrCreate: [LikeCreateOrConnectWithoutPostInput!]
+  create: [LikeCreateWithoutPostInput!]
+  createMany: LikeCreateManyPostInputEnvelope
+}
+
+input LikeCreateNestedManyWithoutUserInput {
+  connect: [LikeWhereUniqueInput!]
+  connectOrCreate: [LikeCreateOrConnectWithoutUserInput!]
+  create: [LikeCreateWithoutUserInput!]
+  createMany: LikeCreateManyUserInputEnvelope
+}
+
+input LikeCreateOrConnectWithoutPostInput {
+  create: LikeCreateWithoutPostInput!
+  where: LikeWhereUniqueInput!
+}
+
+input LikeCreateOrConnectWithoutUserInput {
+  create: LikeCreateWithoutUserInput!
+  where: LikeWhereUniqueInput!
+}
+
+input LikeCreateWithoutPostInput {
+  createdAt: DateTime
+  updatedAt: DateTime
+  user: UserCreateNestedOneWithoutLikesInput!
+}
+
+input LikeCreateWithoutUserInput {
+  createdAt: DateTime
+  post: PostCreateNestedOneWithoutLikesInput!
+  updatedAt: DateTime
+}
+
+input LikeListRelationFilter {
+  every: LikeWhereInput
+  none: LikeWhereInput
+  some: LikeWhereInput
+}
+
+input LikeOrderByRelationAggregateInput {
+  _count: SortOrder
+}
+
+type LikePost {
+  createdAt: DateTime!
+  id: ID!
+  post: Post!
+  postId: Int!
+  updatedAt: DateTime!
+  user: User!
+  userId: Int!
+}
+
+input LikeUserIdPostIdCompoundUniqueInput {
+  postId: Int!
+  userId: Int!
+}
+
+input LikeWhereInput {
+  AND: [LikeWhereInput!]
+  NOT: [LikeWhereInput!]
+  OR: [LikeWhereInput!]
+  createdAt: DateTimeFilter
+  id: IntFilter
+  post: PostRelationFilter
+  postId: IntFilter
+  updatedAt: DateTimeFilter
+  user: UserRelationFilter
+  userId: IntFilter
+}
+
+input LikeWhereUniqueInput {
+  AND: [LikeWhereInput!]
+  NOT: [LikeWhereInput!]
+  OR: [LikeWhereInput!]
+  createdAt: DateTimeFilter
+  id: Int
+  post: PostRelationFilter
+  postId: IntFilter
+  updatedAt: DateTimeFilter
+  user: UserRelationFilter
+  userId: IntFilter
+  userId_postId: LikeUserIdPostIdCompoundUniqueInput
+}
+
 type LogoutResponse {
   loggedOut: Boolean!
 }
@@ -311,10 +423,12 @@ type Mutation {
   createPost(createPostInput: PostCreateWithoutUserInput!): Post!
   followUser(targetUserIdInput: TargetUserIdInput!): FollowUser!
   getNewTokens: NewTokensResonse!
+  likePost(targetPostInput: TargetPostInput!): LikePost!
   logout(id: Int!): LogoutResponse!
   signin(signInInput: SignInInput!): SignResponse!
   signup(signupInput: UserCreateInput!): SignResponse!
   unfollowUser(targetUserIdInput: TargetUserIdInput!): FollowUser!
+  unlikePost(targetPostInput: TargetPostInput!): LikePost!
 }
 
 input NestedBoolFilter {
@@ -424,15 +538,38 @@ input PostCreateNestedManyWithoutUserInput {
   createMany: PostCreateManyUserInputEnvelope
 }
 
+input PostCreateNestedOneWithoutLikesInput {
+  connect: PostWhereUniqueInput
+  connectOrCreate: PostCreateOrConnectWithoutLikesInput
+  create: PostCreateWithoutLikesInput
+}
+
+input PostCreateOrConnectWithoutLikesInput {
+  create: PostCreateWithoutLikesInput!
+  where: PostWhereUniqueInput!
+}
+
 input PostCreateOrConnectWithoutUserInput {
   create: PostCreateWithoutUserInput!
   where: PostWhereUniqueInput!
+}
+
+input PostCreateWithoutLikesInput {
+  createdAt: DateTime
+  isHideLikeAndCount: Boolean
+  isTurnOffComment: Boolean
+  mediaFiles: MediaFileCreateNestedManyWithoutPostInput
+  postHashtags: PostHashtagCreateNestedManyWithoutPostInput
+  title: String
+  updatedAt: DateTime
+  user: UserCreateNestedOneWithoutPostsInput!
 }
 
 input PostCreateWithoutUserInput {
   createdAt: DateTime
   isHideLikeAndCount: Boolean
   isTurnOffComment: Boolean
+  likes: LikeCreateNestedManyWithoutPostInput
   mediaFiles: MediaFileCreateNestedManyWithoutPostInput
   postHashtags: PostHashtagCreateNestedManyWithoutPostInput
   title: String
@@ -544,6 +681,7 @@ input PostOrderByWithRelationInput {
   id: SortOrder
   isHideLikeAndCount: SortOrder
   isTurnOffComment: SortOrder
+  likes: LikeOrderByRelationAggregateInput
   mediaFiles: MediaFileOrderByRelationAggregateInput
   postHashtags: PostHashtagOrderByRelationAggregateInput
   title: SortOrderInput
@@ -575,6 +713,7 @@ input PostWhereInput {
   id: IntFilter
   isHideLikeAndCount: BoolFilter
   isTurnOffComment: BoolFilter
+  likes: LikeListRelationFilter
   mediaFiles: MediaFileListRelationFilter
   postHashtags: PostHashtagListRelationFilter
   title: StringNullableFilter
@@ -591,6 +730,7 @@ input PostWhereUniqueInput {
   id: Int
   isHideLikeAndCount: BoolFilter
   isTurnOffComment: BoolFilter
+  likes: LikeListRelationFilter
   mediaFiles: MediaFileListRelationFilter
   postHashtags: PostHashtagListRelationFilter
   title: StringNullableFilter
@@ -671,6 +811,10 @@ input StringNullableFilter {
   startsWith: String
 }
 
+input TargetPostInput {
+  id: Int!
+}
+
 input TargetUserIdInput {
   id: Int!
 }
@@ -694,6 +838,7 @@ type User {
 type UserCount {
   followers: Int!
   following: Int!
+  likes: Int!
   posts: Int!
 }
 
@@ -702,6 +847,7 @@ input UserCreateInput {
   email: String!
   followers: FollowCreateNestedManyWithoutFollowerInput
   following: FollowCreateNestedManyWithoutFollowingInput
+  likes: LikeCreateNestedManyWithoutUserInput
   name: String!
   password: String!
   posts: PostCreateNestedManyWithoutUserInput
@@ -723,6 +869,18 @@ input UserCreateNestedOneWithoutFollowingInput {
   create: UserCreateWithoutFollowingInput
 }
 
+input UserCreateNestedOneWithoutLikesInput {
+  connect: UserWhereUniqueInput
+  connectOrCreate: UserCreateOrConnectWithoutLikesInput
+  create: UserCreateWithoutLikesInput
+}
+
+input UserCreateNestedOneWithoutPostsInput {
+  connect: UserWhereUniqueInput
+  connectOrCreate: UserCreateOrConnectWithoutPostsInput
+  create: UserCreateWithoutPostsInput
+}
+
 input UserCreateOrConnectWithoutFollowersInput {
   create: UserCreateWithoutFollowersInput!
   where: UserWhereUniqueInput!
@@ -733,10 +891,21 @@ input UserCreateOrConnectWithoutFollowingInput {
   where: UserWhereUniqueInput!
 }
 
+input UserCreateOrConnectWithoutLikesInput {
+  create: UserCreateWithoutLikesInput!
+  where: UserWhereUniqueInput!
+}
+
+input UserCreateOrConnectWithoutPostsInput {
+  create: UserCreateWithoutPostsInput!
+  where: UserWhereUniqueInput!
+}
+
 input UserCreateWithoutFollowersInput {
   createdAt: DateTime
   email: String!
   following: FollowCreateNestedManyWithoutFollowingInput
+  likes: LikeCreateNestedManyWithoutUserInput
   name: String!
   password: String!
   posts: PostCreateNestedManyWithoutUserInput
@@ -750,9 +919,38 @@ input UserCreateWithoutFollowingInput {
   createdAt: DateTime
   email: String!
   followers: FollowCreateNestedManyWithoutFollowerInput
+  likes: LikeCreateNestedManyWithoutUserInput
   name: String!
   password: String!
   posts: PostCreateNestedManyWithoutUserInput
+  refreshToken: String
+  role: Role
+  updatedAt: DateTime
+  username: String!
+}
+
+input UserCreateWithoutLikesInput {
+  createdAt: DateTime
+  email: String!
+  followers: FollowCreateNestedManyWithoutFollowerInput
+  following: FollowCreateNestedManyWithoutFollowingInput
+  name: String!
+  password: String!
+  posts: PostCreateNestedManyWithoutUserInput
+  refreshToken: String
+  role: Role
+  updatedAt: DateTime
+  username: String!
+}
+
+input UserCreateWithoutPostsInput {
+  createdAt: DateTime
+  email: String!
+  followers: FollowCreateNestedManyWithoutFollowerInput
+  following: FollowCreateNestedManyWithoutFollowingInput
+  likes: LikeCreateNestedManyWithoutUserInput
+  name: String!
+  password: String!
   refreshToken: String
   role: Role
   updatedAt: DateTime
@@ -765,6 +963,7 @@ input UserOrderByWithRelationInput {
   followers: FollowOrderByRelationAggregateInput
   following: FollowOrderByRelationAggregateInput
   id: SortOrder
+  likes: LikeOrderByRelationAggregateInput
   name: SortOrder
   password: SortOrder
   posts: PostOrderByRelationAggregateInput
@@ -800,6 +999,7 @@ input UserWhereInput {
   followers: FollowListRelationFilter
   following: FollowListRelationFilter
   id: IntFilter
+  likes: LikeListRelationFilter
   name: StringFilter
   password: StringFilter
   posts: PostListRelationFilter
@@ -818,6 +1018,7 @@ input UserWhereUniqueInput {
   followers: FollowListRelationFilter
   following: FollowListRelationFilter
   id: Int
+  likes: LikeListRelationFilter
   name: StringFilter
   password: StringFilter
   posts: PostListRelationFilter


### PR DESCRIPTION
## Issue Link

- https://www.notion.so/MM-48-BE-Implement-Like-Unlike-Post-Functionality-f27ab331a837490882ad85ea95f65c78?pvs=4

## Definition of Done

- [x] Create Like Prisma Model
- [x] Implement Like and Unlike BE functionality 

## Notes

- BE

## Pre-condition

### Docker Setup

- docker-compose up --build

### Local Setup

- cd client && npm install && npm run dev
- cd api && npm install && npm run dev
- goto the http://localhost:3030/graphql

#### Like Post
```
mutation LikePost($targetPostInput: TargetPostInput!) {
  likePost(targetPostInput: $targetPostInput) {
    createdAt
    id
    postId
    userId
    updatedAt
    createdAt
  }
}
```
input

```
{
  "targetPostInput": {
    "id": 238
  }
}
```

#### Unlike Post

```
mutation UnlikePost($targetPostInput: TargetPostInput!) {
  unlikePost(targetPostInput: $targetPostInput) {
    createdAt
    id
    postId
    userId
    updatedAt
  }
}
```

input

```
{
  "targetPostInput": {
    "id": 238
  }
}
```


## Expected Output

- It should now a functionality to like and unlike specific by
- The userId are premade based on the accessToken

## Screenshots/Recordings

[likeunliepost.webm](https://github.com/Osomware/meme-me/assets/108642414/a7c03ef1-e59e-4448-b438-afb52b289d0b)
