### PR TITLE
MM-[49] - [FE] Implement Like Post Functionality

### DIFF
--- a/api/src/like-post/like-post.resolver.ts
+++ b/api/src/like-post/like-post.resolver.ts
@@ -1,4 +1,4 @@
-import { Resolver, Mutation, Args } from '@nestjs/graphql'
+import { Resolver, Mutation, Query, Args } from '@nestjs/graphql'
 
 import { LikePostService } from './like-post.service'
 import { LikePost } from './entities/like-post.entity'
@@ -23,5 +23,13 @@ export class LikePostResolver {
     @CurrentUserId() userId: number
   ): Promise<LikePost> {
     return this.likePostService.unlikePost(targetPostInput, userId)
+  }
+
+  @Query(() => Boolean, { name: 'checkUserLikePost' })
+  async checkUserLikePost(
+    @CurrentUserId() userId: number,
+    @Args('targetPostInput') targetPostInput: TargetPostInput
+  ): Promise<Boolean> {
+    return await this.likePostService.checkUserLikePost(userId, targetPostInput)
   }
 }

--- a/api/src/like-post/like-post.service.ts
+++ b/api/src/like-post/like-post.service.ts
@@ -39,4 +39,17 @@ export class LikePostService {
       }
     })
   }
+
+  async checkUserLikePost(userId: number, targetPostInput: TargetPostInput): Promise<Boolean> {
+    const likePostRelationship = await this.prisma.like.findUnique({
+      where: {
+        userId_postId: {
+          postId: targetPostInput.id,
+          userId
+        }
+      }
+    })
+
+    return !!likePostRelationship
+  }
 }

--- a/api/src/post/entities/post.entity.ts
+++ b/api/src/post/entities/post.entity.ts
@@ -4,6 +4,7 @@ import { User } from '~/user/user.entity'
 import { Hashtag } from './hashtag.entity'
 import { MediaFile } from './mediaFile.entity'
 import { PostHashtagEntity } from './post.hashtag.entity'
+import { PostCount } from '@generated/post/post-count.output'
 
 @ObjectType()
 export class Post {
@@ -39,4 +40,7 @@ export class Post {
 
   @Field(() => [PostHashtagEntity], { nullable: true })
   postHashtags?: Array<PostHashtagEntity>
+
+  @Field(() => PostCount, { nullable: false })
+  _count?: PostCount
 }

--- a/api/src/post/post.service.ts
+++ b/api/src/post/post.service.ts
@@ -38,7 +38,8 @@ export class PostService {
             hashtag: true
           }
         },
-        mediaFiles: true
+        mediaFiles: true,
+        _count: true
       }
     })
   }
@@ -53,7 +54,8 @@ export class PostService {
             hashtag: true
           }
         },
-        mediaFiles: true
+        mediaFiles: true,
+        _count: true
       }
     })
   }
@@ -68,7 +70,8 @@ export class PostService {
             hashtag: true
           }
         },
-        mediaFiles: true
+        mediaFiles: true,
+        _count: true
       }
     })
   }

--- a/api/src/schema.gql
+++ b/api/src/schema.gql
@@ -504,6 +504,7 @@ enum NullsOrder {
 }
 
 type Post {
+  _count: PostCount!
   createdAt: DateTime
   hashtags: [Hashtag!]
   id: ID!
@@ -515,6 +516,12 @@ type Post {
   updatedAt: DateTime
   user: User
   userId: Int
+}
+
+type PostCount {
+  likes: Int!
+  mediaFiles: Int!
+  postHashtags: Int!
 }
 
 input PostCreateManyUserInput {
@@ -741,6 +748,7 @@ input PostWhereUniqueInput {
 
 type Query {
   checkUserFollowed(targetUserIdInput: TargetUserIdInput!): Boolean!
+  checkUserLikePost(targetPostInput: TargetPostInput!): Boolean!
   countAllPost: Int!
   findAllPost(cursor: PostWhereUniqueInput, distinct: [PostScalarFieldEnum!], orderBy: [PostOrderByWithRelationInput!], skip: Int, take: Int, where: PostWhereInput): [Post!]!
   findAllPostByUsername(cursor: PostWhereUniqueInput, distinct: [PostScalarFieldEnum!], orderBy: [PostOrderByWithRelationInput!], skip: Int, take: Int, where: PostWhereInput): [Post!]!

--- a/client/src/components/molecules/ReactionButton/index.tsx
+++ b/client/src/components/molecules/ReactionButton/index.tsx
@@ -4,7 +4,7 @@ import React, { ComponentProps, FC, ReactNode } from 'react'
 import Button from '~/components/atoms/Buttons/ButtonAction'
 
 export type Props = {
-  count: string
+  count: number
   children: ReactNode
   direction?: string
   btnStyle?: string
@@ -23,7 +23,7 @@ const ReactionButton: FC<Props> = (props): JSX.Element => {
       <Button
         type="button"
         variant="secondary-outline"
-        className={clsx('rounded-full bg-section-1 border-stroke-2 p-3 outline-none')}
+        className={clsx('rounded-full bg-section-1 border-stroke-2 p-3 outline-none', btnStyle)}
         {...rest}
       >
         {children}

--- a/client/src/components/templates/ProfileLayout/index.tsx
+++ b/client/src/components/templates/ProfileLayout/index.tsx
@@ -1,7 +1,6 @@
 import clsx from 'clsx'
 import { isEmpty } from 'lodash'
 import dynamic from 'next/dynamic'
-import toast from 'react-hot-toast'
 import { useRouter } from 'next/router'
 import React, { FC, ReactNode } from 'react'
 import { AvatarFullConfig, genConfig } from 'react-nice-avatar'
@@ -65,7 +64,6 @@ const ProfileLayout: FC<ProfileLayoutProps> = ({ metaTitle, children }): JSX.Ele
         {
           onSuccess: () => {
             void queryClient.invalidateQueries()
-            toast.success('Unfollow')
           }
         }
       )
@@ -77,7 +75,6 @@ const ProfileLayout: FC<ProfileLayoutProps> = ({ metaTitle, children }): JSX.Ele
         {
           onSuccess: () => {
             void queryClient.invalidateQueries()
-            toast.success('Follow')
           }
         }
       )

--- a/client/src/graphql/mutations/like.ts
+++ b/client/src/graphql/mutations/like.ts
@@ -1,0 +1,25 @@
+import { gql } from 'graphql-request'
+
+export const LIKE_POST_MUTATION = gql`
+  mutation LikePost($targetPostInput: TargetPostInput!) {
+    likePost(targetPostInput: $targetPostInput) {
+      id
+      postId
+      userId
+      updatedAt
+      createdAt
+    }
+  }
+`
+
+export const UNLIKE_POST_MUTATION = gql`
+  mutation UnlikePost($targetPostInput: TargetPostInput!) {
+    unlikePost(targetPostInput: $targetPostInput) {
+      id
+      postId
+      userId
+      createdAt
+      updatedAt
+    }
+  }
+`

--- a/client/src/graphql/queries/likeQuery.ts
+++ b/client/src/graphql/queries/likeQuery.ts
@@ -1,0 +1,7 @@
+import { gql } from 'graphql-request'
+
+export const CHECK_IS_USER_LIKE_POST = gql`
+  query checkUserLikePost($targetPostInput: TargetPostInput!) {
+    checkUserLikePost(targetPostInput: $targetPostInput)
+  }
+`

--- a/client/src/graphql/queries/postsQuery.ts
+++ b/client/src/graphql/queries/postsQuery.ts
@@ -24,6 +24,9 @@ export const GET_ALL_POST_QUERY = gql`
           tag
         }
       }
+      _count {
+        likes
+      }
     }
   }
 `
@@ -53,6 +56,9 @@ export const GET_ONE_POST_QUERY = gql`
           tag
         }
       }
+      _count {
+        likes
+      }
     }
   }
 `
@@ -66,6 +72,9 @@ export const GET_ALL_POST_BY_USERNAME_QUERY = gql`
         url
       }
       createdAt
+      _count {
+        likes
+      }
     }
   }
 `

--- a/client/src/hooks/useLike.ts
+++ b/client/src/hooks/useLike.ts
@@ -1,0 +1,80 @@
+import toast from 'react-hot-toast'
+import { useMutation, UseMutationResult, useQuery, UseQueryResult } from '@tanstack/react-query'
+
+import { gqlClient } from '~/lib/gqlClient'
+import { TargetPostInput } from '~/utils/types/input'
+import { CHECK_IS_USER_LIKE_POST } from '~/graphql/queries/likeQuery'
+import { LIKE_POST_MUTATION, UNLIKE_POST_MUTATION } from '~/graphql/mutations/like'
+
+type Response = {
+  id: number
+  postId: number
+  userId: number
+  createdAt: string
+  updatedAt: string
+}
+
+export type ResultUserLikePostQuery = {
+  checkUserLikePost: boolean
+}
+type LikeFetchQueryType = UseMutationResult<Response, Error, TargetPostInput, unknown>
+type CheckIsUserLikePost = UseQueryResult<ResultUserLikePostQuery, Error>
+
+type ReturnType = {
+  handleLike: () => LikeFetchQueryType
+  handleUnlike: () => LikeFetchQueryType
+  checkIsUserLikePost: (id: number) => CheckIsUserLikePost
+}
+
+const useLike = (): ReturnType => {
+  const handleLike = (): LikeFetchQueryType =>
+    useMutation<Response, Error, TargetPostInput, unknown>({
+      mutationFn: async (targetPostInput: TargetPostInput) => {
+        return await gqlClient.request(LIKE_POST_MUTATION, {
+          targetPostInput: {
+            id: targetPostInput.id
+          }
+        })
+      },
+      onError: (err: Error) => {
+        const [errorMessage] = err.message.split(/:\s/, 2)
+        toast.error(errorMessage)
+      }
+    })
+
+  const handleUnlike = (): LikeFetchQueryType =>
+    useMutation<Response, Error, TargetPostInput, unknown>({
+      mutationFn: async (targetPostInput: TargetPostInput) => {
+        return await gqlClient.request(UNLIKE_POST_MUTATION, {
+          targetPostInput: {
+            id: targetPostInput.id
+          }
+        })
+      },
+      onError: (err: Error) => {
+        const [errorMessage] = err.message.split(/:\s/, 2)
+        toast.error(errorMessage)
+      }
+    })
+
+  const checkIsUserLikePost = (id: number): CheckIsUserLikePost =>
+    useQuery<ResultUserLikePostQuery, Error>({
+      queryKey: ['like', id],
+      queryFn: async () => {
+        return await gqlClient.request(CHECK_IS_USER_LIKE_POST, {
+          targetPostInput: {
+            id
+          }
+        })
+      },
+      enabled: !isNaN(id)
+    })
+
+  return {
+    handleLike,
+    handleUnlike,
+    checkIsUserLikePost
+  }
+}
+
+export default useLike

--- a/client/src/pages/[@username]/index.tsx
+++ b/client/src/pages/[@username]/index.tsx
@@ -100,7 +100,9 @@ const Username: NextPage = (): JSX.Element => {
               >
                 <div className="inline-flex items-center space-x-0.5">
                   <Heart className="w-4 h-4 stroke-white" fill="#fff" />
-                  <span className="text-xs font-semibold text-white">0</span>
+                  <span className="text-xs font-semibold text-white">
+                    {post?._count?.likes ?? 0}
+                  </span>
                 </div>
                 <div className="inline-flex items-center space-x-0.5">
                   <MessageCircle className="w-4 h-4 stroke-white" fill="#fff" />

--- a/client/src/utils/interface/Post.ts
+++ b/client/src/utils/interface/Post.ts
@@ -20,4 +20,7 @@ export interface IPost {
       tag: string
     }
   }
+  _count: {
+    likes: number
+  }
 }

--- a/client/src/utils/types/input.ts
+++ b/client/src/utils/types/input.ts
@@ -31,3 +31,7 @@ export type MediaFiles = {
   key: string
   url: string
 }
+
+export type TargetPostInput = {
+  id: number
+}


### PR DESCRIPTION
## Issue Link

- https://www.notion.so/MM-49-FE-Implement-Like-Post-Functionality-219f11eca2fc4a90a4c06f42c3ef4f53?pvs=4

## Definition of Done

- [x] Modified existing Query to add `_count` of likes
- [x] Create Like Hooks to handle Like and Unlike 
- [x] Check Post of User Already Like
- [x] Applied Post Like Count in each pages  

## Notes

- Integration #50 

## Pre-condition

### Docker Setup

- docker-compose up --build

### Local Setup

- cd client && npm install && npm run dev
- cd api && npm install && npm run dev
- goto the home page and like any user post

## Expected Output

- It should now have a like functionality
- They can like and unlike
- Only authenticated User are able to like the post

## Screenshots/Recordings
[likepost.webm](https://github.com/Osomware/meme-me/assets/108642414/37b1187f-8548-40c8-8136-c84e274ccf38)
