### PR TITLE
MM-[50] - [FE] Implement Delete Post Functionality

### DIFF
--- a/api/src/post/dto/delete-post.input.ts
+++ b/api/src/post/dto/delete-post.input.ts
@@ -1,0 +1,7 @@
+import { InputType, Field, Int } from '@nestjs/graphql'
+
+@InputType()
+export class DeletePostInput {
+  @Field(() => Int)
+  id: number
+}

--- a/api/src/post/post.resolver.ts
+++ b/api/src/post/post.resolver.ts
@@ -2,6 +2,7 @@ import { Resolver, Query, Mutation, Args, Int } from '@nestjs/graphql'
 
 import { PostService } from './post.service'
 import { Post } from './entities/post.entity'
+import { DeletePostInput } from './dto/delete-post.input'
 import { FindManyPostArgs } from '@generated/post/find-many-post.args'
 import { CurrentUserId } from '~/auth/decorators/currentUserId.decotrator'
 import { FindFirstPostOrThrowArgs } from '@generated/post/find-first-post-or-throw.args'
@@ -37,5 +38,13 @@ export class PostResolver {
   @Query(() => Int, { name: 'countAllPost' })
   countllPost(): Promise<number> {
     return this.postService.countAllPost()
+  }
+
+  @Mutation(() => Post, { name: 'deletePost' })
+  async deletePost(
+    @Args('deletePostInput') deletePostInput: DeletePostInput,
+    @CurrentUserId() userId: number
+  ): Promise<Post> {
+    return this.postService.delete(deletePostInput, userId)
   }
 }

--- a/api/src/post/post.service.ts
+++ b/api/src/post/post.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common'
 
 import { Post } from '@generated/post/post.model'
 import { PrismaService } from '~/prisma/prisma.service'
+import { DeletePostInput } from './dto/delete-post.input'
 import { FindManyPostArgs } from '@generated/post/find-many-post.args'
 import { FindFirstPostOrThrowArgs } from '@generated/post/find-first-post-or-throw.args'
 import { PostCreateWithoutUserInput } from '@generated/post/post-create-without-user.input'
@@ -78,5 +79,34 @@ export class PostService {
 
   async countAllPost(): Promise<number> {
     return await this.prisma.post.count()
+  }
+
+  async delete(deletePostInput: DeletePostInput, userId: number): Promise<Post> {
+    const findUserPost = await this.prisma.post.findFirst({
+      where: {
+        id: {
+          equals: deletePostInput.id
+        },
+        userId: {
+          equals: userId
+        }
+      }
+    })
+
+    if (!findUserPost) {
+      throw new Error('You are not authorized to delete this post!')
+    }
+
+    return await this.prisma.post.delete({
+      where: {
+        id: deletePostInput.id,
+        userId
+      },
+      include: {
+        user: true,
+        likes: true,
+        _count: true
+      }
+    })
   }
 }

--- a/api/src/schema.gql
+++ b/api/src/schema.gql
@@ -23,6 +23,10 @@ input DateTimeFilter {
   notIn: [DateTime!]
 }
 
+input DeletePostInput {
+  id: Int!
+}
+
 input EnumRoleFilter {
   equals: Role
   in: [Role!]
@@ -421,6 +425,7 @@ input MediaFileWhereUniqueInput {
 
 type Mutation {
   createPost(createPostInput: PostCreateWithoutUserInput!): Post!
+  deletePost(deletePostInput: DeletePostInput!): Post!
   followUser(targetUserIdInput: TargetUserIdInput!): FollowUser!
   getNewTokens: NewTokensResonse!
   likePost(targetPostInput: TargetPostInput!): LikePost!

--- a/client/src/components/molecules/PostDropdownMenu/index.tsx
+++ b/client/src/components/molecules/PostDropdownMenu/index.tsx
@@ -1,0 +1,60 @@
+import clsx from 'clsx'
+import React, { FC } from 'react'
+import { Menu } from '@headlessui/react'
+import { MoreHorizontal, Trash } from 'react-feather'
+
+import MenuTransition from '~/components/templates/MenuTransition'
+
+type Props = {
+  actions: {
+    handleDeletePost: () => Promise<void>
+  }
+}
+
+const PostDropdownMenu: FC<Props> = (props): JSX.Element => {
+  const {
+    actions: { handleDeletePost }
+  } = props
+
+  const handleOpenConfirmationModal = async (): Promise<void> => {
+    const result = confirm('Are you sure you want to delete?')
+    if (result) {
+      await handleDeletePost()
+    }
+  }
+
+  return (
+    <Menu as="div" className="relative inline-block text-left">
+      <div>
+        <Menu.Button className="text-white rounded-full p-1">
+          <MoreHorizontal />
+        </Menu.Button>
+      </div>
+      <MenuTransition>
+        <Menu.Items
+          className={clsx(
+            'absolute right-0 w-40 origin-top-right',
+            'rounded bg-white focus:outline-none'
+          )}
+        >
+          <div className="px-1.5 py-1.5">
+            <Menu.Item>
+              <button
+                type="button"
+                onClick={() => {
+                  void handleOpenConfirmationModal()
+                }}
+                className="relative flex items-center justify-center w-full text-rose-500 outline-none"
+              >
+                <Trash className="absolute left-2 h-4 w-4" aria-hidden="true" />
+                <span className="text-center font-medium">Delete</span>
+              </button>
+            </Menu.Item>
+          </div>
+        </Menu.Items>
+      </MenuTransition>
+    </Menu>
+  )
+}
+
+export default PostDropdownMenu

--- a/client/src/components/molecules/PostList/index.tsx
+++ b/client/src/components/molecules/PostList/index.tsx
@@ -10,9 +10,9 @@ import { IPost } from '~/utils/interface/Post'
 import { useZustand } from '~/hooks/useZustand'
 import { ResultQuery } from '~/hooks/useFollow'
 import PostModal from '~/components/organisms/PostModal'
+import { ResultUserLikePostQuery } from '~/hooks/useLike'
 import { CHECK_IS_FOLLOWED } from '~/graphql/queries/followQuery'
 import { CHECK_IS_USER_LIKE_POST } from '~/graphql/queries/likeQuery'
-import { ResultUserLikePostQuery } from '~/hooks/useLike'
 
 type PostListProps = {
   posts: IPost[]

--- a/client/src/components/templates/MenuTransition/index.tsx
+++ b/client/src/components/templates/MenuTransition/index.tsx
@@ -1,0 +1,24 @@
+import React, { FC, Fragment, ReactNode } from 'react'
+import { Transition } from '@headlessui/react'
+
+type Props = {
+  children: ReactNode
+}
+
+const MenuTransition: FC<Props> = ({ children }): JSX.Element => {
+  return (
+    <Transition
+      as={Fragment}
+      enter="transition ease-out duration-100"
+      enterFrom="transform opacity-0 scale-95"
+      enterTo="transform opacity-100 scale-100"
+      leave="transition ease-in duration-75"
+      leaveFrom="transform opacity-100 scale-100"
+      leaveTo="transform opacity-0 scale-95"
+    >
+      {children}
+    </Transition>
+  )
+}
+
+export default MenuTransition

--- a/client/src/graphql/mutations/post.ts
+++ b/client/src/graphql/mutations/post.ts
@@ -19,3 +19,11 @@ export const CREATE_POST_MUTATION = gql`
     }
   }
 `
+
+export const DELETE_POST_MUTATION = gql`
+  mutation DeletePost($deletePostInput: DeletePostInput!) {
+    deletePost(deletePostInput: $deletePostInput) {
+      id
+    }
+  }
+`

--- a/client/src/utils/types/input.ts
+++ b/client/src/utils/types/input.ts
@@ -35,3 +35,7 @@ export type MediaFiles = {
 export type TargetPostInput = {
   id: number
 }
+
+export type DeletePostInput = {
+  id: number
+}


### PR DESCRIPTION
## Issue Link

- https://www.notion.so/MM-50-FE-Implement-Delete-Post-Functionality-da3faade71de413e99c81485b47dcc64?pvs=4

## Definition of Done

- [x] Create Post Delete Graphql API
- [x] Integrate Delete Post Functionality
- [x] Create Dropdown Delete Menu
- [x] Integrate Delete Post Functionaltiy  

## Notes

- FE with BE together

## Pre-condition

### Docker Setup

- docker-compose up --build

### Local Setup

- cd client && npm install && npm run dev
- cd api && npm install && npm run dev
- goto the http://localhost:3030/graphql

## Expected Output

- It should now a delete post functionality
- Only user can able to delete it
- Only user who created the post can delete it

## Screenshots/Recordings
[deletepost.webm](https://github.com/Osomware/meme-me/assets/108642414/782d0434-9cb9-4e09-937f-ebf14ab64de3)

