### PR TITLE
MM-53 - [FE] Display Post Comment with Infinite Scroll

### DIFF
--- a/api/src/comment-post/comment-post.resolver.ts
+++ b/api/src/comment-post/comment-post.resolver.ts
@@ -1,8 +1,9 @@
-import { Resolver, Mutation, Args } from '@nestjs/graphql'
+import { Resolver, Mutation, Args, Query, Int } from '@nestjs/graphql'
 
 import { CommentPostService } from './comment-post.service'
 import { CommentPost } from './entities/comment-post.entity'
 import { CurrentUserId } from '~/auth/decorators/currentUserId.decotrator'
+import { FindManyCommentArgs } from '@generated/comment/find-many-comment.args'
 import { CommentCreateWithoutUserInput } from '@generated/comment/comment-create-without-user.input'
 
 @Resolver(() => CommentPost)
@@ -16,5 +17,15 @@ export class CommentPostResolver {
     @CurrentUserId() userId: number
   ): Promise<CommentPost> {
     return this.commentPostService.create(commentCreateWithoutUserInput, userId)
+  }
+
+  @Query(() => [CommentPost], { name: 'findAllCommentByPostId' })
+  findAllByPostId(@Args() args: FindManyCommentArgs): Promise<CommentPost[]> {
+    return this.commentPostService.findAllByPostId(args)
+  }
+
+  @Query(() => Int, { name: 'countAllComment' })
+  countllPost(): Promise<number> {
+    return this.commentPostService.countAllComment()
   }
 }

--- a/api/src/comment-post/comment-post.service.ts
+++ b/api/src/comment-post/comment-post.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common'
 
 import { PrismaService } from '~/prisma/prisma.service'
 import { CommentPost } from './entities/comment-post.entity'
+import { FindManyCommentArgs } from '@generated/comment/find-many-comment.args'
 import { CommentCreateWithoutUserInput } from '@generated/comment/comment-create-without-user.input'
 
 @Injectable()
@@ -32,5 +33,22 @@ export class CommentPostService {
         childComments: true
       }
     })
+  }
+
+  async findAllByPostId(args: FindManyCommentArgs): Promise<CommentPost[]> {
+    return await this.prisma.comment.findMany({
+      ...args,
+      include: {
+        user: true,
+        post: true,
+        childComments: true,
+        parent: true,
+        _count: true
+      }
+    })
+  }
+
+  async countAllComment(): Promise<number> {
+    return await this.prisma.comment.count()
   }
 }

--- a/api/src/schema.gql
+++ b/api/src/schema.gql
@@ -151,6 +151,20 @@ input CommentOrderByRelationAggregateInput {
   _count: SortOrder
 }
 
+input CommentOrderByWithRelationInput {
+  childComments: CommentOrderByRelationAggregateInput
+  createdAt: SortOrder
+  id: SortOrder
+  parent: CommentOrderByWithRelationInput
+  parentId: SortOrderInput
+  post: PostOrderByWithRelationInput
+  postId: SortOrder
+  text: SortOrder
+  updatedAt: SortOrder
+  user: UserOrderByWithRelationInput
+  userId: SortOrder
+}
+
 type CommentPost {
   _count: CommentCount!
   childComments: [CommentPost!]
@@ -164,6 +178,16 @@ type CommentPost {
   updatedAt: DateTime!
   user: User!
   userId: Int!
+}
+
+enum CommentScalarFieldEnum {
+  createdAt
+  id
+  parentId
+  postId
+  text
+  updatedAt
+  userId
 }
 
 input CommentWhereInput {
@@ -999,7 +1023,9 @@ input PostWhereUniqueInput {
 type Query {
   checkUserFollowed(targetUserIdInput: TargetUserIdInput!): Boolean!
   checkUserLikePost(targetPostInput: TargetPostInput!): Boolean!
+  countAllComment: Int!
   countAllPost: Int!
+  findAllCommentByPostId(cursor: CommentWhereUniqueInput, distinct: [CommentScalarFieldEnum!], orderBy: [CommentOrderByWithRelationInput!], skip: Int, take: Int, where: CommentWhereInput): [CommentPost!]!
   findAllPost(cursor: PostWhereUniqueInput, distinct: [PostScalarFieldEnum!], orderBy: [PostOrderByWithRelationInput!], skip: Int, take: Int, where: PostWhereInput): [Post!]!
   findAllPostByUsername(cursor: PostWhereUniqueInput, distinct: [PostScalarFieldEnum!], orderBy: [PostOrderByWithRelationInput!], skip: Int, take: Int, where: PostWhereInput): [Post!]!
   findOnePost(cursor: PostWhereUniqueInput, distinct: [PostScalarFieldEnum!], orderBy: [PostOrderByWithRelationInput!], skip: Int, take: Int, where: PostWhereInput): Post!

--- a/client/src/components/molecules/CommentList/index.tsx
+++ b/client/src/components/molecules/CommentList/index.tsx
@@ -1,0 +1,25 @@
+import React, { FC } from 'react'
+
+import Comment from '~/components/organisms/Comment'
+import { IComment } from '~/utils/interface/Comment'
+
+type Props = {
+  comments: IComment[]
+}
+
+const CommentList: FC<Props> = ({ comments }): JSX.Element => {
+  return (
+    <div className="flex flex-col space-y-4">
+      {comments?.map((comment, index) => (
+        <Comment
+          key={index}
+          {...{
+            comment
+          }}
+        />
+      ))}
+    </div>
+  )
+}
+
+export default CommentList

--- a/client/src/components/organisms/Comment/index.tsx
+++ b/client/src/components/organisms/Comment/index.tsx
@@ -1,21 +1,28 @@
 import clsx from 'clsx'
+import moment from 'moment'
 import React, { FC } from 'react'
 import dynamic from 'next/dynamic'
-import { ChevronDown, Heart } from 'react-feather'
+import { Heart } from 'react-feather'
 import { AvatarConfig, genConfig } from 'react-nice-avatar'
 
-import { defaultAvatarStyle } from '~/utils/constants/defaultAvatarStyle'
+import { IComment } from '~/utils/interface/Comment'
 
 const ReactNiceAvatar = dynamic(async () => await import('react-nice-avatar'), { ssr: false })
 
-export type CommentProps = Record<string, unknown>
+export type CommentProps = {
+  comment: IComment
+}
 
-const Comment: FC<CommentProps> = (): JSX.Element => {
-  const myConfig = genConfig(defaultAvatarStyle as AvatarConfig)
+const Comment: FC<CommentProps> = (props): JSX.Element => {
+  const {
+    comment: { text, createdAt, user }
+  } = props
+
+  const myConfig = genConfig(user?.email as AvatarConfig)
 
   return (
     <div className="flex flex-col space-y-2">
-      <div className="flex items-center">
+      <div className="flex items-center justify-between">
         <div className="flex items-start gap-x-2">
           <ReactNiceAvatar
             className={clsx(
@@ -25,30 +32,28 @@ const Comment: FC<CommentProps> = (): JSX.Element => {
             {...myConfig}
           />
           <div className="text-sm leading-tight">
-            <h2 className="text-secondary line-clamp-1 font-semibold">nooraldeenhegazi</h2>
-            <span className="text-secondary-300">
-              “I&apos;m gonna make people feel okay... these words means alot...
-            </span>
+            <h2 className="text-secondary line-clamp-1 font-semibold">{user?.username}</h2>
+            <span className="text-secondary-300">{text}</span>
           </div>
         </div>
         <div className="px-2 inline-flex items-center flex-col space-y-1 text-secondary-200">
           <Heart className="w-4 h-4 cursor-pointer" />
-          <span className="text-[10px]">13.7K</span>
+          <span className="text-[10px]">0</span>
         </div>
       </div>
       <div className="px-10 text-xs text-secondary-100 inline-flex items-center gap-x-4">
-        <span>6-11</span>
+        <span>{moment(createdAt).format('M-D')}</span>
         <span className="hover:underline cursor-pointer hover:text-secondary-200">Reply</span>
       </div>
-      <div
+      {/* <div
         className={clsx(
           'inline-flex items-center space-x-1 px-10 text-xs text-secondary-100',
           'hover:underline cursor-pointer hover:text-secondary-200'
         )}
       >
-        <span>View more replies (36)</span>
+        <span>View more reply</span>
         <ChevronDown className="w-4 h-4" />
-      </div>
+      </div> */}
     </div>
   )
 }

--- a/client/src/components/organisms/Post/index.tsx
+++ b/client/src/components/organisms/Post/index.tsx
@@ -115,7 +115,7 @@ const Post: FC<PostProps> = (props): JSX.Element => {
     },
     {
       type: 'comment',
-      count: 0
+      count: _count?.comments ?? 0
     },
     {
       type: 'bookmark',

--- a/client/src/graphql/queries/commentQuery.ts
+++ b/client/src/graphql/queries/commentQuery.ts
@@ -1,0 +1,29 @@
+import { gql } from 'graphql-request'
+
+export const GET_ALL_COMMENTS_BY_POST_ID = gql`
+  query FindAllCommentByPostId(
+    $skip: Int
+    $take: Int
+    $where: CommentWhereInput
+    $orderBy: [CommentOrderByWithRelationInput!]
+  ) {
+    findAllCommentByPostId(skip: $skip, take: $take, where: $where, orderBy: $orderBy) {
+      id
+      text
+      createdAt
+      updatedAt
+      user {
+        id
+        name
+        email
+        username
+      }
+    }
+  }
+`
+
+export const COUNT_ALL_COMMENT_QUERY = gql`
+  query CountAllComment {
+    countAllComment
+  }
+`

--- a/client/src/graphql/queries/postsQuery.ts
+++ b/client/src/graphql/queries/postsQuery.ts
@@ -26,6 +26,7 @@ export const GET_ALL_POST_QUERY = gql`
       }
       _count {
         likes
+        comments
       }
     }
   }
@@ -58,6 +59,7 @@ export const GET_ONE_POST_QUERY = gql`
       }
       _count {
         likes
+        comments
       }
     }
   }
@@ -74,6 +76,7 @@ export const GET_ALL_POST_BY_USERNAME_QUERY = gql`
       createdAt
       _count {
         likes
+        comments
       }
     }
   }

--- a/client/src/hooks/useComment.ts
+++ b/client/src/hooks/useComment.ts
@@ -1,9 +1,20 @@
 import toast from 'react-hot-toast'
-import { useMutation, UseMutationResult } from '@tanstack/react-query'
+import {
+  useMutation,
+  useInfiniteQuery,
+  UseMutationResult,
+  UseInfiniteQueryResult
+} from '@tanstack/react-query'
 
 import { gqlClient } from '~/lib/gqlClient'
 import { CommentCreateWithoutUserInput } from '~/utils/types/input'
 import { CREATE_COMMENT_POST_MUTATION } from '~/graphql/mutations/comment'
+import {
+  COUNT_ALL_COMMENT_QUERY,
+  GET_ALL_COMMENTS_BY_POST_ID
+} from '~/graphql/queries/commentQuery'
+import { queryClient } from '~/lib/queryClient'
+import { IComment } from '~/utils/interface/Comment'
 
 type Response = {
   id: string
@@ -14,14 +25,24 @@ type Response = {
   createdAt: string
   updatedAt: string
 }
+type CommentFetchResponse = {
+  pages: Array<{
+    pagePostCount: number
+    findAllCommentByPostId: IComment[]
+  }>
+  prevOffset: number
+  commentCount: number
+}
 type CommentFetchQueryType = UseMutationResult<
   Response,
   Error,
   CommentCreateWithoutUserInput,
   unknown
 >
+type CommentInfiniteQueryType = UseInfiniteQueryResult<CommentFetchResponse, Error>
 type ReturnType = {
   handleComment: () => CommentFetchQueryType
+  getAllCommentsByPostId: (postId: number) => CommentInfiniteQueryType
 }
 
 const useComment = (): ReturnType => {
@@ -39,14 +60,59 @@ const useComment = (): ReturnType => {
           }
         })
       },
+      onSuccess: () => {
+        void queryClient.invalidateQueries(['comments', 'detail'])
+        void queryClient.invalidateQueries(['posts'])
+      },
       onError: (err: Error) => {
         const [errorMessage] = err.message.split(/:\s/, 2)
         toast.error(errorMessage)
       }
     })
 
+  const getAllCommentsByPostId = (postId: number): CommentInfiniteQueryType =>
+    useInfiniteQuery<CommentFetchResponse, Error>({
+      queryKey: ['comments', 'detail', postId],
+      queryFn: async ({ pageParam = 0 }) => {
+        const skip = pageParam ?? undefined
+        const limit = 20
+
+        const comments: CommentFetchResponse = await gqlClient.request(
+          GET_ALL_COMMENTS_BY_POST_ID,
+          {
+            skip,
+            take: limit,
+            where: {
+              postId: {
+                equals: postId
+              }
+            },
+            orderBy: {
+              createdAt: 'desc'
+            }
+          }
+        )
+
+        const count: { countAllComment: number } = await gqlClient.request(COUNT_ALL_COMMENT_QUERY)
+
+        return {
+          ...comments,
+          commentCount: count?.countAllComment,
+          prevOffset: pageParam ?? 0
+        }
+      },
+      getNextPageParam: (lastPage) => {
+        if (lastPage?.prevOffset + 15 > lastPage?.commentCount) {
+          return false
+        }
+        return lastPage?.prevOffset + 15
+      },
+      enabled: !isNaN(postId)
+    })
+
   return {
-    handleComment
+    handleComment,
+    getAllCommentsByPostId
   }
 }
 

--- a/client/src/hooks/usePost.ts
+++ b/client/src/hooks/usePost.ts
@@ -107,7 +107,7 @@ const usePost = (): ReturnType => {
       queryFn: async ({ pageParam = 0 }) => {
         const skip = pageParam ?? undefined
         const limit = 5
-        const posts: any = await gqlClient.request(GET_ALL_POST_QUERY, {
+        const posts: PostFetchResponse = await gqlClient.request(GET_ALL_POST_QUERY, {
           orderBy: {
             createdAt: 'desc'
           },

--- a/client/src/pages/[@username]/index.tsx
+++ b/client/src/pages/[@username]/index.tsx
@@ -106,7 +106,9 @@ const Username: NextPage = (): JSX.Element => {
                 </div>
                 <div className="inline-flex items-center space-x-0.5">
                   <MessageCircle className="w-4 h-4 stroke-white" fill="#fff" />
-                  <span className="text-xs font-semibold text-white">0</span>
+                  <span className="text-xs font-semibold text-white">
+                    {post?._count?.comments ?? 0}
+                  </span>
                 </div>
               </div>
             </button>

--- a/client/src/utils/interface/Comment.ts
+++ b/client/src/utils/interface/Comment.ts
@@ -1,0 +1,9 @@
+import { IUser } from './User'
+
+export interface IComment {
+  id: string
+  text: string
+  createdAt: string
+  updatedAt: string
+  user: Pick<IUser, 'id' | 'name' | 'email' | 'username'>
+}

--- a/client/src/utils/interface/Post.ts
+++ b/client/src/utils/interface/Post.ts
@@ -22,5 +22,6 @@ export interface IPost {
   }
   _count: {
     likes: number
+    comments: number
   }
 }


### PR DESCRIPTION
## Issue Link

- https://www.notion.so/MM-53-FE-Display-Post-Comment-with-Infinite-Scroll-e5ebdaa7f74d4b29a8a220b00e49bfec?pvs=4

## Definition of Done

- [x] Create Hooks for Infinite Queries of Comments
- [x] Fix Comment counts in each pages
- [x] Fetch 15 page every request  

## Notes

- Related PR #53 

## Pre-condition

### Docker Setup

- docker-compose up --build

### Local Setup

- cd client && npm install && npm run dev
- cd api && npm install && npm run dev
- goto the homepage and try to make a comments in the post

## Expected Output

- It should now have an infinite scroll in the comments in each posts

## Screenshots/Recordings

[coments.webm](https://github.com/Osomware/meme-me/assets/108642414/3ba34c25-eee7-4da4-9f78-06519d749ebf)
