### PR TITLE
MM-54 - [FE] Filter Infinite Posts in Home Page

### DIFF
--- a/api/src/post/dto/filter-post.input.ts
+++ b/api/src/post/dto/filter-post.input.ts
@@ -1,0 +1,7 @@
+import { ArgsType, Field } from '@nestjs/graphql'
+
+@ArgsType()
+export class FilterPostInput {
+  @Field(() => String, { nullable: true })
+  filter?: 'Following' | 'Newest' | 'Popular'
+}

--- a/api/src/post/post.resolver.ts
+++ b/api/src/post/post.resolver.ts
@@ -3,6 +3,7 @@ import { Resolver, Query, Mutation, Args, Int } from '@nestjs/graphql'
 import { PostService } from './post.service'
 import { Post } from './entities/post.entity'
 import { DeletePostInput } from './dto/delete-post.input'
+import { FilterPostInput } from './dto/filter-post.input'
 import { FindManyPostArgs } from '@generated/post/find-many-post.args'
 import { CurrentUserId } from '~/auth/decorators/currentUserId.decotrator'
 import { FindFirstPostOrThrowArgs } from '@generated/post/find-first-post-or-throw.args'
@@ -21,8 +22,21 @@ export class PostResolver {
   }
 
   @Query(() => [Post], { name: 'findAllPost' })
-  findAll(@Args() args: FindManyPostArgs): Promise<Post[]> {
-    return this.postService.findAll(args)
+  findAll(
+    @Args() args: FindManyPostArgs,
+    @Args() filterInput: FilterPostInput,
+    @CurrentUserId() userId: number
+  ): Promise<Post[]> {
+    switch (filterInput.filter) {
+      case 'Following':
+        return this.postService.filterFollowingPosts(args, userId)
+      case 'Newest':
+        return this.postService.filterNewestPosts(args)
+      case 'Popular':
+        return this.postService.filterPopularPosts(args)
+      default:
+        return this.postService.findAll(args)
+    }
   }
 
   @Query(() => Post, { name: 'findOnePost' })

--- a/api/src/schema.gql
+++ b/api/src/schema.gql
@@ -1026,7 +1026,7 @@ type Query {
   countAllComment: Int!
   countAllPost: Int!
   findAllCommentByPostId(cursor: CommentWhereUniqueInput, distinct: [CommentScalarFieldEnum!], orderBy: [CommentOrderByWithRelationInput!], skip: Int, take: Int, where: CommentWhereInput): [CommentPost!]!
-  findAllPost(cursor: PostWhereUniqueInput, distinct: [PostScalarFieldEnum!], orderBy: [PostOrderByWithRelationInput!], skip: Int, take: Int, where: PostWhereInput): [Post!]!
+  findAllPost(cursor: PostWhereUniqueInput, distinct: [PostScalarFieldEnum!], filter: String, orderBy: [PostOrderByWithRelationInput!], skip: Int, take: Int, where: PostWhereInput): [Post!]!
   findAllPostByUsername(cursor: PostWhereUniqueInput, distinct: [PostScalarFieldEnum!], orderBy: [PostOrderByWithRelationInput!], skip: Int, take: Int, where: PostWhereInput): [Post!]!
   findOnePost(cursor: PostWhereUniqueInput, distinct: [PostScalarFieldEnum!], orderBy: [PostOrderByWithRelationInput!], skip: Int, take: Int, where: PostWhereInput): Post!
   findOneUser(cursor: UserWhereUniqueInput, distinct: [UserScalarFieldEnum!], orderBy: [UserOrderByWithRelationInput!], skip: Int, take: Int, where: UserWhereInput): User!

--- a/client/src/components/molecules/PostList/index.tsx
+++ b/client/src/components/molecules/PostList/index.tsx
@@ -67,7 +67,7 @@ const PostList: FC<PostListProps> = ({ posts }): JSX.Element => {
 
         return (
           <Post
-            key={post.id}
+            key={index}
             {...{
               post,
               isPostAuthor,

--- a/client/src/graphql/queries/postsQuery.ts
+++ b/client/src/graphql/queries/postsQuery.ts
@@ -1,8 +1,14 @@
 import { gql } from 'graphql-request'
 
 export const GET_ALL_POST_QUERY = gql`
-  query GetAllUserPost($orderBy: [PostOrderByWithRelationInput!], $skip: Int, $take: Int) {
-    findAllPost(orderBy: $orderBy, skip: $skip, take: $take) {
+  query GetAllUserPost(
+    $orderBy: [PostOrderByWithRelationInput!]
+    $skip: Int
+    $take: Int
+    $where: PostWhereInput
+    $filter: String
+  ) {
+    findAllPost(orderBy: $orderBy, skip: $skip, take: $take, where: $where, filter: $filter) {
       id
       title
       isHideLikeAndCount

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -1,11 +1,12 @@
 import type { NextPage } from 'next'
+import { useRouter } from 'next/router'
 import { useInView } from 'react-intersection-observer'
 import React, { FC, ReactNode, useEffect } from 'react'
 
-import usePost from '~/hooks/usePost'
 import { HashLoader } from 'react-spinners'
 import Alert from '~/components/atoms/Alert'
 import { IPost } from '~/utils/interface/Post'
+import usePost, { PostFilter } from '~/hooks/usePost'
 import PostList from '~/components/molecules/PostList'
 import StoryList from '~/components/molecules/StoryList'
 import HomeLayout from '~/components/templates/HomeLayout'
@@ -15,12 +16,17 @@ import SuggestionRightBar from '~/components/organisms/SuggestionRightbar'
 import PostSkeletonLoading from '~/components/atoms/Skeletons/PostSkeletonLoading'
 
 const Home: NextPage = (): JSX.Element => {
+  const router = useRouter()
+  const filter = router?.query?.filter as string
+  const newFilter = filter?.charAt(0).toUpperCase() + filter?.slice(1)
   const { ref, inView } = useInView()
 
   // * POSTS HOOKS
   const { getAllPosts } = usePost()
 
-  const { data, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } = getAllPosts()
+  const { data, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } = getAllPosts(
+    newFilter as PostFilter
+  )
 
   const posts =
     data?.pages.reduce((acc: IPost[], page: any) => {


### PR DESCRIPTION
## Issue Link

- https://www.notion.so/MM-54-FE-Filter-Infinite-Posts-in-Home-Page-893423c7833e470eb6f6230324febd74?pvs=4

## Definition of Done

- [x] Modified Post with Filter Options
- [x] Display Post based on Filter

## Notes

- Related PR: #28 

## Pre-condition

### Docker Setup

- docker-compose up --build

### Local Setup

- cd client && npm install && npm run dev
- cd api && npm install && npm run dev
- goto the homepage and click the filter

## Expected Output

- It should have a filter in the home feeds with All by default, Following, Newest and Popular filter

## Screenshots/Recordings

[filterByPost.webm](https://github.com/Osomware/meme-me/assets/108642414/18ed2ecf-febb-41b9-b00d-a1ba722f4683)
