### PR TITLE
MM-55 - [FE] Display Suggested User with Follow and Show more Functionality

### DIFF
--- a/api/src/auth/auth.resolver.ts
+++ b/api/src/auth/auth.resolver.ts
@@ -12,8 +12,9 @@ import { LogoutReturnType, SignReturnType } from './types'
 import { NewTokensResonse } from './dto/new-tokens-reponse'
 import { RefreshTokenGuard } from './guards/refreshToken.guard'
 import { CurrentUser } from './decorators/currentUser.decorator'
-import { CurrentUserId } from './decorators/currentUserId.decotrator'
 import { UserCreateInput } from '@generated/user/user-create.input'
+import { CurrentUserId } from './decorators/currentUserId.decotrator'
+import { FindManyUserArgs } from '@generated/user/find-many-user.args'
 import { FindFirstUserOrThrowArgs } from '@generated/user/find-first-user-or-throw.args'
 
 @Resolver(() => Auth)
@@ -50,5 +51,18 @@ export class AuthResolver {
     @CurrentUser('refreshToken') refreshToken: string
   ): SignReturnType {
     return this.authService.getNewTokens(userId, refreshToken)
+  }
+
+  @Query(() => [User], { name: 'getSuggestedUsers' })
+  getSuggestedUsers(
+    @Args() args: FindManyUserArgs,
+    @CurrentUserId() userId: number
+  ): Promise<User[]> {
+    return this.authService.suggestedUsers(args, userId)
+  }
+
+  @Query(() => Int, { name: 'countAllUserExceptCurrent' })
+  countAllUserExceptCurrent(@CurrentUserId() userId: number): Promise<number> {
+    return this.authService.countAllUserExceptCurrent(userId)
   }
 }

--- a/api/src/auth/auth.service.ts
+++ b/api/src/auth/auth.service.ts
@@ -8,6 +8,7 @@ import { SignInInput } from './dto/signin-input'
 import { PrismaService } from '~/prisma/prisma.service'
 import { LogoutReturnType, SignReturnType, Token } from './types'
 import { UserCreateInput } from '@generated/user/user-create.input'
+import { FindManyUserArgs } from '@generated/user/find-many-user.args'
 import { FindFirstUserOrThrowArgs } from '@generated/user/find-first-user-or-throw.args'
 
 type FieldValues = 'email' | 'username'
@@ -171,5 +172,41 @@ export class AuthService {
       refreshToken,
       user
     }
+  }
+
+  async suggestedUsers(args: FindManyUserArgs, userId: number): Promise<User[]> {
+    return await this.prisma.user.findMany({
+      ...args,
+      where: {
+        id: {
+          not: {
+            equals: userId
+          }
+        },
+        role: {
+          equals: 'USER'
+        }
+      },
+      include: {
+        _count: true,
+        comments: true,
+        followers: true,
+        following: true,
+        likes: true,
+        posts: true
+      }
+    })
+  }
+
+  async countAllUserExceptCurrent(userId: number): Promise<number> {
+    return await this.prisma.user.count({
+      where: {
+        id: {
+          not: {
+            equals: userId
+          }
+        }
+      }
+    })
   }
 }

--- a/api/src/schema.gql
+++ b/api/src/schema.gql
@@ -1025,12 +1025,14 @@ type Query {
   checkUserLikePost(targetPostInput: TargetPostInput!): Boolean!
   countAllComment: Int!
   countAllPost: Int!
+  countAllUserExceptCurrent: Int!
   findAllCommentByPostId(cursor: CommentWhereUniqueInput, distinct: [CommentScalarFieldEnum!], orderBy: [CommentOrderByWithRelationInput!], skip: Int, take: Int, where: CommentWhereInput): [CommentPost!]!
   findAllPost(cursor: PostWhereUniqueInput, distinct: [PostScalarFieldEnum!], filter: String, orderBy: [PostOrderByWithRelationInput!], skip: Int, take: Int, where: PostWhereInput): [Post!]!
   findAllPostByUsername(cursor: PostWhereUniqueInput, distinct: [PostScalarFieldEnum!], orderBy: [PostOrderByWithRelationInput!], skip: Int, take: Int, where: PostWhereInput): [Post!]!
   findOnePost(cursor: PostWhereUniqueInput, distinct: [PostScalarFieldEnum!], orderBy: [PostOrderByWithRelationInput!], skip: Int, take: Int, where: PostWhereInput): Post!
   findOneUser(cursor: UserWhereUniqueInput, distinct: [UserScalarFieldEnum!], orderBy: [UserOrderByWithRelationInput!], skip: Int, take: Int, where: UserWhereInput): User!
   getAllPostHashtag(cursor: HashtagWhereUniqueInput, distinct: [HashtagScalarFieldEnum!], orderBy: [HashtagOrderByWithRelationInput!], skip: Int, take: Int, where: HashtagWhereInput): [PostHashtag!]!
+  getSuggestedUsers(cursor: UserWhereUniqueInput, distinct: [UserScalarFieldEnum!], orderBy: [UserOrderByWithRelationInput!], skip: Int, take: Int, where: UserWhereInput): [User!]!
   searchHashtag(query: String!): [PostHashtag!]!
 }
 

--- a/client/src/components/molecules/SuggestedUserList/SuggestedUserItem.tsx
+++ b/client/src/components/molecules/SuggestedUserList/SuggestedUserItem.tsx
@@ -1,0 +1,70 @@
+import React, { FC } from 'react'
+
+import UserDetails from '../UserDetails'
+import useFollow from '~/hooks/useFollow'
+import { IUser } from '~/utils/interface/User'
+import { queryClient } from '~/lib/queryClient'
+import Button from '~/components/atoms/Buttons/ButtonAction'
+
+type Props = {
+  user: IUser
+  isFollowed: boolean
+}
+
+const SuggestedUserItem: FC<Props> = ({ isFollowed, user }): JSX.Element => {
+  // * FOLLOW HOOKS
+  const { handleFollow, handleUnfollow } = useFollow()
+  const followMethod = handleFollow()
+  const unFollowMethod = handleUnfollow()
+
+  const handleFollowUnfollow = async (): Promise<void> => {
+    if (isFollowed) {
+      await unFollowMethod.mutateAsync(
+        {
+          id: user?.id
+        },
+        {
+          onSuccess: () => {
+            void queryClient.invalidateQueries(['follow', user?.id])
+          }
+        }
+      )
+    } else {
+      await followMethod.mutateAsync(
+        {
+          id: user?.id
+        },
+        {
+          onSuccess: () => {
+            void queryClient.invalidateQueries(['follow', user?.id])
+          }
+        }
+      )
+    }
+  }
+
+  return (
+    <li className="flex items-center justify-between">
+      <UserDetails
+        {...{
+          avatar: user.email,
+          name: user.name,
+          username: user.username,
+          size: 'sm'
+        }}
+      />
+      <Button
+        type="button"
+        onClick={() => {
+          void handleFollowUnfollow()
+        }}
+        variant={isFollowed ? 'secondary-outline' : 'primary'}
+        className="text-xs py-1.5 font-semibold w-[76px]"
+      >
+        {isFollowed ? 'Following' : 'Follow'}
+      </Button>
+    </li>
+  )
+}
+
+export default SuggestedUserItem

--- a/client/src/components/molecules/SuggestedUserList/index.tsx
+++ b/client/src/components/molecules/SuggestedUserList/index.tsx
@@ -1,41 +1,78 @@
-import Link from 'next/link'
 import React, { FC } from 'react'
 
-import UserDetails from './../UserDetails'
-import Button from '~/components/atoms/Buttons/ButtonAction'
-import { dummySuggestedUsers } from '~/utils/constants/dummySuggetedUsers'
+import { gqlClient } from '~/lib/gqlClient'
+import Spinner from '~/utils/icons/Spinner'
+import { IUser } from '~/utils/interface/User'
+import { ResultQuery } from '~/hooks/useFollow'
+import { UserFetchReponse } from '~/hooks/useUser'
+import SuggestedUserItem from './SuggestedUserItem'
+import { CHECK_IS_FOLLOWED } from '~/graphql/queries/followQuery'
+import {
+  FetchNextPageOptions,
+  InfiniteQueryObserverResult,
+  useQueries
+} from '@tanstack/react-query'
 
-type SuggestedUserListProps = Record<string, unknown>
+type SuggestedUserListProps = {
+  users: IUser[]
+  fetchNextPage: (
+    options?: FetchNextPageOptions | undefined
+  ) => Promise<InfiniteQueryObserverResult<UserFetchReponse, Error>>
+  hasNextPage: boolean | undefined
+  isFetchingNextPage: boolean
+}
 
-const SuggestedUserList: FC<SuggestedUserListProps> = (): JSX.Element => {
+const SuggestedUserList: FC<SuggestedUserListProps> = (props): JSX.Element => {
+  const { users, fetchNextPage, hasNextPage, isFetchingNextPage } = props
+
+  const followStatuses = useQueries({
+    queries: users?.map((user) => ({
+      queryKey: ['follow', user?.id],
+      queryFn: async () =>
+        await gqlClient.request(CHECK_IS_FOLLOWED, {
+          targetUserIdInput: {
+            id: user?.id
+          }
+        })
+    }))
+  })
+
   return (
     <nav className="mt-5">
       <ul className="flex flex-col space-y-6">
-        {dummySuggestedUsers.map((item) => (
-          <li key={item.id} className="flex items-center justify-between">
-            <UserDetails
+        {users.map((user, index) => {
+          const followCheckResult = followStatuses[index]?.data as ResultQuery
+          const isFollowed = followCheckResult?.checkUserFollowed ?? false
+
+          return (
+            <SuggestedUserItem
+              key={index}
               {...{
-                avatar: item.avatar,
-                name: item.name,
-                username: item.username,
-                size: 'sm'
+                isFollowed,
+                user
               }}
             />
-            <Button
-              type="button"
-              variant={item.isFollowed ? 'secondary-outline' : 'primary'}
-              className="text-xs py-1.5 font-semibold w-[76px]"
-            >
-              {item.isFollowed ? 'Following' : 'Follow'}
-            </Button>
-          </li>
-        ))}
+          )
+        })}
       </ul>
-      <div className="mt-4 text-center">
-        <Link href="#" className="text-xs font-medium text-secondary-200 hover:underline">
-          Show more
-        </Link>
-      </div>
+      {isFetchingNextPage ? (
+        <div className="flex justify-center">
+          <Spinner width={5} height={5} />
+        </div>
+      ) : null}
+
+      {(hasNextPage as boolean) && (
+        <div className="mt-4 text-center">
+          <span
+            onClick={() => {
+              void fetchNextPage()
+            }}
+            className="text-xs cursor-pointer font-medium text-secondary-200 hover:underline"
+          >
+            Show more
+          </span>
+        </div>
+      )}
     </nav>
   )
 }

--- a/client/src/components/molecules/UserDetails/index.tsx
+++ b/client/src/components/molecules/UserDetails/index.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx'
+import Link from 'next/link'
 import React, { FC } from 'react'
 import dynamic from 'next/dynamic'
 import { AvatarFullConfig, genConfig } from 'react-nice-avatar'
@@ -27,7 +28,10 @@ const UserDetails: FC<UserDetailsProps> = ({ avatar, name, username, size }): JS
   const getUsernameSize = (size: Size): string => (size === 'base' ? 'text-sm' : 'text-xs')
 
   return (
-    <div className={clsx('flex items-center', size === 'base' ? 'gap-x-4' : 'gap-x-2')}>
+    <Link
+      href={`/@${username}`}
+      className={clsx('flex items-center', size === 'base' ? 'gap-x-4' : 'gap-x-2')}
+    >
       <ReactNiceAvatar
         id={name}
         className={clsx(
@@ -37,12 +41,16 @@ const UserDetails: FC<UserDetailsProps> = ({ avatar, name, username, size }): JS
         {...myConfig}
       />
       <div className="leading-none">
-        <h2 className={clsx('text-secondary line-clamp-1', getNameSize(size as Size))}>{name}</h2>
-        <span className={clsx('text-sm text-secondary-100', getUsernameSize(size as Size))}>
+        <h2
+          className={clsx('text-secondary line-clamp-1 hover:underline', getNameSize(size as Size))}
+        >
           {username}
+        </h2>
+        <span className={clsx('text-sm text-secondary-100', getUsernameSize(size as Size))}>
+          {name}
         </span>
       </div>
-    </div>
+    </Link>
   )
 }
 

--- a/client/src/components/organisms/Comment/index.tsx
+++ b/client/src/components/organisms/Comment/index.tsx
@@ -42,7 +42,7 @@ const Comment: FC<CommentProps> = (props): JSX.Element => {
         </div>
       </div>
       <div className="px-10 text-xs text-secondary-100 inline-flex items-center gap-x-4">
-        <span>{moment(createdAt).format('M-D')}</span>
+        <span>{moment(createdAt).fromNow()}</span>
         <span className="hover:underline cursor-pointer hover:text-secondary-200">Reply</span>
       </div>
       {/* <div

--- a/client/src/components/organisms/Sidebar/index.tsx
+++ b/client/src/components/organisms/Sidebar/index.tsx
@@ -29,7 +29,7 @@ const Sidebar: FC<SidebarProps> = (): JSX.Element => {
   const [sidebarLinks, setSidebarLinks] = useState<ISidebar[]>(sidebarMenus)
   const [isUploadModal, setIsUploadModal] = useState<boolean>(false)
 
-  const store = useZustand(useStore, (state) => state)
+  const store = useZustand(useStore, (state) => state.user)
 
   const myConfig = genConfig(defaultAvatarStyle as AvatarFullConfig)
 
@@ -44,7 +44,7 @@ const Sidebar: FC<SidebarProps> = (): JSX.Element => {
       if (link.name === 'Profile') {
         return {
           ...link,
-          href: !isEmpty(store?.user) ? `/@${store?.user?.username ?? ''}` : ''
+          href: !isEmpty(store) ? `/@${store?.username ?? ''}` : ''
         }
       }
       return link
@@ -74,7 +74,7 @@ const Sidebar: FC<SidebarProps> = (): JSX.Element => {
             return (
               <li key={index} className="px-3">
                 <Link
-                  href={isUserProfile ? `/@${store?.user?.username ?? ''}` : item.href}
+                  href={isUserProfile ? `/@${store?.username ?? ''}` : item.href}
                   className={clsx(
                     'group w-full inline-flex items-center space-x-4 py-1.5 md:py-2',
                     'transition ease-in-out duration-75 outline-primary',
@@ -142,9 +142,9 @@ const Sidebar: FC<SidebarProps> = (): JSX.Element => {
                 <Disclosure.Panel className="px-8 py-4 text-sm text-gray-500">
                   <UserDetails
                     {...{
-                      avatar: defaultAvatarStyle,
-                      name: store?.user?.name ?? '',
-                      username: `@${store?.user?.username ?? ''}`
+                      avatar: store?.email ?? '',
+                      name: store?.name ?? '',
+                      username: `${store?.username ?? ''}`
                     }}
                   />
                 </Disclosure.Panel>

--- a/client/src/components/organisms/SuggestionRightbar/index.tsx
+++ b/client/src/components/organisms/SuggestionRightbar/index.tsx
@@ -4,6 +4,10 @@ import Image from 'next/image'
 import React, { FC, useState } from 'react'
 import { Remind, UploadOne } from '@icon-park/react'
 
+import useUser from '~/hooks/useUser'
+import Spinner from '~/utils/icons/Spinner'
+import Alert from '~/components/atoms/Alert'
+import { IUser } from '~/utils/interface/User'
 import UploadPostModal from './../UploadPostModal'
 import SearchField from '~/components/molecules/SearchField'
 import SuggestedUserList from '~/components/molecules/SuggestedUserList'
@@ -11,6 +15,23 @@ import SuggestedUserList from '~/components/molecules/SuggestedUserList'
 type SuggestionRightBarProps = Record<string, unknown>
 
 const SuggestionRightBar: FC<SuggestionRightBarProps> = (): JSX.Element => {
+  // * USER HOOKS
+  const { getSuggestedUsers } = useUser()
+  const {
+    data: suggestedUserData,
+    isLoading,
+    isError,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage
+  } = getSuggestedUsers()
+
+  const suggestedUsers =
+    suggestedUserData?.pages.reduce((acc: IUser[], page: any) => {
+      const pagePosts = page.getSuggestedUsers as IUser[]
+      return [...acc, ...pagePosts]
+    }, []) ?? []
+
   const [isUploadModal, setIsUploadModal] = useState<boolean>(false)
 
   const businessLinks = [
@@ -66,30 +87,47 @@ const SuggestionRightBar: FC<SuggestionRightBarProps> = (): JSX.Element => {
             }}
           />
         </header>
-        {/* Suggested User List */}
-        <main>
-          <header className="flex items-center justify-between mt-6 text-sm">
-            <h2 className="text-secondary font-bold">Suggestions for you</h2>
-            <Link href="#" className="text-primary font-semibold hover:underline">
-              See All
-            </Link>
-          </header>
-          {/* List of User */}
-          <SuggestedUserList />
-          <hr className="my-4" />
-          <h2 className="text-secondary font-bold text-sm">Latest Post Activity</h2>
-          <div className="border-[3px] mt-4 border-white shadow rounded-xl">
-            <Image
-              src="https://blog.hubspot.com/hs-fs/hubfs/best-time-to-post-on-instagram-3.jpg?width=595&height=400&name=best-time-to-post-on-instagram-3.jpg"
-              width={300}
-              height={300}
-              quality={50}
-              priority={true}
-              className="overflow-hidden rounded-xl"
-              alt=""
-            />
+        {isError && (
+          <div className="py-4">
+            <Alert type="error" message="Something went wrong fetching data..." />
           </div>
-        </main>
+        )}
+        {isLoading ? (
+          <div className="flex justify-center py-6">
+            <Spinner height={6} width={6} />
+          </div>
+        ) : (
+          <main>
+            <header className="flex items-center justify-between mt-6 text-sm">
+              <h2 className="text-secondary font-bold">Suggestions for you</h2>
+              <Link href="#" className="text-primary font-semibold hover:underline">
+                See All
+              </Link>
+            </header>
+            {/* List of User */}
+            <SuggestedUserList
+              {...{
+                users: suggestedUsers,
+                fetchNextPage,
+                hasNextPage,
+                isFetchingNextPage
+              }}
+            />
+            <hr className="my-4" />
+            <h2 className="text-secondary font-bold text-sm">Latest Post Activity</h2>
+            <div className="border-[3px] mt-4 border-white shadow rounded-xl">
+              <Image
+                src="https://blog.hubspot.com/hs-fs/hubfs/best-time-to-post-on-instagram-3.jpg?width=595&height=400&name=best-time-to-post-on-instagram-3.jpg"
+                width={300}
+                height={300}
+                quality={50}
+                priority={true}
+                className="overflow-hidden rounded-xl"
+                alt=""
+              />
+            </div>
+          </main>
+        )}
       </div>
       <div className="mb-auto">
         <ul className="flex items-center gap-x-2 text-xs text-secondary-100 px-4 py-2">

--- a/client/src/components/templates/ProfileLayout/index.tsx
+++ b/client/src/components/templates/ProfileLayout/index.tsx
@@ -14,7 +14,6 @@ import Alert from '~/components/atoms/Alert'
 import { useZustand } from '~/hooks/useZustand'
 import { queryClient } from '~/lib/queryClient'
 import HomeLayout from '~/components/templates/HomeLayout'
-import useScreenCondition from '~/hooks/useScreenCondition'
 import { profileTabs } from '~/utils/constants/profileTabs'
 import Button from '~/components/atoms/Buttons/ButtonAction'
 import SuggestionRightBar from '~/components/organisms/SuggestionRightbar'
@@ -43,9 +42,6 @@ const ProfileLayout: FC<ProfileLayoutProps> = ({ metaTitle, children }): JSX.Ele
   const myConfig = genConfig(userFound?.email as AvatarFullConfig)
 
   const isCurrentUser = userFound?.id === currentUser?.id
-
-  // * SCREEN SIZE CONDITION HOOKS
-  const isMaxWidth = useScreenCondition('(max-width: 1380px)')
 
   // * FOLLOW HOOKS
   const { checkIsFollowed, handleFollow, handleUnfollow } = useFollow()
@@ -237,11 +233,13 @@ const ProfileLayout: FC<ProfileLayoutProps> = ({ metaTitle, children }): JSX.Ele
           </section>
         </article>
       </div>
-      {!isMaxWidth && (
-        <aside className="ml-auto border-l border-stroke-3 h-full w-80 shrink-0 sticky top-0 mx-1">
-          <SuggestionRightBar />
-        </aside>
-      )}
+      <aside
+        className={clsx(
+          'border-l border-stroke-3 h-full w-80 shrink-0 sticky top-0 mx-1 hidden xl:block'
+        )}
+      >
+        <SuggestionRightBar />
+      </aside>
     </HomeLayout>
   )
 }

--- a/client/src/graphql/queries/userQuery.ts
+++ b/client/src/graphql/queries/userQuery.ts
@@ -16,3 +16,21 @@ export const USER_QUERY = gql`
     }
   }
 `
+
+export const GET_SUGGESTED_USERS = gql`
+  query GetSuggestedUsers($skip: Int, $take: Int, $orderBy: [UserOrderByWithRelationInput!]) {
+    getSuggestedUsers(skip: $skip, take: $take, orderBy: $orderBy) {
+      id
+      name
+      email
+      username
+      createdAt
+    }
+  }
+`
+
+export const COUNT_ALL_USER_EXCEPT_CURRENT = gql`
+  query CountAllUserExceptCurrent {
+    countAllUserExceptCurrent
+  }
+`

--- a/client/src/hooks/useUser.ts
+++ b/client/src/hooks/useUser.ts
@@ -1,17 +1,34 @@
-import { useQuery, UseQueryResult } from '@tanstack/react-query'
+import {
+  useQuery,
+  UseQueryResult,
+  useInfiniteQuery,
+  UseInfiniteQueryResult
+} from '@tanstack/react-query'
 
 import { gqlClient } from '~/lib/gqlClient'
 import { IUser } from '~/utils/interface/User'
-import { USER_QUERY } from '~/graphql/queries/userQuery'
+import {
+  USER_QUERY,
+  GET_SUGGESTED_USERS,
+  COUNT_ALL_USER_EXCEPT_CURRENT
+} from '~/graphql/queries/userQuery'
 
 type Result = {
   findOneUser: IUser
 }
-
+export type UserFetchReponse = {
+  pages: Array<{
+    pageUserCount: number
+    getSuggestedUsers: IUser[]
+  }>
+  prevOffset: number
+  userCount: number
+}
 type UserQueryType = UseQueryResult<Result, unknown>
-
+type UserFetchQueryType = UseInfiniteQueryResult<UserFetchReponse, Error>
 type ReturnType = {
   getCurrentUser: (username: string, isReady?: boolean) => UserQueryType
+  getSuggestedUsers: () => UserFetchQueryType
 }
 
 export const userKeys = {
@@ -38,8 +55,42 @@ const useUser = (): ReturnType => {
       enabled: isReady as boolean
     })
 
+  const getSuggestedUsers = (): UserFetchQueryType =>
+    useInfiniteQuery<UserFetchReponse, Error>({
+      queryKey: userKeys?.all,
+      queryFn: async ({ pageParam = 0 }) => {
+        const skip = pageParam ?? undefined
+        const limit = 4
+
+        const users: UserFetchReponse = await gqlClient.request(GET_SUGGESTED_USERS, {
+          orderBy: {
+            createdAt: 'desc'
+          },
+          skip,
+          take: limit
+        })
+
+        const count: { countAllUserExceptCurrent: number } = await gqlClient.request(
+          COUNT_ALL_USER_EXCEPT_CURRENT
+        )
+
+        return {
+          ...users,
+          userCount: count?.countAllUserExceptCurrent,
+          prevOffset: pageParam ?? 0
+        }
+      },
+      getNextPageParam: (lastPage) => {
+        if (lastPage?.prevOffset + 4 > lastPage?.userCount) {
+          return false
+        }
+        return lastPage?.prevOffset + 4
+      }
+    })
+
   return {
-    getCurrentUser
+    getCurrentUser,
+    getSuggestedUsers
   }
 }
 

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx'
 import type { NextPage } from 'next'
 import { useRouter } from 'next/router'
 import { useInView } from 'react-intersection-observer'
@@ -10,7 +11,6 @@ import usePost, { PostFilter } from '~/hooks/usePost'
 import PostList from '~/components/molecules/PostList'
 import StoryList from '~/components/molecules/StoryList'
 import HomeLayout from '~/components/templates/HomeLayout'
-import useScreenCondition from '~/hooks/useScreenCondition'
 import FeedFilterTab from '~/components/molecules/FeedFilterTab'
 import SuggestionRightBar from '~/components/organisms/SuggestionRightbar'
 import PostSkeletonLoading from '~/components/atoms/Skeletons/PostSkeletonLoading'
@@ -40,16 +40,9 @@ const Home: NextPage = (): JSX.Element => {
     }
   }, [inView])
 
-  // SCREEN SIZE CONDITION HOOKS
-  const isMaxWidth = useScreenCondition('(max-width: 1380px)')
-
   if (isLoading) {
     return (
-      <PageLayout
-        {...{
-          isMaxWidth
-        }}
-      >
+      <PageLayout>
         <PostSkeletonLoading />
       </PageLayout>
     )
@@ -57,11 +50,7 @@ const Home: NextPage = (): JSX.Element => {
 
   if (isError) {
     return (
-      <PageLayout
-        {...{
-          isMaxWidth
-        }}
-      >
+      <PageLayout>
         <div className="py-6">
           <Alert type="error" message="Something went wrong fetching data" />
         </div>
@@ -70,11 +59,7 @@ const Home: NextPage = (): JSX.Element => {
   }
 
   return (
-    <PageLayout
-      {...{
-        isMaxWidth
-      }}
-    >
+    <PageLayout>
       <div>
         {posts?.length === 0 ? (
           <div className="mt-3">
@@ -100,7 +85,7 @@ const Home: NextPage = (): JSX.Element => {
   )
 }
 
-const PageLayout: FC<{ children: ReactNode; isMaxWidth: boolean }> = ({ children, isMaxWidth }) => {
+const PageLayout: FC<{ children: ReactNode }> = ({ children }) => {
   return (
     <HomeLayout metaTitle="Home" className="flex">
       <article className="max-w-3xl w-full mx-auto px-8 py-6">
@@ -113,11 +98,13 @@ const PageLayout: FC<{ children: ReactNode; isMaxWidth: boolean }> = ({ children
         </div>
         {children}
       </article>
-      {!isMaxWidth && (
-        <aside className="border-l border-stroke-3 h-full w-80 shrink-0 sticky top-0 mx-1">
-          <SuggestionRightBar />
-        </aside>
-      )}
+      <aside
+        className={clsx(
+          'border-l border-stroke-3 h-full w-80 shrink-0 sticky top-0 mx-1 hidden xl:block'
+        )}
+      >
+        <SuggestionRightBar />
+      </aside>
     </HomeLayout>
   )
 }


### PR DESCRIPTION
## Issue Link

- https://www.notion.so/MM-55-FE-Display-Suggested-User-with-Follow-and-Show-more-Functionality-893423c7833e470eb6f6230324febd74?pvs=4

## Definition of Done

- [x] Create Suggested User Graphql API
- [x] Create Function Hooks to fetch Suggested User
- [x] Implement Follow and Show more functionality display  

## Notes

- Backend and Frontend Integration
- Problem in Following Feed Post incorrect Fetch

## Pre-condition

### Docker Setup

- docker-compose up --build

### Local Setup

- cd client && npm install && npm run dev
- cd api && npm install && npm run dev
- goto the home page and you'll see the suggested users display

## Expected Output

- It should now have a suggested user in the right side of the page with follow functionality and infinite show more

## Screenshots/Recordings
[suggestedUsers.webm](https://github.com/Osomware/meme-me/assets/108642414/ba7efc38-eccd-4a27-93e8-61a72d5d3997)


