### PR TITLE
MM-57 - [FE] Fix Input Caption Post Limit with 200 Letters

### DIFF
--- a/client/src/components/organisms/UploadPostModal/index.tsx
+++ b/client/src/components/organisms/UploadPostModal/index.tsx
@@ -173,6 +173,8 @@ const UploadPostModal: FC<UploadPostModalProps> = ({ isOpen, closeModal }): JSX.
   // * THIS WILL AUTOMATICALLY ADD THE VALUE WITH EMOJI
   const handleEmojiSelect = (emoji: Emoji): void => {
     const captions = watch('captions')
+    if (captions?.length === 200) return
+
     if (captions !== undefined) {
       setValue('captions', captions + emoji.native)
     }


### PR DESCRIPTION
## Issue Link

- https://www.notion.so/MM-57-FE-Fix-Input-Caption-Post-Limit-with-200-Letters-4419289c8b7b472aada3e02c5de8c1a2?pvs=4

## Definition of Done

- [x] Fix Caption Input Limit to 200 with Icon Prevention

## Notes

- Fix issue

## Pre-condition

### Docker Setup

- docker-compose up --build

### Local Setup

- cd client && npm install && npm run dev
- cd api && npm install && npm run dev
- upload and add caption with limit of 200

## Expected Output

- It should now fix the exceed limit letters of 200 of adding icon

## Screenshots/Recordings

[limit.webm](https://github.com/Osomware/meme-me/assets/108642414/d01026f1-30b7-4a51-a9e5-ce0fd34b6ff7)
