### PR TITLE
MM-58 - [FE] Fix Posts Following Filters Display

### DIFF
--- a/api/src/post/post.service.ts
+++ b/api/src/post/post.service.ts
@@ -113,22 +113,22 @@ export class PostService {
   // FILTERED ALL FOLLOWING POSTS
   async filterFollowingPosts(args: FindManyPostArgs, userId: number): Promise<Post[]> {
     const { filter, ...filteredArgs }: { [x: string]: any } = args
-    const following = await this.prisma.follow.findMany({
+    const followers = await this.prisma.follow.findMany({
       where: {
-        followerId: userId
+        followingId: userId
       },
       select: {
-        followingId: true
+        followerId: true
       }
     })
 
-    const followingIds = following.map((follow) => follow.followingId)
+    const followerIds = followers.map((follow) => follow.followerId)
 
     const posts = await this.prisma.post.findMany({
       ...filteredArgs,
       where: {
         userId: {
-          in: followingIds
+          in: followerIds
         }
       },
       include: {


### PR DESCRIPTION
## Issue Link

- https://www.notion.so/MM-58-FE-Fix-Posts-Following-Filters-Display-95accd79e82b4a4a8a8a246825907261?pvs=4

## Definition of Done

- [x] Fix Post Filter Display by switching following to followers ids

## Notes

- N/A

## Pre-condition

### Docker Setup

- docker-compose up --build

### Local Setup

- cd client && npm install && npm run dev
- cd api && npm install && npm run dev
- CLick the feeds filter of Following and You'll see the post of users you followed

## Expected Output

- It should able to properly display the posts of the users you followed in the post following filter

## Screenshots/Recordings

[fixdisplay.webm](https://github.com/Osomware/meme-me/assets/108642414/3e6387cd-624f-4def-91c8-ab10c317642b)

