### PR TITLE
MM-59 - [FE] Implement Infinite Display Post in User Profile

### DIFF
--- a/api/src/post/dto/count-username.input.ts
+++ b/api/src/post/dto/count-username.input.ts
@@ -1,0 +1,7 @@
+import { ArgsType, Field } from '@nestjs/graphql'
+
+@ArgsType()
+export class CountUsernameInput {
+  @Field(() => String, { nullable: true })
+  username: string
+}

--- a/api/src/post/post.resolver.ts
+++ b/api/src/post/post.resolver.ts
@@ -8,6 +8,7 @@ import { FindManyPostArgs } from '@generated/post/find-many-post.args'
 import { CurrentUserId } from '~/auth/decorators/currentUserId.decotrator'
 import { FindFirstPostOrThrowArgs } from '@generated/post/find-first-post-or-throw.args'
 import { PostCreateWithoutUserInput } from '@generated/post/post-create-without-user.input'
+import { CountUsernameInput } from './dto/count-username.input'
 
 @Resolver(() => Post)
 export class PostResolver {
@@ -60,5 +61,10 @@ export class PostResolver {
     @CurrentUserId() userId: number
   ): Promise<Post> {
     return this.postService.delete(deletePostInput, userId)
+  }
+
+  @Query(() => Int, { name: 'countAllPostByUsername' })
+  countAllPostByUsername(@Args() countUsernameInput: CountUsernameInput): Promise<number> {
+    return this.postService.countAllPostByUsername(countUsernameInput)
   }
 }

--- a/api/src/post/post.service.ts
+++ b/api/src/post/post.service.ts
@@ -6,6 +6,7 @@ import { DeletePostInput } from './dto/delete-post.input'
 import { FindManyPostArgs } from '@generated/post/find-many-post.args'
 import { FindFirstPostOrThrowArgs } from '@generated/post/find-first-post-or-throw.args'
 import { PostCreateWithoutUserInput } from '@generated/post/post-create-without-user.input'
+import { CountUsernameInput } from './dto/count-username.input'
 
 @Injectable()
 export class PostService {
@@ -79,6 +80,18 @@ export class PostService {
 
   async countAllPost(): Promise<number> {
     return await this.prisma.post.count()
+  }
+
+  async countAllPostByUsername(countUsernameInput: CountUsernameInput): Promise<number> {
+    return await this.prisma.post.count({
+      where: {
+        user: {
+          username: {
+            equals: countUsernameInput.username
+          }
+        }
+      }
+    })
   }
 
   async delete(deletePostInput: DeletePostInput, userId: number): Promise<Post> {

--- a/api/src/schema.gql
+++ b/api/src/schema.gql
@@ -1025,6 +1025,7 @@ type Query {
   checkUserLikePost(targetPostInput: TargetPostInput!): Boolean!
   countAllComment(cursor: CommentWhereUniqueInput, distinct: [CommentScalarFieldEnum!], orderBy: [CommentOrderByWithRelationInput!], skip: Int, take: Int, where: CommentWhereInput): Int!
   countAllPost: Int!
+  countAllPostByUsername(username: String): Int!
   countAllUserExceptCurrent: Int!
   findAllCommentByPostId(cursor: CommentWhereUniqueInput, distinct: [CommentScalarFieldEnum!], orderBy: [CommentOrderByWithRelationInput!], skip: Int, take: Int, where: CommentWhereInput): [CommentPost!]!
   findAllPost(cursor: PostWhereUniqueInput, distinct: [PostScalarFieldEnum!], filter: String, orderBy: [PostOrderByWithRelationInput!], skip: Int, take: Int, where: PostWhereInput): [Post!]!

--- a/client/src/components/organisms/PostModal/index.tsx
+++ b/client/src/components/organisms/PostModal/index.tsx
@@ -344,7 +344,11 @@ const PostModal: FC<PostModalProps> = ({ isOpen, closeModal, postId }): JSX.Elem
                         }}
                         btnStyle={isLikePost ? '!bg-rose-50 !border-rose-100' : ''}
                       >
-                        <Heart fill={isLikePost ? '#f43f5e' : '#586ca0'} stroke="none" />
+                        <Heart
+                          className="w-5 h-5"
+                          fill={isLikePost ? '#f43f5e' : '#586ca0'}
+                          stroke="none"
+                        />
                       </ReactionButton>
                     )}
                     {reaction.type === Reaction.comment && (
@@ -353,7 +357,7 @@ const PostModal: FC<PostModalProps> = ({ isOpen, closeModal, postId }): JSX.Elem
                         direction="flex-row"
                         className="p-2 rounded-full"
                       >
-                        <Messageicon className="w-4 h-4 fill-current" />
+                        <Messageicon className="w-5 h-5 fill-current" />
                       </ReactionButton>
                     )}
                     {reaction.type === Reaction.bookmark && (

--- a/client/src/graphql/queries/postsQuery.ts
+++ b/client/src/graphql/queries/postsQuery.ts
@@ -72,8 +72,13 @@ export const GET_ONE_POST_QUERY = gql`
 `
 
 export const GET_ALL_POST_BY_USERNAME_QUERY = gql`
-  query FindAllPostByUsername($where: PostWhereInput, $orderBy: [PostOrderByWithRelationInput!]) {
-    findAllPostByUsername(where: $where, orderBy: $orderBy) {
+  query FindAllPostByUsername(
+    $where: PostWhereInput
+    $orderBy: [PostOrderByWithRelationInput!]
+    $skip: Int
+    $take: Int
+  ) {
+    findAllPostByUsername(where: $where, orderBy: $orderBy, skip: $skip, take: $take) {
       id
       mediaFiles {
         key
@@ -82,7 +87,6 @@ export const GET_ALL_POST_BY_USERNAME_QUERY = gql`
       createdAt
       _count {
         likes
-        comments
       }
     }
   }
@@ -91,5 +95,11 @@ export const GET_ALL_POST_BY_USERNAME_QUERY = gql`
 export const COUNT_ALL_POST_QUERY = gql`
   query CountAllPosts {
     countAllPost
+  }
+`
+
+export const COUNT_ALL_POST_BY_USERNAME_QUERY = gql`
+  query countAllPostByUsername($username: String) {
+    countAllPostByUsername(username: $username)
   }
 `


### PR DESCRIPTION
## Issue Link

- https://www.notion.so/MM-59-FE-Implement-Infinite-Display-Post-in-User-Profile-c7fb91c562c343db818c1c5b977f92e8?pvs=4

## Definition of Done

- [x] Modified Current queries to infinite queries
- [x] Modified Backend with Count by Username 
- [x] Set Initial Post Count to 15 and Fetch again 

## Notes

- N/A

## Pre-condition

### Docker Setup

- docker-compose up --build

### Local Setup

- cd client && npm install && npm run dev
- cd api && npm install && npm run dev
- goto the profile and scroll

## Expected Output

- It should now have an infinite scroll of the profile page that fetch the 15 post and when scroll will fetch again another 15

## Screenshots/Recordings

[profile.webm](https://github.com/Osomware/meme-me/assets/108642414/18ccfc85-4b56-4d59-b958-0250ba2c5b46)

