### PR TITLE
MM-61 - [FE] Implement Delete Comment Functionality

### DIFF
--- a/api/src/comment-post/comment-post.resolver.ts
+++ b/api/src/comment-post/comment-post.resolver.ts
@@ -2,6 +2,7 @@ import { Resolver, Mutation, Args, Query, Int } from '@nestjs/graphql'
 
 import { CommentPostService } from './comment-post.service'
 import { CommentPost } from './entities/comment-post.entity'
+import { DeleteCommentPostInput } from './dto/delete-comment-post.input'
 import { CurrentUserId } from '~/auth/decorators/currentUserId.decotrator'
 import { FindManyCommentArgs } from '@generated/comment/find-many-comment.args'
 import { CommentCreateWithoutUserInput } from '@generated/comment/comment-create-without-user.input'
@@ -27,5 +28,13 @@ export class CommentPostResolver {
   @Query(() => Int, { name: 'countAllComment' })
   countllPost(@Args() args: FindManyCommentArgs): Promise<number> {
     return this.commentPostService.countAllComment(args)
+  }
+
+  @Mutation(() => CommentPost, { name: 'deleteComment' })
+  async deleteComment(
+    @Args('deleteCommentInput') deleteCommentInput: DeleteCommentPostInput,
+    @CurrentUserId() userId: number
+  ): Promise<CommentPost> {
+    return this.commentPostService.deleteComment(deleteCommentInput, userId)
   }
 }

--- a/api/src/comment-post/comment-post.service.ts
+++ b/api/src/comment-post/comment-post.service.ts
@@ -4,6 +4,7 @@ import { PrismaService } from '~/prisma/prisma.service'
 import { CommentPost } from './entities/comment-post.entity'
 import { FindManyCommentArgs } from '@generated/comment/find-many-comment.args'
 import { CommentCreateWithoutUserInput } from '@generated/comment/comment-create-without-user.input'
+import { DeleteCommentPostInput } from './dto/delete-comment-post.input'
 
 @Injectable()
 export class CommentPostService {
@@ -50,5 +51,36 @@ export class CommentPostService {
 
   async countAllComment(args: FindManyCommentArgs): Promise<number> {
     return await this.prisma.comment.count(args)
+  }
+
+  async deleteComment(
+    deleteCommentInput: DeleteCommentPostInput,
+    userId: number
+  ): Promise<CommentPost> {
+    const findUserPost = await this.prisma.comment.findFirst({
+      where: {
+        id: {
+          equals: deleteCommentInput.id
+        },
+        userId: {
+          equals: userId
+        }
+      }
+    })
+
+    if (!findUserPost) {
+      throw new Error('You are not authorized to delete this comment!')
+    }
+
+    return await this.prisma.comment.delete({
+      where: {
+        id: deleteCommentInput.id,
+        userId
+      },
+      include: {
+        user: true,
+        _count: true
+      }
+    })
   }
 }

--- a/api/src/comment-post/dto/delete-comment-post.input.ts
+++ b/api/src/comment-post/dto/delete-comment-post.input.ts
@@ -1,0 +1,7 @@
+import { InputType, Field, Int } from '@nestjs/graphql'
+
+@InputType()
+export class DeleteCommentPostInput {
+  @Field(() => Int)
+  id: number
+}

--- a/api/src/post/post.resolver.ts
+++ b/api/src/post/post.resolver.ts
@@ -4,11 +4,11 @@ import { PostService } from './post.service'
 import { Post } from './entities/post.entity'
 import { DeletePostInput } from './dto/delete-post.input'
 import { FilterPostInput } from './dto/filter-post.input'
+import { CountUsernameInput } from './dto/count-username.input'
 import { FindManyPostArgs } from '@generated/post/find-many-post.args'
 import { CurrentUserId } from '~/auth/decorators/currentUserId.decotrator'
 import { FindFirstPostOrThrowArgs } from '@generated/post/find-first-post-or-throw.args'
 import { PostCreateWithoutUserInput } from '@generated/post/post-create-without-user.input'
-import { CountUsernameInput } from './dto/count-username.input'
 
 @Resolver(() => Post)
 export class PostResolver {

--- a/api/src/post/post.service.ts
+++ b/api/src/post/post.service.ts
@@ -3,10 +3,10 @@ import { Injectable } from '@nestjs/common'
 import { Post } from '@generated/post/post.model'
 import { PrismaService } from '~/prisma/prisma.service'
 import { DeletePostInput } from './dto/delete-post.input'
+import { CountUsernameInput } from './dto/count-username.input'
 import { FindManyPostArgs } from '@generated/post/find-many-post.args'
 import { FindFirstPostOrThrowArgs } from '@generated/post/find-first-post-or-throw.args'
 import { PostCreateWithoutUserInput } from '@generated/post/post-create-without-user.input'
-import { CountUsernameInput } from './dto/count-username.input'
 
 @Injectable()
 export class PostService {

--- a/api/src/schema.gql
+++ b/api/src/schema.gql
@@ -240,6 +240,10 @@ input DateTimeFilter {
   notIn: [DateTime!]
 }
 
+input DeleteCommentPostInput {
+  id: Int!
+}
+
 input DeletePostInput {
   id: Int!
 }
@@ -654,6 +658,7 @@ input MediaFileWhereUniqueInput {
 type Mutation {
   commentPost(commentCreateWithoutUserInput: CommentCreateWithoutUserInput!): CommentPost!
   createPost(createPostInput: PostCreateWithoutUserInput!): Post!
+  deleteComment(deleteCommentInput: DeleteCommentPostInput!): CommentPost!
   deletePost(deletePostInput: DeletePostInput!): Post!
   followUser(targetUserIdInput: TargetUserIdInput!): FollowUser!
   getNewTokens: NewTokensResonse!

--- a/client/src/components/molecules/CommentDropdownMenu/index.tsx
+++ b/client/src/components/molecules/CommentDropdownMenu/index.tsx
@@ -1,0 +1,101 @@
+import clsx from 'clsx'
+import React, { FC } from 'react'
+import toast from 'react-hot-toast'
+import { Menu } from '@headlessui/react'
+import { Flag, MoreHorizontal, Trash } from 'react-feather'
+
+import useComment from '~/hooks/useComment'
+import { queryClient } from '~/lib/queryClient'
+import MenuTransition from '~/components/templates/MenuTransition'
+
+type Props = {
+  isPostAuthor: boolean
+  commentId: string
+}
+
+const CommentDropdownMenu: FC<Props> = ({ isPostAuthor, commentId }): JSX.Element => {
+  const { handleDeleteCommentMutation } = useComment()
+  const handleDeleteComment = handleDeleteCommentMutation()
+
+  const handleOpenConfirmationModal = async (): Promise<void> => {
+    const result = confirm('Are you sure you want to delete?')
+
+    if (result) {
+      await handleDeleteComment.mutateAsync(
+        {
+          id: Number(commentId)
+        },
+        {
+          onSuccess: () => {
+            void queryClient.invalidateQueries(['comments', 'detail'])
+            toast.success('Deleted Successfully!')
+          }
+        }
+      )
+    }
+  }
+
+  const handleReportComment = (): void => {
+    alert('NO ACTION YET!')
+  }
+
+  return (
+    <Menu as="div" className="relative inline-block text-left">
+      {({ open }) => (
+        <>
+          <div className={clsx('opacity-0', open ? 'opacity-100' : 'group-hover:opacity-100')}>
+            <Menu.Button className="flex items-center">
+              <MoreHorizontal className="w-5 h-5" />
+            </Menu.Button>
+          </div>
+          <MenuTransition>
+            <Menu.Items
+              className={clsx(
+                'absolute right-0 w-40 origin-top-right',
+                'rounded bg-white focus:outline-none shadow-md',
+                'border border-slate-100 divide-y divide-stroke-3'
+              )}
+            >
+              <div className="py-1.5">
+                <Menu.Item>
+                  <button
+                    type="button"
+                    onClick={handleReportComment}
+                    className={clsx(
+                      'relative flex items-center justify-center w-full',
+                      'text-secondary outline-none hover:bg-background py-1'
+                    )}
+                  >
+                    <Flag className="absolute left-3 h-4 w-4" aria-hidden="true" />
+                    <span className="text-center font-medium">Report</span>
+                  </button>
+                </Menu.Item>
+              </div>
+              {isPostAuthor && (
+                <div className="py-1.5">
+                  <Menu.Item>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        void handleOpenConfirmationModal()
+                      }}
+                      className={clsx(
+                        'relative flex items-center justify-center w-full',
+                        'text-rose-500 outline-none hover:bg-rose-50 py-1'
+                      )}
+                    >
+                      <Trash className="absolute left-3 h-4 w-4" aria-hidden="true" />
+                      <span className="text-center font-medium">Delete</span>
+                    </button>
+                  </Menu.Item>
+                </div>
+              )}
+            </Menu.Items>
+          </MenuTransition>
+        </>
+      )}
+    </Menu>
+  )
+}
+
+export default CommentDropdownMenu

--- a/client/src/components/molecules/CommentList/index.tsx
+++ b/client/src/components/molecules/CommentList/index.tsx
@@ -5,16 +5,18 @@ import { IComment } from '~/utils/interface/Comment'
 
 type Props = {
   comments: IComment[]
+  isPostAuthor: boolean
 }
 
-const CommentList: FC<Props> = ({ comments }): JSX.Element => {
+const CommentList: FC<Props> = ({ comments, isPostAuthor }): JSX.Element => {
   return (
     <div className="flex flex-col space-y-4">
       {comments?.map((comment, index) => (
         <Comment
           key={index}
           {...{
-            comment
+            comment,
+            isPostAuthor
           }}
         />
       ))}

--- a/client/src/components/molecules/PostDropdownMenu/index.tsx
+++ b/client/src/components/molecules/PostDropdownMenu/index.tsx
@@ -37,16 +37,19 @@ const PostDropdownMenu: FC<Props> = (props): JSX.Element => {
             'rounded bg-white focus:outline-none'
           )}
         >
-          <div className="px-1.5 py-1.5">
+          <div className="py-1.5">
             <Menu.Item>
               <button
                 type="button"
                 onClick={() => {
                   void handleOpenConfirmationModal()
                 }}
-                className="relative flex items-center justify-center w-full text-rose-500 outline-none"
+                className={clsx(
+                  'relative flex items-center justify-center w-full',
+                  'text-rose-500 outline-none hover:bg-rose-50 py-1'
+                )}
               >
-                <Trash className="absolute left-2 h-4 w-4" aria-hidden="true" />
+                <Trash className="absolute left-3 h-4 w-4" aria-hidden="true" />
                 <span className="text-center font-medium">Delete</span>
               </button>
             </Menu.Item>

--- a/client/src/components/organisms/Comment/index.tsx
+++ b/client/src/components/organisms/Comment/index.tsx
@@ -1,21 +1,24 @@
 import clsx from 'clsx'
 import React, { FC } from 'react'
 import dynamic from 'next/dynamic'
-import { Heart, MoreHorizontal } from 'react-feather'
+import { Heart } from 'react-feather'
 import { AvatarConfig, genConfig } from 'react-nice-avatar'
 
 import { IComment } from '~/utils/interface/Comment'
 import { formatTimeDifference } from '~/helpers/formatTimeDifference'
+import CommentDropdownMenu from '~/components/molecules/CommentDropdownMenu'
 
 const ReactNiceAvatar = dynamic(async () => await import('react-nice-avatar'), { ssr: false })
 
 export type CommentProps = {
   comment: IComment
+  isPostAuthor: boolean
 }
 
 const Comment: FC<CommentProps> = (props): JSX.Element => {
   const {
-    comment: { text, createdAt, user }
+    isPostAuthor,
+    comment: { id, text, createdAt, user }
   } = props
 
   const myConfig = genConfig(user?.email as AvatarConfig)
@@ -37,11 +40,12 @@ const Comment: FC<CommentProps> = (props): JSX.Element => {
           </div>
         </div>
         <div className="ml-auto flex flex-col items-center pl-2">
-          <div className="opacity-0 group-hover:opacity-100">
-            <button type="button" className="flex items-center">
-              <MoreHorizontal className="w-5 h-5" />
-            </button>
-          </div>
+          <CommentDropdownMenu
+            {...{
+              isPostAuthor,
+              commentId: id
+            }}
+          />
           <div className="px-2 inline-flex items-center flex-col text-secondary-200">
             <Heart className="w-4 h-4 cursor-pointer" />
             <span className="text-[10px]">0</span>

--- a/client/src/components/organisms/PostModal/index.tsx
+++ b/client/src/components/organisms/PostModal/index.tsx
@@ -415,7 +415,8 @@ const PostModal: FC<PostModalProps> = ({ isOpen, closeModal, postId }): JSX.Elem
                     <>
                       <CommentList
                         {...{
-                          comments
+                          comments,
+                          isPostAuthor
                         }}
                       />
                       {isFetchingNextPage ? (

--- a/client/src/graphql/mutations/comment.ts
+++ b/client/src/graphql/mutations/comment.ts
@@ -13,3 +13,12 @@ export const CREATE_COMMENT_POST_MUTATION = gql`
     }
   }
 `
+
+export const DELETE_COMMENT_MUTATION = gql`
+  mutation DeleteComment($deleteCommentInput: DeleteCommentPostInput!) {
+    deleteComment(deleteCommentInput: $deleteCommentInput) {
+      id
+      text
+    }
+  }
+`

--- a/client/src/utils/types/input.ts
+++ b/client/src/utils/types/input.ts
@@ -44,3 +44,7 @@ export type CommentCreateWithoutUserInput = {
   postId: number
   text: string
 }
+
+export type DeleteCommentInput = {
+  id: number
+}


### PR DESCRIPTION
## Issue Link

- https://www.notion.so/MM-61-FE-Implement-Delete-Comment-Functionality-4b0a560166ec4c408df9c66f341b4159?pvs=4

## Definition of Done

- [x] Create Delete Backend Functionality
- [x] Create Delete Comment Hooks Functionality
- [x] Create Dropdown Menu in Comment Option  

## Notes

- N/A

## Pre-condition

### Docker Setup

- docker-compose up --build

### Local Setup

- cd client && npm install && npm run dev
- cd api && npm install && npm run dev
- goto the http://localhost:3030/graphql

delete mutation
```
mutation DeleteComment($deleteCommentInput: DeleteCommentPostInput!) {
  deleteComment(deleteCommentInput: $deleteCommentInput) {
    id
    text
  }
}
```
input
```
{
  "deleteCommentInput": {
    "id": <commend-id>
  }
}
```

## Expected Output

- It should now a functionality of delete in the comment section
- Only a creator of a comment can delete the comment

## Screenshots/Recordings
[delete.webm](https://github.com/Osomware/meme-me/assets/108642414/e7f7c4da-a986-49fa-974b-6b2214cc42a6)

